### PR TITLE
Support comma separator for groups of thousands in numerical sort.

### DIFF
--- a/src/js/oTable.js
+++ b/src/js/oTable.js
@@ -163,8 +163,8 @@ OTable.prototype.sortRowsByColumn = function (index, sortAscending, isNumericVal
 		}
 
 		if (isNumericValue) {
-			aCol = parseFloat(aCol);
-			bCol = parseFloat(bCol);
+			aCol = parseFloat(aCol.replace(/,/g,''));
+			bCol = parseFloat(bCol.replace(/,/g,''));
 		}
 
 		if (sortAscending) {

--- a/test/oTableSort.test.js
+++ b/test/oTableSort.test.js
@@ -119,10 +119,16 @@ describe('oTable sorting', () => {
 						<td data-o-table-data-type="numeric">12.03</td>
 					</tr>
 					<tr>
+						<td data-o-table-data-type="numeric">480,000</td>
+					</tr>
+					<tr>
 						<td data-o-table-data-type="numeric">1.2</td>
 					</tr>
 					<tr>
 						<td data-o-table-data-type="numeric">3</td>
+					</tr>
+					<tr>
+						<td data-o-table-data-type="numeric">1,216,000</td>
 					</tr>
 					<tr>
 						<td data-o-table-data-type="numeric"></td>
@@ -143,6 +149,8 @@ describe('oTable sorting', () => {
 			proclaim.equal(rows[1].textContent, '1.2');
 			proclaim.equal(rows[2].textContent, '3');
 			proclaim.equal(rows[3].textContent, '12.03');
+			proclaim.equal(rows[4].textContent, '480,000');
+			proclaim.equal(rows[5].textContent, '1,216,000');
 			proclaim.equal(oTableEl.getAttribute('data-o-table-order'), 'ASC');
 			done();
 		});


### PR DESCRIPTION
This does not handle potential formats outside of the UK/US: 

"[...] while the U.K. and U.S. use a comma to separate groups of thousands, many other countries use a period instead, and some countries separate thousands groups with a thin space. Table 1-3 shows some commonly used numeric formats."

https://docs.oracle.com/cd/E19455-01/806-0169/overview-9/index.html