### PR TITLE
change caption so they are unstyled by default

### DIFF
--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -4,6 +4,12 @@
   }
   .#{$classname} {
     @extend %o-table-base;
+    caption.#{$classname}__caption--top {
+      @extend %o-table__caption--top;
+    }
+  }
+  .#{$classname} {
+    @extend %o-table-base;
     caption.#{$classname}__caption--bottom {
       @extend %o-table__caption--bottom;
     }

--- a/src/scss/base.scss
+++ b/src/scss/base.scss
@@ -8,8 +8,9 @@
   @extend %o-ft-typography-body;
 
   caption {
-    caption-side: top;
-    // @extend %o-table__caption--top;
+    width: 100%;
+    margin: 0;
+    padding: 0;
   }
 
   th,


### PR DESCRIPTION
Change to caption so that default styling is absent, allowing user to create their own content or use the o-table__caption--top class to use basic style
