### PR TITLE
Move numeric styling from data attr to class

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Simply add an `o-table` class to any table you wish to apply the styles to:
 </table>
 ```
 
-Where a `td` contains numeric data, or a `th` is for cells containing numeric data, also add the class `.o-table__cell--numeric` and a `data-o-table-data-o-table-data-type="numeric"` attribute (the latter allows the column to be sorted correctly):
+Where a `td` contains numeric data, or a `th` is for cells containing numeric data, also add the class `.o-table__cell--numeric` and a `data-o-table-data-type="numeric"` attribute (the latter allows the column to be sorted correctly):
 
 ```html
 <table class="o-table">
@@ -161,7 +161,7 @@ const OTable = require('o-table');
 oTable = new OTable(document.body);
 ```
 
-Sorting numbers works if the column has been declared as a numeric column via `data-o-table-data-o-table-data-type="numeric" class="o-table__cell--numeric"`.
+Sorting numbers works if the column has been declared as a numeric column via `data-o-table-data-type="numeric" class="o-table__cell--numeric"`.
 
 #### Sorting declaratively
 If you are wanting to sort by a custom pattern, you can apply the sorting values to each row as a data attribute:

--- a/README.md
+++ b/README.md
@@ -122,13 +122,9 @@ Additional classes may be added to the table root element to also apply the foll
 
 ### Content styles
 
-Class: `o-table__cell--content-primary`, Mixin: `oTableCellContentPrimary`
-
-Add to an element containing text in your table cell to make the text larger type.
-
 Class: `o-table__cell--content-secondary`, Mixin: `oTableCellContentSecondary`
 
-
+Reduce the size of some text in a cell and display block to start a new line. The class should be applied to a `<span>` or `<div>` element inside of the table cell.
 
 ### Row stripes
 

--- a/README.md
+++ b/README.md
@@ -25,29 +25,29 @@ Simply add an `o-table` class to any table you wish to apply the styles to:
 </table>
 ```
 
-Where a `td` contains numeric data, or a `th` is for cells containing numeric data, also add a `data-type="numeric"` attribute:
+Where a `td` contains numeric data, or a `th` is for cells containing numeric data, also add the class `.o-table__cell--numeric` and a `data-o-table-data-o-table-data-type="numeric"` attribute (the latter allows the column to be sorted correctly):
 
 ```html
 <table class="o-table">
 	<tr>
 		<th>Index</th>
-		<th data-type="numeric">Value</th>
+		<th data-o-table-data-type="numeric" class="o-table__cell--numeric">Value</th>
 	</tr>
 	<tr>
 		<td>FTSE 100</td>
-		<td data-type="numeric">6685.52</td>
+		<td data-o-table-data-type="numeric" class="o-table__cell--numeric">6685.52</td>
 	</tr>
 	...
 </table>
 ```
 
-Where table headings (`th`) are used as row headings, ` scope="row"` attributes must be set on the `th`:
+Where table headings (`th`) are used as row headings, `scope="row"` attributes must be set on the `th`:
 
 ```html
 <table class="o-table">
 	<tr>
 		<th scope="row">FTSE 100</th>
-		<td data-type="numeric">6685.52</td>
+		<td data-o-table-data-type="numeric" class="o-table__cell--numeric">6685.52</td>
 	</tr>
 	...
 </table>
@@ -60,13 +60,13 @@ When they're are not present, browsers will implicitly wrap table contents in `t
 	<thead>
 		<tr>
 			<th>Index</th>
-			<th data-type="numeric">Value</th>
+			<th data-o-table-data-type="numeric" class="o-table__cell--numeric">Value</th>
 		</tr>
 	</thead>
 	<tbody>
 		<tr>
 			<td>FTSE 100</td>
-			<td data-type="numeric">6685.52</td>
+			<td data-o-table-data-type="numeric" class="o-table__cell--numeric">6685.52</td>
 		</tr>
 		...
 	</tbody>
@@ -120,6 +120,16 @@ If using __o-table__ in silent mode, use the mixin `oTableBase' in your table st
 
 Additional classes may be added to the table root element to also apply the following styling options. They can be combined as required.
 
+### Content styles
+
+Class: `o-table__cell--content-primary`, Mixin: `oTableCellContentPrimary`
+
+Add to an element containing text in your table cell to make the text larger type.
+
+Class: `o-table__cell--content-secondary`, Mixin: `oTableCellContentSecondary`
+
+
+
 ### Row stripes
 
 Class: `o-table--row-stripes`, Mixin: `oTableRowStripes`
@@ -155,7 +165,7 @@ const OTable = require('o-table');
 oTable = new OTable(document.body);
 ```
 
-Sorting numbers works if the column has been declared as a numeric column via `data-o-table-data-type="numeric"`.
+Sorting numbers works if the column has been declared as a numeric column via `data-o-table-data-o-table-data-type="numeric" class="o-table__cell--numeric"`.
 
 #### Sorting declaratively
 If you are wanting to sort by a custom pattern, you can apply the sorting values to each row as a data attribute:

--- a/demos/src/basic.mustache
+++ b/demos/src/basic.mustache
@@ -2,27 +2,27 @@
 	<thead>
 		<th>Cheese</th>
 		<th>Bread</th>
-		<th data-o-table-data-type="numeric">Cost (GBP)</th>
-		<th data-o-table-data-type="numeric">Cost (EUR)</th>
+		<th data-o-table-data-type="numeric" class="o-table__cell--numeric">Cost (GBP)</th>
+		<th data-o-table-data-type="numeric" class="o-table__cell--numeric">Cost (EUR)</th>
 	</thead>
 	<tbody>
 		<tr>
 			<td>cheddar</td>
 			<td>rye</td>
-			<td data-o-table-data-type="numeric">2</td>
-			<td data-o-table-data-type="numeric">1.56</td>
+			<td data-o-table-data-type="numeric" class="o-table__cell--numeric">2</td>
+			<td data-o-table-data-type="numeric" class="o-table__cell--numeric">1.56</td>
 		</tr>
 		<tr>
 			<td>stilton</td>
 			<td>wholemeal</td>
-			<td data-o-table-data-type="numeric">2</td>
-			<td data-o-table-data-type="numeric">1.85</td>
+			<td data-o-table-data-type="numeric" class="o-table__cell--numeric">2</td>
+			<td data-o-table-data-type="numeric" class="o-table__cell--numeric">1.85</td>
 		</tr>
 		<tr>
 			<td>red leicester</td>
 			<td>white</td>
-			<td data-o-table-data-type="numeric">3</td>
-			<td data-o-table-data-type="numeric">2.72</td>
+			<td data-o-table-data-type="numeric" class="o-table__cell--numeric">3</td>
+			<td data-o-table-data-type="numeric" class="o-table__cell--numeric">2.72</td>
 		</tr>
 	</tbody>
 </table>
@@ -31,27 +31,27 @@
 	<thead>
 		<th>Cheese</th>
 		<th>Bread</th>
-		<th data-o-table-data-type="numeric">Cost (GBP)</th>
-		<th data-o-table-data-type="numeric">Cost (EUR)</th>
+		<th data-o-table-data-type="numeric" class="o-table__cell--numeric">Cost (GBP)</th>
+		<th data-o-table-data-type="numeric" class="o-table__cell--numeric">Cost (EUR)</th>
 	</thead>
 	<tbody>
 		<tr>
 			<td data-o-table-order=0>cheddar</td>
 			<td data-o-table-order=1>rye</td>
-			<td data-o-table-order=2>2</td>
-			<td data-o-table-order=3>1.56</td>
+			<td data-o-table-order=2 class="o-table__cell--numeric">2</td>
+			<td data-o-table-order=3 class="o-table__cell--numeric">1.56</td>
 		</tr>
 		<tr>
 			<td data-o-table-order=3>stilton</td>
 			<td data-o-table-order=2>wholemeal</td>
-			<td data-o-table-order=1>2</td>
-			<td  data-o-table-order=0>1.85</td>
+			<td data-o-table-order=1 data-o-table-data-type="numeric" class="o-table__cell--numeric">2</td>
+			<td  data-o-table-order=0 data-o-table-data-type="numeric" class="o-table__cell--numeric">1.85</td>
 		</tr>
 		<tr>
 			<td data-o-table-order=1>red leicester</td>
 			<td data-o-table-order=3>white</td>
-			<td data-o-table-order=2>3</td>
-			<td data-o-table-order=0>2.72</td>
+			<td data-o-table-order=2 data-o-table-data-type="numeric" class="o-table__cell--numeric">3</td>
+			<td data-o-table-order=0 data-o-table-data-type="numeric" class="o-table__cell--numeric">2.72</td>
 		</tr>
 	</tbody>
 </table>

--- a/demos/src/basic.mustache
+++ b/demos/src/basic.mustache
@@ -1,9 +1,9 @@
 <table class="o-table {{modifierClass}}" data-o-component="o-table">
 	<thead>
-		<th>Cheese</th>
-		<th>Bread</th>
-		<th data-o-table-data-type="numeric" class="o-table__cell--numeric">Cost (GBP)</th>
-		<th data-o-table-data-type="numeric" class="o-table__cell--numeric">Cost (EUR)</th>
+		<th>Cheese <span class="o-table__cell--content-secondary">Type of cheese</span></th>
+		<th>Bread <span class="o-table__cell--content-secondary">Type of bread</span></th>
+		<th data-o-table-data-type="numeric" class="o-table__cell--numeric">Cost <span class="o-table__cell--content-secondary">(GBP)</span></th>
+		<th data-o-table-data-type="numeric" class="o-table__cell--numeric">Cost <span class="o-table__cell--content-secondary">(EUR)</span></th>
 	</thead>
 	<tbody>
 		<tr>

--- a/demos/src/captions.mustache
+++ b/demos/src/captions.mustache
@@ -8,25 +8,25 @@
 	<tr>
 		<th>Heading</th>
 		<th>Heading</th>
-		<th data-o-table-data-type="numeric">Heading</th>
-		<th data-o-table-data-type="numeric">Heading</th>
+		<th data-o-table-data-type="numeric" class="o-table__cell--numeric">Heading</th>
+		<th data-o-table-data-type="numeric" class="o-table__cell--numeric">Heading</th>
 	</tr>
 	<tr>
 		<td>text data</td>
 		<td>text data</td>
-		<td data-o-table-data-type="numeric">123</td>
-		<td data-o-table-data-type="numeric">123.45</td>
+		<td data-o-table-data-type="numeric" class="o-table__cell--numeric">123</td>
+		<td data-o-table-data-type="numeric" class="o-table__cell--numeric">123.45</td>
 	</tr>
 	<tr>
 		<td>text data</td>
 		<td>text data</td>
-		<td data-o-table-data-type="numeric">22</td>
-		<td data-o-table-data-type="numeric">22.2</td>
+		<td data-o-table-data-type="numeric" class="o-table__cell--numeric">22</td>
+		<td data-o-table-data-type="numeric" class="o-table__cell--numeric">22.2</td>
 	</tr>
 	<tr>
 		<td>text data</td>
 		<td>text data</td>
-		<td data-o-table-data-type="numeric">3</td>
-		<td data-o-table-data-type="numeric">3.0</td>
+		<td data-o-table-data-type="numeric" class="o-table__cell--numeric">3</td>
+		<td data-o-table-data-type="numeric" class="o-table__cell--numeric">3.0</td>
 	</tr>
 </table>

--- a/demos/src/modifiers.mustache
+++ b/demos/src/modifiers.mustache
@@ -36,26 +36,26 @@
 	<tr>
 		<th>Column heading</th>
 		<th>Column heading</th>
-		<th data-o-table-data-type="numeric">Column heading</th>
-		<th data-o-table-data-type="numeric">Column heading</th>
+		<th data-o-table-data-type="numeric" class="o-table__cell--numeric">Column heading</th>
+		<th data-o-table-data-type="numeric" class="o-table__cell--numeric">Column heading</th>
 	</tr>
 	<tr>
 		<td>text data</td>
 		<td>text data</td>
-		<td data-o-table-data-type="numeric">123</td>
-		<td data-o-table-data-type="numeric">123.45</td>
+		<td data-o-table-data-type="numeric" class="o-table__cell--numeric">123</td>
+		<td data-o-table-data-type="numeric" class="o-table__cell--numeric">123.45</td>
 	</tr>
 	<tr>
 		<td>text data</td>
 		<td>text data</td>
-		<td data-o-table-data-type="numeric">22</td>
-		<td data-o-table-data-type="numeric">22.2</td>
+		<td data-o-table-data-type="numeric" class="o-table__cell--numeric">22</td>
+		<td data-o-table-data-type="numeric" class="o-table__cell--numeric">22.2</td>
 	</tr>
 	<tr>
 		<td>text data</td>
 		<td>text data</td>
-		<td data-o-table-data-type="numeric">3</td>
-		<td data-o-table-data-type="numeric">3.0</td>
+		<td data-o-table-data-type="numeric" class="o-table__cell--numeric">3</td>
+		<td data-o-table-data-type="numeric" class="o-table__cell--numeric">3.0</td>
 	</tr>
 </table>
 
@@ -64,28 +64,28 @@
 		<th scope="row">Row heading</th>
 		<td>text data</td>
 		<td>text data</td>
-		<td data-o-table-data-type="numeric">123</td>
-		<td data-o-table-data-type="numeric">123.45</td>
+		<td data-o-table-data-type="numeric" class="o-table__cell--numeric">123</td>
+		<td data-o-table-data-type="numeric" class="o-table__cell--numeric">123.45</td>
 	</tr>
 	<tr>
 		<th scope="row">Row heading</th>
 		<td>text data</td>
 		<td>text data</td>
-		<td data-o-table-data-type="numeric">123</td>
-		<td data-o-table-data-type="numeric">123.45</td>
+		<td data-o-table-data-type="numeric" class="o-table__cell--numeric">123</td>
+		<td data-o-table-data-type="numeric" class="o-table__cell--numeric">123.45</td>
 	</tr>
 	<tr>
 		<th scope="row">Row heading</th>
 		<td>text data</td>
 		<td>text data</td>
-		<td data-o-table-data-type="numeric">123</td>
-		<td data-o-table-data-type="numeric">123.45</td>
+		<td data-o-table-data-type="numeric" class="o-table__cell--numeric">123</td>
+		<td data-o-table-data-type="numeric" class="o-table__cell--numeric">123.45</td>
 	</tr>
 	<tr>
 		<th scope="row">Row heading</th>
 		<td>text data</td>
 		<td>text data</td>
-		<td data-o-table-data-type="numeric">123</td>
-		<td data-o-table-data-type="numeric">123.45</td>
+		<td data-o-table-data-type="numeric" class="o-table__cell--numeric">123</td>
+		<td data-o-table-data-type="numeric" class="o-table__cell--numeric">123.45</td>
 	</tr>
 </table>

--- a/main.scss
+++ b/main.scss
@@ -13,6 +13,8 @@ $o-table-is-silent: true !default;
 @import "src/scss/lines";
 @import "src/scss/borders";
 
+@import "src/scss/deprecated";
+
 @if ($o-table-is-silent == false) {
 	@include oTableAll;
 

--- a/main.scss
+++ b/main.scss
@@ -8,6 +8,7 @@ $o-table-is-silent: true !default;
 @import "src/scss/captions";
 @import "src/scss/base";
 @import "src/scss/compact";
+@import "src/scss/cells";
 @import "src/scss/row-stripes";
 @import "src/scss/lines";
 @import "src/scss/borders";

--- a/src/scss/_base.scss
+++ b/src/scss/_base.scss
@@ -18,12 +18,12 @@
 		margin: 0;
 		padding: 0;
 	}
-	
+
 	th {
 		@include oTypographySansBold(s);
 		@include oColorsFor(o-table-header, color);
 	}
-	
+
 	td {
 		@include oTypographySans(s);
 		@include oColorsFor(o-table-data, color);
@@ -36,19 +36,15 @@
 		text-align: left;
 		vertical-align: top;
 	}
-	
+
 	.primary-data {
 		@include oTypographySans(s);
 		display: block;
 	}
-	
+
 	.secondary-data {
 		@include oTypographySans(xs);
 		display: block;
-	}
-
-	[data-o-table-data-type=numeric] {
-		text-align: right;
 	}
 
 	th:not([scope=row]) {

--- a/src/scss/_base.scss
+++ b/src/scss/_base.scss
@@ -37,16 +37,6 @@
 		vertical-align: top;
 	}
 
-	.primary-data {
-		@include oTypographySans(s);
-		display: block;
-	}
-
-	.secondary-data {
-		@include oTypographySans(xs);
-		display: block;
-	}
-
 	th:not([scope=row]) {
 		vertical-align: bottom;
 	}

--- a/src/scss/_cells.scss
+++ b/src/scss/_cells.scss
@@ -8,14 +8,8 @@
 	text-align: right;
 }
 
-///
-@mixin oTableCellPrimary {
-	@include oTypographySans(s);
-	display: block;
-}
-
-///
-@mixin oTableCellSecondary {
+/// Makes content block and a smaller font size for secondary text in a table cell.
+@mixin oTableCellContentSecondary {
 	@include oTypographySans(xs);
 	display: block;
 }

--- a/src/scss/_cells.scss
+++ b/src/scss/_cells.scss
@@ -7,3 +7,15 @@
 @mixin oTableCellNumeric {
 	text-align: right;
 }
+
+///
+@mixin oTableCellPrimary {
+	@include oTypographySans(s);
+	display: block;
+}
+
+///
+@mixin oTableCellSecondary {
+	@include oTypographySans(xs);
+	display: block;
+}

--- a/src/scss/_cells.scss
+++ b/src/scss/_cells.scss
@@ -1,0 +1,9 @@
+////
+/// @group o-table
+/// @link http://registry.origami.ft.com/components/o-table
+////
+
+/// Add this to the table cell class to align text right
+@mixin oTableCellNumeric {
+	text-align: right;
+}

--- a/src/scss/_deprecated.scss
+++ b/src/scss/_deprecated.scss
@@ -1,3 +1,19 @@
-[data-o-table-data-type=numeric] {
-	@include oTableCellNumeric;
+@if ($o-table-is-silent == false) {
+	.o-table {
+
+		.primary-data {
+			@include oTypographySans(s);
+			display: block;
+		}
+
+		.secondary-data {
+			@include oTypographySans(xs);
+			display: block;
+		}
+
+		[data-o-table-data-type=numeric] {
+			@include oTableCellNumeric;
+		}
+	}
+
 }

--- a/src/scss/_deprecated.scss
+++ b/src/scss/_deprecated.scss
@@ -1,0 +1,3 @@
+[data-o-table-data-type=numeric] {
+	@include oTableCellNumeric;
+}

--- a/src/scss/_deprecated.scss
+++ b/src/scss/_deprecated.scss
@@ -2,13 +2,11 @@
 	.o-table {
 
 		.primary-data {
-			@include oTypographySans(s);
-			display: block;
+			@include oTableCellContentPrimary;
 		}
 
 		.secondary-data {
-			@include oTypographySans(xs);
-			display: block;
+			@include oTableCellContentSecondary;
 		}
 
 		[data-o-table-data-type=numeric] {

--- a/src/scss/_deprecated.scss
+++ b/src/scss/_deprecated.scss
@@ -1,3 +1,8 @@
+/// Adds block to primary content of a cell
+@mixin oTableCellContentPrimary {
+	display: block;
+}
+
 @if ($o-table-is-silent == false) {
 	.o-table {
 

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -30,6 +30,14 @@
 		.#{$classname}__cell--numeric {
 			@include oTableCellNumeric;
 		}
+
+		.#{$classname}__cell--primary {
+			@include oTableCellPrimary;
+		}
+
+		.#{$classname}__cell--secondary {
+			@include oTableCellSecondary;
+		}
 	}
 	.#{$classname}--row-stripes {
 		@include oTableRowStripes;

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -27,6 +27,7 @@
 			@include oTableCaptionBottom;
 		}
 
+		[data-o-table-data-type=numeric], // Note: remove data styling for next major release.
 		.#{$classname}__cell--numeric {
 			@include oTableCellNumeric;
 		}

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -27,7 +27,6 @@
 			@include oTableCaptionBottom;
 		}
 
-		[data-o-table-data-type=numeric], // Note: remove data styling for next major release.
 		.#{$classname}__cell--numeric {
 			@include oTableCellNumeric;
 		}

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -26,6 +26,10 @@
 		.#{$classname}__caption--bottom {
 			@include oTableCaptionBottom;
 		}
+
+		.#{$classname}__cell--numeric {
+			@include oTableCellNumeric;
+		}
 	}
 	.#{$classname}--row-stripes {
 		@include oTableRowStripes;

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -31,10 +31,6 @@
 			@include oTableCellNumeric;
 		}
 
-		.#{$classname}__cell--content-primary {
-			@include oTableCellContentPrimary;
-		}
-
 		.#{$classname}__cell--content-secondary {
 			@include oTableCellContentSecondary;
 		}

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -31,12 +31,12 @@
 			@include oTableCellNumeric;
 		}
 
-		.#{$classname}__cell--primary {
-			@include oTableCellPrimary;
+		.#{$classname}__cell--content-primary {
+			@include oTableCellContentPrimary;
 		}
 
-		.#{$classname}__cell--secondary {
-			@include oTableCellSecondary;
+		.#{$classname}__cell--content-secondary {
+			@include oTableCellContentSecondary;
 		}
 	}
 	.#{$classname}--row-stripes {


### PR DESCRIPTION
This removes the styling based on the `o-table-data-type="numeric"` selector, however as this data attr is used for the JS sorting functionality it needs to remain so we're adding both the class and the data attr when the style is required. Not sure if this is the best way of doing this so leaving it open for discussion.

Would be a breaking change as well as we're requiring people to add a class to style the cells.