### PR TITLE
Sort affordance

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,6 +3,7 @@
     "dependencies": {
         "o-colors": "^4.0.0",
         "o-grid": "^4.0.6",
+        "o-icons": "^5.0.0",
         "o-typography": "^5.0.0"
     },
     "main": [

--- a/main.scss
+++ b/main.scss
@@ -2,6 +2,7 @@ $o-table-is-silent: true !default;
 
 @import "o-colors/main";
 @import "o-grid/main";
+@import "o-icons/main";
 @import "o-typography/main";
 
 @import "src/scss/color-use-cases";

--- a/src/scss/_base.scss
+++ b/src/scss/_base.scss
@@ -23,6 +23,30 @@
 		@include oColorsFor(o-table-header, color);
 	}
 
+	&[data-o-table--js] thead th {
+		cursor: pointer;
+		user-select: none; // add vendor prefixes
+		&:after {
+			content: '';
+			visibility: hidden;
+			@include oIconsGetIcon('arrow-up', $container-width: 20,  $container-height: 20, $iconset-version: 1);
+			vertical-align: middle;
+		}
+		&[aria-sort='descending'] {
+			&:after {
+				@include oIconsGetIcon('arrow-down', $container-width: 20,  $container-height: 20, $iconset-version: 1);
+			}
+		}
+		&:hover,
+		&[aria-sort='ascending'],
+		&[aria-sort='descending'] {
+			&:after {
+				vertical-align: middle;
+				visibility: visible;
+			}
+		}
+	}
+
 	td {
 		@include oTypographySans(1);
 		@include oColorsFor(o-table-data, color);

--- a/src/scss/_base.scss
+++ b/src/scss/_base.scss
@@ -26,25 +26,25 @@
 	&[data-o-table--js] thead th {
 		cursor: pointer;
 		user-select: none; // add vendor prefixes
-		padding-right: 30px;
+		padding-right: 20px;
 		&:after {
 			content: '';
-			visibility: hidden;
-			@include oIconsGetIcon('arrow-up', $container-width: 20,  $container-height: 20, $iconset-version: 1);
+			@include oIconsGetIcon('arrows-up-down', $container-width: 20,  $container-height: 20, $iconset-version: 1);
+			margin-right: -20px;
 			vertical-align: middle;
-			margin-right: -30px;
 		}
 		&[aria-sort='descending'] {
 			&:after {
 				@include oIconsGetIcon('arrow-down', $container-width: 20,  $container-height: 20, $iconset-version: 1);
+				vertical-align: middle;
 			}
 		}
-		&:hover,
-		&[aria-sort='ascending'],
-		&[aria-sort='descending'] {
+		&[aria-sort='none']:hover,
+		&:not([aria-sort]):hover,
+		&[aria-sort='ascending'] {
 			&:after {
+				@include oIconsGetIcon('arrow-up', $container-width: 20,  $container-height: 20, $iconset-version: 1);
 				vertical-align: middle;
-				visibility: visible;
 			}
 		}
 	}
@@ -59,10 +59,6 @@
 		padding: 8px;
 		text-align: left;
 		vertical-align: top;
-	}
-
-	&[data-o-table--js] td {
-		padding-right: 30px;
 	}
 
 	th:not([scope=row]) {

--- a/src/scss/_base.scss
+++ b/src/scss/_base.scss
@@ -25,20 +25,22 @@
 
 	&[data-o-table--js] thead th {
 		cursor: pointer;
-		user-select: none; // add vendor prefixes
+		user-select: none;
 		padding-right: 20px;
 		&:after {
 			content: '';
-			@include oIconsGetIcon('arrows-up-down', $container-width: 20,  $container-height: 20, $iconset-version: 1);
 			margin-right: -20px;
+			@include oIconsGetIcon('arrows-up-down', $container-width: 20,  $container-height: 20, $iconset-version: 1);
 			vertical-align: middle;
 		}
+		// Show descending icon with DSC sort applied.
 		&[aria-sort='descending'] {
 			&:after {
 				@include oIconsGetIcon('arrow-down', $container-width: 20,  $container-height: 20, $iconset-version: 1);
 				vertical-align: middle;
 			}
 		}
+		// Show ascending icon with ASC sort applied or on hover with no sort.
 		&[aria-sort='none']:hover,
 		&:not([aria-sort]):hover,
 		&[aria-sort='ascending'] {

--- a/src/scss/_base.scss
+++ b/src/scss/_base.scss
@@ -31,13 +31,13 @@
 			content: '';
 			margin-right: -20px;
 			@include oIconsGetIcon('arrows-up-down', $container-width: 20,  $container-height: 20, $iconset-version: 1);
-			vertical-align: middle;
+			vertical-align: top;
 		}
 		// Show descending icon with DSC sort applied.
 		&[aria-sort='descending'] {
 			&:after {
 				@include oIconsGetIcon('arrow-down', $container-width: 20,  $container-height: 20, $iconset-version: 1);
-				vertical-align: middle;
+				vertical-align: top;
 			}
 		}
 		// Show ascending icon with ASC sort applied or on hover with no sort.
@@ -46,7 +46,7 @@
 		&[aria-sort='ascending'] {
 			&:after {
 				@include oIconsGetIcon('arrow-up', $container-width: 20,  $container-height: 20, $iconset-version: 1);
-				vertical-align: middle;
+				vertical-align: top;
 			}
 		}
 	}

--- a/src/scss/_base.scss
+++ b/src/scss/_base.scss
@@ -26,11 +26,13 @@
 	&[data-o-table--js] thead th {
 		cursor: pointer;
 		user-select: none; // add vendor prefixes
+		padding-right: 30px;
 		&:after {
 			content: '';
 			visibility: hidden;
 			@include oIconsGetIcon('arrow-up', $container-width: 20,  $container-height: 20, $iconset-version: 1);
 			vertical-align: middle;
+			margin-right: -30px;
 		}
 		&[aria-sort='descending'] {
 			&:after {
@@ -57,6 +59,10 @@
 		padding: 8px;
 		text-align: left;
 		vertical-align: top;
+	}
+
+	&[data-o-table--js] td {
+		padding-right: 30px;
 	}
 
 	th:not([scope=row]) {

--- a/src/scss/_cells.scss
+++ b/src/scss/_cells.scss
@@ -11,5 +11,4 @@
 /// Makes content block and a smaller font size for secondary text in a table cell.
 @mixin oTableCellContentSecondary {
 	@include oTypographySans(0);
-	display: block;
 }

--- a/src/scss/_cells.scss
+++ b/src/scss/_cells.scss
@@ -11,4 +11,5 @@
 /// Makes content block and a smaller font size for secondary text in a table cell.
 @mixin oTableCellContentSecondary {
 	@include oTypographySans(0);
+	font-weight: normal;
 }

--- a/src/scss/_cells.scss
+++ b/src/scss/_cells.scss
@@ -8,7 +8,7 @@
 	text-align: right;
 }
 
-/// Makes content block and a smaller font size for secondary text in a table cell.
+/// Visually differentiate secondary text in a table cell.
 @mixin oTableCellContentSecondary {
 	@include oTypographySans(0);
 	font-weight: normal;

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -30,21 +30,6 @@
 			@include oTableCellNumeric;
 		}
 
-		&[data-o-table--js] thead th.#{$classname}__cell--numeric {
-			padding-left: 20px;
-			&:after {
-				display: none;
-			}
-			&:hover,
-			&[aria-sort='ascending'],
-			&[aria-sort='descending'] {
-				padding-left: 0;
-				&:after {
-					display: inline-block;
-				}
-			}
-		}
-
 		.#{$classname}__cell--content-secondary {
 			@include oTableCellContentSecondary;
 		}

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -30,6 +30,21 @@
 			@include oTableCellNumeric;
 		}
 
+		&[data-o-table--js] thead th.#{$classname}__cell--numeric {
+			padding-left: 20px;
+			&:after {
+				display: none;
+			}
+			&:hover,
+			&[aria-sort='ascending'],
+			&[aria-sort='descending'] {
+				padding-left: 0;
+				&:after {
+					display: inline-block;
+				}
+			}
+		}
+
 		.#{$classname}__cell--content-secondary {
 			@include oTableCellContentSecondary;
 		}


### PR DESCRIPTION
Adds sort affordance to tables: We have a cursor pointer, an indication icon, and a hover state. 🎉 

@olipowell and I chatted through the changes, we think this style is a good way to improve `o-tables` in the short term.

![kapture 2017-09-14 at 10 18 14](https://user-images.githubusercontent.com/10405691/30421918-3ebdf032-9936-11e7-9228-b01e2fbdd67f.gif)

So the sort icons can stay inline with the header, we have made changes to the style of `o-tables__cell--content-secondary`. It is no longer set to `display:block` and therefore sits inline when used in a table heading. We now ensure it's of normal weight to visually differentiate it.

**Before:**
<img width="618" alt="screen shot 2017-09-14 at 10 30 40" src="https://user-images.githubusercontent.com/10405691/30422420-cc3bebac-9937-11e7-9d74-002276948c2c.png">

**After:**
![kapture 2017-09-14 at 10 19 02](https://user-images.githubusercontent.com/10405691/30421916-3e83e5d6-9936-11e7-9819-5b4e39f51d14.gif)
