### PR TITLE
Add support for sorting numeric columns with blank cells.

### DIFF
--- a/demos/src/basic.mustache
+++ b/demos/src/basic.mustache
@@ -22,7 +22,7 @@
 			<td>red leicester</td>
 			<td>white</td>
 			<td class="o-table__cell--numeric">3</td>
-			<td class="o-table__cell--numeric">2.72</td>
+			<td class="o-table__cell--numeric"></td>
 		</tr>
 	</tbody>
 </table>
@@ -51,7 +51,7 @@
 			<td>red leicester</td>
 			<td>white</td>
 			<td class="o-table__cell--numeric">3</td>
-			<td class="o-table__cell--numeric">2.72</td>
+			<td class="o-table__cell--numeric"></td>
 		</tr>
 	</tbody>
 </table>

--- a/demos/src/pa11y.mustache
+++ b/demos/src/pa11y.mustache
@@ -22,7 +22,7 @@
 			<td>red leicester</td>
 			<td>white</td>
 			<td class="o-table__cell--numeric">3</td>
-			<td class="o-table__cell--numeric">2.72</td>
+			<td class="o-table__cell--numeric"></td>
 		</tr>
 	</tbody>
 </table>
@@ -51,7 +51,7 @@
 			<td>red leicester</td>
 			<td>white</td>
 			<td class="o-table__cell--numeric">3</td>
-			<td class="o-table__cell--numeric">2.72</td>
+			<td class="o-table__cell--numeric"></td>
 		</tr>
 	</tbody>
 </table>

--- a/src/js/oTable.js
+++ b/src/js/oTable.js
@@ -115,20 +115,20 @@ OTable.prototype.removeEventListeners = function () {
 	});
 };
 
-function ascendingSort (a, b) {
-	if (a < b) {
+function ascendingSort (a, b, isNumericValue) {
+	if (isNumericValue && isNaN(a) || a < b) {
 		return -1;
-	} else if (b < a) {
+	} else if (isNumericValue && isNaN(b) || b < a) {
 		return 1;
 	} else {
 		return 0;
 	}
 }
 
-function descendingSort (a, b) {
-	if (a < b) {
+function descendingSort (a, b, isNumericValue) {
+	if (isNumericValue && isNaN(a) || a < b) {
 		return 1;
-	} else if (b < a) {
+	} else if (isNumericValue && isNaN(b) || b < a) {
 		return -1;
 	} else {
 		return 0;
@@ -168,9 +168,9 @@ OTable.prototype.sortRowsByColumn = function (index, sortAscending, isNumericVal
 		}
 
 		if (sortAscending) {
-			return ascendingSort(aCol, bCol);
+			return ascendingSort(aCol, bCol, isNumericValue);
 		} else {
-			return descendingSort(aCol, bCol);
+			return descendingSort(aCol, bCol, isNumericValue);
 		}
 
 	});

--- a/src/scss/_base.scss
+++ b/src/scss/_base.scss
@@ -54,6 +54,11 @@
 	td {
 		@include oTypographySans(1);
 		@include oColorsFor(o-table-data, color);
+		&:empty:before {
+			content: '';
+			@include oIconsGetIcon('minus', $container-width: 15,  $container-height: 15, $iconset-version: 1);
+			vertical-align: middle;
+		}
 	}
 
 	th,

--- a/test/oTableSort.test.js
+++ b/test/oTableSort.test.js
@@ -124,6 +124,9 @@ describe('oTable sorting', () => {
 					<tr>
 						<td data-o-table-data-type="numeric">3</td>
 					</tr>
+					<tr>
+						<td data-o-table-data-type="numeric"></td>
+					</tr>
 				</tbody>
 			</table>
 		`);
@@ -136,9 +139,10 @@ describe('oTable sorting', () => {
 		oTableEl.querySelector('thead th').dispatchEvent(click);
 		oTableEl.addEventListener('oTable.sorted', () => {
 			const rows = oTableEl.querySelectorAll('tbody tr td');
-			proclaim.equal(rows[0].textContent, '1.2');
-			proclaim.equal(rows[1].textContent, '3');
-			proclaim.equal(rows[2].textContent, '12.03');
+			proclaim.equal(rows[0].textContent, '');
+			proclaim.equal(rows[1].textContent, '1.2');
+			proclaim.equal(rows[2].textContent, '3');
+			proclaim.equal(rows[3].textContent, '12.03');
 			proclaim.equal(oTableEl.getAttribute('data-o-table-order'), 'ASC');
 			done();
 		});


### PR DESCRIPTION
- Fix broken sort: Support sort on non numeric (i.e. empty) cells in numeric columns.
- Add an icon in empty cells. This provides a better screen reading experience as apposed to adding "-" to indicate a blank cell. The arbitrary size / weight is questionable though (review required). 
- Remove the content of some cells in the demo to show off the improved appearance and sort functionality.

![screen shot 2017-09-22 at 16 24 09](https://user-images.githubusercontent.com/10405691/30755229-c0b0bd08-9fbd-11e7-83a7-3583a10707ee.png)
![screen shot 2017-09-22 at 16 24 18](https://user-images.githubusercontent.com/10405691/30755231-c109b282-9fbd-11e7-8d4a-056d893ab8dd.png)
![screen shot 2017-09-22 at 16 24 42](https://user-images.githubusercontent.com/10405691/30755230-c0b3ef0a-9fbd-11e7-88ce-4fa6b6abcacc.png)

Where it will be used (instead of dashes):
![untitled](https://user-images.githubusercontent.com/10405691/30755180-979f0eb0-9fbd-11e7-8f5e-24569b2bd4e7.jpg)

