### PR TITLE
Always order table columns ASC on first click.

### DIFF
--- a/src/js/oTable.js
+++ b/src/js/oTable.js
@@ -57,11 +57,11 @@ function OTable(rootEl) {
  */
 OTable.prototype._sortByColumn = function _sortByColumn (columnIndex) {
 	return function (event) {
+		let currentSort = event.currentTarget.getAttribute('aria-sort');
 		this.tableHeaders.forEach((header) => {
 			header.setAttribute('aria-sort', 'none');
 		});
-
-		if (this.rootEl.getAttribute('data-o-table-order') === null || this.rootEl.getAttribute('data-o-table-order') === "DES") {
+		if (this.rootEl.getAttribute('data-o-table-order') === null || currentSort === "none" || currentSort === "descending") {
 			this.rootEl.setAttribute('data-o-table-order', 'ASC');
 			event.currentTarget.setAttribute('aria-sort', 'ascending');
 		} else {


### PR DESCRIPTION
Clicking a column to sort orders the column items ascending. However clicking a different, unsorted column will then order descending. 

This PR changes that behaviour so the first click of an unsorted column always orders ascending first.

The impact of this change is best demonstrated with some sort icons.
Sort order affordance is a work in progress, **this PR does not include the icons**, they are used to demonstrate the sort behaviour change.

Old: When sorting by "cost" for the first time it is ordered descending, after having just ordered "cheese" ascending.
![diff-order](https://user-images.githubusercontent.com/10405691/30321236-46cab6b4-97ad-11e7-801b-a671a4dd1d7a.gif)

New: When sorting by "cost" for the first time it is ordered ascending, same as when sorting "cheese" for the first time.
![asc-first](https://user-images.githubusercontent.com/10405691/30321245-4b2da96e-97ad-11e7-8b09-cb892ab797b4.gif)
