### PR TITLE
bower.json updated

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
     "dependencies": {
         "o-colors": ">=2.5.0 <4",
         "o-grid": "^4.0.6",
-        "o-typography": ">=2.0.0 <4"
+        "o-typography": ">=2.0.0 <5"
     },
     "main": [
         "main.scss",


### PR DESCRIPTION
When bower installing o-table, it is unable to find a suitable version for o-typography. With this update it will resolve its version to 4.3.1, which matches with other module requirements.