### PR TITLE
Correct text alignment for number columns in responsive tables.

### DIFF
--- a/demos/src/basic.mustache
+++ b/demos/src/basic.mustache
@@ -9,20 +9,20 @@
 		<tr>
 			<td>cheddar</td>
 			<td>rye</td>
-			<td data-o-table-data-type="numeric" class="o-table__cell--numeric">2</td>
-			<td data-o-table-data-type="numeric" class="o-table__cell--numeric">1.56</td>
+			<td class="o-table__cell--numeric">2</td>
+			<td class="o-table__cell--numeric">1.56</td>
 		</tr>
 		<tr>
 			<td>stilton</td>
 			<td>wholemeal</td>
-			<td data-o-table-data-type="numeric" class="o-table__cell--numeric">2</td>
-			<td data-o-table-data-type="numeric" class="o-table__cell--numeric">1.85</td>
+			<td class="o-table__cell--numeric">2</td>
+			<td class="o-table__cell--numeric">1.85</td>
 		</tr>
 		<tr>
 			<td>red leicester</td>
 			<td>white</td>
-			<td data-o-table-data-type="numeric" class="o-table__cell--numeric">3</td>
-			<td data-o-table-data-type="numeric" class="o-table__cell--numeric">2.72</td>
+			<td class="o-table__cell--numeric">3</td>
+			<td class="o-table__cell--numeric">2.72</td>
 		</tr>
 	</tbody>
 </table>
@@ -44,14 +44,14 @@
 		<tr>
 			<td>stilton</td>
 			<td>wholemeal</td>
-			<td data-o-table-data-type="numeric" class="o-table__cell--numeric">2</td>
-			<td  data-o-table-data-type="numeric" class="o-table__cell--numeric">1.85</td>
+			<td class="o-table__cell--numeric">2</td>
+			<td  class="o-table__cell--numeric">1.85</td>
 		</tr>
 		<tr>
 			<td>red leicester</td>
 			<td>white</td>
-			<td data-o-table-data-type="numeric" class="o-table__cell--numeric">3</td>
-			<td data-o-table-data-type="numeric" class="o-table__cell--numeric">2.72</td>
+			<td class="o-table__cell--numeric">3</td>
+			<td class="o-table__cell--numeric">2.72</td>
 		</tr>
 	</tbody>
 </table>

--- a/demos/src/captions.mustache
+++ b/demos/src/captions.mustache
@@ -14,19 +14,19 @@
 	<tr>
 		<td>text data</td>
 		<td>text data</td>
-		<td data-o-table-data-type="numeric" class="o-table__cell--numeric">123</td>
-		<td data-o-table-data-type="numeric" class="o-table__cell--numeric">123.45</td>
+		<td class="o-table__cell--numeric">123</td>
+		<td class="o-table__cell--numeric">123.45</td>
 	</tr>
 	<tr>
 		<td>text data</td>
 		<td>text data</td>
-		<td data-o-table-data-type="numeric" class="o-table__cell--numeric">22</td>
-		<td data-o-table-data-type="numeric" class="o-table__cell--numeric">22.2</td>
+		<td class="o-table__cell--numeric">22</td>
+		<td class="o-table__cell--numeric">22.2</td>
 	</tr>
 	<tr>
 		<td>text data</td>
 		<td>text data</td>
-		<td data-o-table-data-type="numeric" class="o-table__cell--numeric">3</td>
-		<td data-o-table-data-type="numeric" class="o-table__cell--numeric">3.0</td>
+		<td class="o-table__cell--numeric">3</td>
+		<td class="o-table__cell--numeric">3.0</td>
 	</tr>
 </table>

--- a/demos/src/pa11y.mustache
+++ b/demos/src/pa11y.mustache
@@ -9,20 +9,20 @@
 		<tr>
 			<td>cheddar</td>
 			<td>rye</td>
-			<td data-o-table-data-type="numeric" class="o-table__cell--numeric">2</td>
-			<td data-o-table-data-type="numeric" class="o-table__cell--numeric">1.56</td>
+			<td class="o-table__cell--numeric">2</td>
+			<td class="o-table__cell--numeric">1.56</td>
 		</tr>
 		<tr>
 			<td>stilton</td>
 			<td>wholemeal</td>
-			<td data-o-table-data-type="numeric" class="o-table__cell--numeric">2</td>
-			<td data-o-table-data-type="numeric" class="o-table__cell--numeric">1.85</td>
+			<td class="o-table__cell--numeric">2</td>
+			<td class="o-table__cell--numeric">1.85</td>
 		</tr>
 		<tr>
 			<td>red leicester</td>
 			<td>white</td>
-			<td data-o-table-data-type="numeric" class="o-table__cell--numeric">3</td>
-			<td data-o-table-data-type="numeric" class="o-table__cell--numeric">2.72</td>
+			<td class="o-table__cell--numeric">3</td>
+			<td class="o-table__cell--numeric">2.72</td>
 		</tr>
 	</tbody>
 </table>
@@ -38,20 +38,20 @@
 		<tr>
 			<td>cheddar</td>
 			<td>rye</td>
-			<td data-o-table-data-type="numeric" class="o-table__cell--numeric">2</td>
-			<td data-o-table-data-type="numeric" class="o-table__cell--numeric">1.56</td>
+			<td class="o-table__cell--numeric">2</td>
+			<td class="o-table__cell--numeric">1.56</td>
 		</tr>
 		<tr>
 			<td>stilton</td>
 			<td>wholemeal</td>
-			<td data-o-table-data-type="numeric" class="o-table__cell--numeric">2</td>
-			<td data-o-table-data-type="numeric" class="o-table__cell--numeric">1.85</td>
+			<td class="o-table__cell--numeric">2</td>
+			<td class="o-table__cell--numeric">1.85</td>
 		</tr>
 		<tr>
 			<td>red leicester</td>
 			<td>white</td>
-			<td data-o-table-data-type="numeric" class="o-table__cell--numeric">3</td>
-			<td data-o-table-data-type="numeric" class="o-table__cell--numeric">2.72</td>
+			<td class="o-table__cell--numeric">3</td>
+			<td class="o-table__cell--numeric">2.72</td>
 		</tr>
 	</tbody>
 </table>
@@ -73,14 +73,14 @@
 		<tr>
 			<td data-o-table-order=3>stilton</td>
 			<td data-o-table-order=2>wholemeal</td>
-			<td data-o-table-order=1 data-o-table-data-type="numeric" class="o-table__cell--numeric">2</td>
-			<td  data-o-table-order=0 data-o-table-data-type="numeric" class="o-table__cell--numeric">1.85</td>
+			<td data-o-table-order=1 class="o-table__cell--numeric">2</td>
+			<td  data-o-table-order=0 class="o-table__cell--numeric">1.85</td>
 		</tr>
 		<tr>
 			<td data-o-table-order=1>red leicester</td>
 			<td data-o-table-order=3>white</td>
-			<td data-o-table-order=2 data-o-table-data-type="numeric" class="o-table__cell--numeric">3</td>
-			<td data-o-table-order=0 data-o-table-data-type="numeric" class="o-table__cell--numeric">2.72</td>
+			<td data-o-table-order=2 class="o-table__cell--numeric">3</td>
+			<td data-o-table-order=0 class="o-table__cell--numeric">2.72</td>
 		</tr>
 	</tbody>
 </table>
@@ -101,20 +101,20 @@
 	<tr>
 		<td>text data</td>
 		<td>text data</td>
-		<td data-o-table-data-type="numeric" class="o-table__cell--numeric">123</td>
-		<td data-o-table-data-type="numeric" class="o-table__cell--numeric">123.45</td>
+		<td class="o-table__cell--numeric">123</td>
+		<td class="o-table__cell--numeric">123.45</td>
 	</tr>
 	<tr>
 		<td>text data</td>
 		<td>text data</td>
-		<td data-o-table-data-type="numeric" class="o-table__cell--numeric">22</td>
-		<td data-o-table-data-type="numeric" class="o-table__cell--numeric">22.2</td>
+		<td class="o-table__cell--numeric">22</td>
+		<td class="o-table__cell--numeric">22.2</td>
 	</tr>
 	<tr>
 		<td>text data</td>
 		<td>text data</td>
-		<td data-o-table-data-type="numeric" class="o-table__cell--numeric">3</td>
-		<td data-o-table-data-type="numeric" class="o-table__cell--numeric">3.0</td>
+		<td class="o-table__cell--numeric">3</td>
+		<td class="o-table__cell--numeric">3.0</td>
 	</tr>
 </table>
 
@@ -122,37 +122,43 @@
 	<thead>
 		<th>Cheese</th>
 		<th>Bread</th>
-		<th>Cost (GBP)</th>
-		<th>Cost (EUR)</th>
+		<th data-o-table-data-type="numeric" class="o-table__cell--numeric">Cost (GBP)</th>
+		<th data-o-table-data-type="numeric" class="o-table__cell--numeric">Cost (EUR)</th>
+		<th>Taste Note</th>
 	</thead>
 	<tbody>
 		<tr>
 			<td>cheddar</td>
 			<td>rye</td>
-			<td>2</td>
-			<td>1.56</td>
+			<td class="o-table__cell--numeric">2</td>
+			<td class="o-table__cell--numeric">1.56</td>
+			<td>sharp</td>
 		</tr>
 		<tr>
 			<td>stilton</td>
 			<td>wholemeal</td>
-			<td>2</td>
-			<td>1.85</td>
+			<td class="o-table__cell--numeric">2</td>
+			<td class="o-table__cell--numeric">1.85</td>
+			<td>strong</td>
 		</tr>
 		<tr>
 			<td>red leicester</td>
 			<td>white</td>
-			<td>3</td>
-			<td>2.72</td>
+			<td class="o-table__cell--numeric">3</td>
+			<td class="o-table__cell--numeric">2.72</td>
+			<td>sweet</td>
 		</tr>
 	</tbody>
 </table>
+
 
 <table class="o-table o-table--responsive-overflow o-table--row-stripes" data-o-component="o-table">
 	<thead>
 		<th>Cheese</th>
 		<th>Bread</th>
-		<th>Cost (GBP)</th>
-		<th>Cost (EUR)</th>
+		<th data-o-table-data-type="numeric" class="o-table__cell--numeric">Cost (GBP)</th>
+		<th data-o-table-data-type="numeric" class="o-table__cell--numeric">Cost (EUR)</th>
+		<th>Taste Note</th>
 	</thead>
 	<tbody>
 		<tr>
@@ -160,18 +166,21 @@
 			<td>rye</td>
 			<td>2</td>
 			<td>1.56</td>
+			<td>sharp</td>
 		</tr>
 		<tr>
 			<td>stilton</td>
 			<td>wholemeal</td>
 			<td>2</td>
 			<td>1.85</td>
+			<td>strong</td>
 		</tr>
 		<tr>
 			<td>red leicester</td>
 			<td>white</td>
 			<td>3</td>
 			<td>2.72</td>
+			<td>sweet</td>
 		</tr>
 	</tbody>
 </table>
@@ -180,45 +189,52 @@
 	<thead>
 		<th>Cheese</th>
 		<th>Bread</th>
-		<th>Cost (GBP)</th>
-		<th>Cost (EUR)</th>
+		<th data-o-table-data-type="numeric" class="o-table__cell--numeric">Cost (GBP)</th>
+		<th data-o-table-data-type="numeric" class="o-table__cell--numeric">Cost (EUR)</th>
+		<th>Taste Note</th>
 	</thead>
 	<tbody>
 		<tr>
 			<td>cheddar</td>
 			<td>rye</td>
-			<td>2</td>
-			<td>1.56</td>
+			<td class="o-table__cell--numeric">2</td>
+			<td class="o-table__cell--numeric">1.56</td>
+			<td>sharp</td>
 		</tr>
 		<tr>
 			<td>stilton</td>
 			<td>wholemeal</td>
-			<td>2</td>
-			<td>1.85</td>
+			<td class="o-table__cell--numeric">2</td>
+			<td class="o-table__cell--numeric">1.85</td>
+			<td>strong</td>
 		</tr>
 		<tr>
 			<td>red leicester</td>
 			<td>white</td>
-			<td>3</td>
-			<td>2.72</td>
+			<td class="o-table__cell--numeric">3</td>
+			<td class="o-table__cell--numeric">2.72</td>
+			<td>sweet</td>
 		</tr>
 		<tr>
 			<td>cheddar</td>
 			<td>rye</td>
-			<td>2</td>
-			<td>1.56</td>
+			<td class="o-table__cell--numeric">2</td>
+			<td class="o-table__cell--numeric">1.56</td>
+			<td>sharp</td>
 		</tr>
 		<tr>
 			<td>stilton</td>
 			<td>wholemeal</td>
-			<td>2</td>
-			<td>1.85</td>
+			<td class="o-table__cell--numeric">2</td>
+			<td class="o-table__cell--numeric">1.85</td>
+			<td>strong</td>
 		</tr>
 		<tr>
 			<td>red leicester</td>
 			<td>white</td>
-			<td>3</td>
-			<td>2.72</td>
+			<td class="o-table__cell--numeric">3</td>
+			<td class="o-table__cell--numeric">2.72</td>
+			<td>sweet</td>
 		</tr>
 	</tbody>
 </table>

--- a/demos/src/responsive-flat.mustache
+++ b/demos/src/responsive-flat.mustache
@@ -2,27 +2,31 @@
 	<thead>
 		<th>Cheese</th>
 		<th>Bread</th>
-		<th>Cost (GBP)</th>
-		<th>Cost (EUR)</th>
+		<th data-o-table-data-type="numeric" class="o-table__cell--numeric">Cost (GBP)</th>
+		<th data-o-table-data-type="numeric" class="o-table__cell--numeric">Cost (EUR)</th>
+		<th>Taste Note</th>
 	</thead>
 	<tbody>
 		<tr>
 			<td>cheddar</td>
 			<td>rye</td>
-			<td>2</td>
-			<td>1.56</td>
+			<td class="o-table__cell--numeric">2</td>
+			<td class="o-table__cell--numeric">1.56</td>
+			<td>sharp</td>
 		</tr>
 		<tr>
 			<td>stilton</td>
 			<td>wholemeal</td>
-			<td>2</td>
-			<td>1.85</td>
+			<td class="o-table__cell--numeric">2</td>
+			<td class="o-table__cell--numeric">1.85</td>
+			<td>strong</td>
 		</tr>
 		<tr>
 			<td>red leicester</td>
 			<td>white</td>
-			<td>3</td>
-			<td>2.72</td>
+			<td class="o-table__cell--numeric">3</td>
+			<td class="o-table__cell--numeric">2.72</td>
+			<td>sweet</td>
 		</tr>
 	</tbody>
 </table>

--- a/demos/src/responsive-overflow.mustache
+++ b/demos/src/responsive-overflow.mustache
@@ -2,8 +2,9 @@
 	<thead>
 		<th>Cheese</th>
 		<th>Bread</th>
-		<th>Cost (GBP)</th>
-		<th>Cost (EUR)</th>
+		<th data-o-table-data-type="numeric" class="o-table__cell--numeric">Cost (GBP)</th>
+		<th data-o-table-data-type="numeric" class="o-table__cell--numeric">Cost (EUR)</th>
+		<th>Taste Note</th>
 	</thead>
 	<tbody>
 		<tr>
@@ -11,18 +12,21 @@
 			<td>rye</td>
 			<td>2</td>
 			<td>1.56</td>
+			<td>sharp</td>
 		</tr>
 		<tr>
 			<td>stilton</td>
 			<td>wholemeal</td>
 			<td>2</td>
 			<td>1.85</td>
+			<td>strong</td>
 		</tr>
 		<tr>
 			<td>red leicester</td>
 			<td>white</td>
 			<td>3</td>
 			<td>2.72</td>
+			<td>sweet</td>
 		</tr>
 	</tbody>
 </table>

--- a/demos/src/responsive-scroll.mustache
+++ b/demos/src/responsive-scroll.mustache
@@ -2,45 +2,52 @@
 	<thead>
 		<th>Cheese</th>
 		<th>Bread</th>
-		<th>Cost (GBP)</th>
-		<th>Cost (EUR)</th>
+		<th data-o-table-data-type="numeric" class="o-table__cell--numeric">Cost (GBP)</th>
+		<th data-o-table-data-type="numeric" class="o-table__cell--numeric">Cost (EUR)</th>
+		<th>Taste Note</th>
 	</thead>
 	<tbody>
 		<tr>
 			<td>cheddar</td>
 			<td>rye</td>
-			<td>2</td>
-			<td>1.56</td>
+			<td class="o-table__cell--numeric">2</td>
+			<td class="o-table__cell--numeric">1.56</td>
+			<td>sharp</td>
 		</tr>
 		<tr>
 			<td>stilton</td>
 			<td>wholemeal</td>
-			<td>2</td>
-			<td>1.85</td>
+			<td class="o-table__cell--numeric">2</td>
+			<td class="o-table__cell--numeric">1.85</td>
+			<td>strong</td>
 		</tr>
 		<tr>
 			<td>red leicester</td>
 			<td>white</td>
-			<td>3</td>
-			<td>2.72</td>
+			<td class="o-table__cell--numeric">3</td>
+			<td class="o-table__cell--numeric">2.72</td>
+			<td>sweet</td>
 		</tr>
 		<tr>
 			<td>cheddar</td>
 			<td>rye</td>
-			<td>2</td>
-			<td>1.56</td>
+			<td class="o-table__cell--numeric">2</td>
+			<td class="o-table__cell--numeric">1.56</td>
+			<td>sharp</td>
 		</tr>
 		<tr>
 			<td>stilton</td>
 			<td>wholemeal</td>
-			<td>2</td>
-			<td>1.85</td>
+			<td class="o-table__cell--numeric">2</td>
+			<td class="o-table__cell--numeric">1.85</td>
+			<td>strong</td>
 		</tr>
 		<tr>
 			<td>red leicester</td>
 			<td>white</td>
-			<td>3</td>
-			<td>2.72</td>
+			<td class="o-table__cell--numeric">3</td>
+			<td class="o-table__cell--numeric">2.72</td>
+			<td>sweet</td>
 		</tr>
 	</tbody>
 </table>

--- a/src/scss/_responsive-flat.scss
+++ b/src/scss/_responsive-flat.scss
@@ -18,6 +18,12 @@
 		display: table;
 	}
 
+	@include oGridRespondTo($until: S) {
+		.o-table__cell--numeric {
+			text-align: left;
+		}
+	}
+
 	td {
 		padding: 8px;
 		width: 50%;

--- a/src/scss/_responsive-scroll.scss
+++ b/src/scss/_responsive-scroll.scss
@@ -12,6 +12,12 @@
 		display: table;
 	}
 
+	@include oGridRespondTo($until: S) {
+		.o-table__cell--numeric {
+			text-align: left;
+		}
+	}
+
 	thead {
 		display: flex;
 		flex-shrink: 0;


### PR DESCRIPTION
Numeric columns `data-o-table-data-type="numeric"`, which contain numerical rows with the class `.o-table__cell--numeric` do not display correctly responsively.

Changes:
- On small screens align numerical cells left in responsive tables.
- Update the demos to include numerical column examples.

As well as adding new numerical column demos, `data-o-table-data-type="numeric"` has been removed from `td` cells in the demos. This doesn't appear to be needed, we only need to know that a column `th` is numeric to maintain sort functionality. Adding the `data-o-table-data-type` attribute arbitrarily could significantly increase the payload of a table with many numerical fields, but there may be a reason for it I'm missing.

before:
<img width="1110" alt="screen shot 2017-09-12 at 14 00 45" src="https://user-images.githubusercontent.com/10405691/30327301-741119b8-97c3-11e7-808a-bea36b285f4d.png">

after:
<img width="1099" alt="screen shot 2017-09-12 at 13 59 43" src="https://user-images.githubusercontent.com/10405691/30327304-77ae9032-97c3-11e7-8b2c-febcc2246b4b.png">
