### PR TITLE
Fix table sorting for IE.

### DIFF
--- a/src/js/oTable.js
+++ b/src/js/oTable.js
@@ -143,8 +143,9 @@ function descendingSort (a, b) {
  * @returns undefined
  */
 OTable.prototype.sortRowsByColumn = function (index, sortAscending, isNumericValue) {
-	const rows = Array.from(this.rootEl.querySelectorAll('tbody tr'));
 	const tbody = this.rootEl.querySelector('tbody');
+	const rows = Array.from(tbody.querySelectorAll('tr'));
+
 	rows.sort(function (a, b) {
 		let aCol = a.querySelectorAll('td')[index];
 		let bCol = b.querySelectorAll('td')[index];
@@ -173,8 +174,6 @@ OTable.prototype.sortRowsByColumn = function (index, sortAscending, isNumericVal
 		}
 
 	});
-
-	tbody.innerHTML = '';
 
 	rows.forEach(function(row) {
 		tbody.appendChild(row);


### PR DESCRIPTION
Table sorting appears to be broken in IE:

![ie-sorti](https://user-images.githubusercontent.com/10405691/30427509-ffdc162a-9947-11e7-8136-cb8c8cc920fe.gif)

It seems IE loses the content of the table rows when `tbody.innerHTML = '';` is called, resulting in empty table row tags upon sort. As the `Node.appendChild()` method moves dom nodes from their current position to the new position if they already exist we can remove `tbody.innerHTML = '';` to fix this issue.
https://developer.mozilla.org/en-US/docs/Web/API/Node/appendChild