### PR TITLE
Multi level headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,18 +24,22 @@ Add an `o-table` class to any table you wish to apply the styles to:
 </table>
 ```
 
-Where a `td` contains numeric data, or a `th` is for cells containing numeric data, also add the class `.o-table__cell--numeric` and a `data-o-table-data-type="numeric"` attribute (the latter allows the column to be sorted correctly):
+Where a `td` contains numeric data, or a `th` is for cells containing numeric data, you may also add the class `.o-table__cell--numeric`. Additionally add the `data-o-table-data-type="numeric"` attribute to the `th` to allow the column to be sorted numerically:
 
 ```html
 <table class="o-table">
-	<tr>
-		<th>Index</th>
-		<th data-o-table-data-type="numeric" class="o-table__cell--numeric">Value</th>
-	</tr>
-	<tr>
-		<td>FTSE 100</td>
-		<td data-o-table-data-type="numeric" class="o-table__cell--numeric">6685.52</td>
-	</tr>
+	<thead>
+		<tr>
+			<th>Index</th>
+			<th data-o-table-data-type="numeric" class="o-table__cell--numeric">Value</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>FTSE 100</td>
+			<td data-o-table-data-type="numeric" class="o-table__cell--numeric">6685.52</td>
+		</tr>
+	</tbody>
 	...
 </table>
 ```
@@ -52,7 +56,7 @@ Where table headings (`th`) are used as row headings, `scope="row"` attributes m
 </table>
 ```
 
-When they're are not present, browsers will implicitly wrap table contents in `tbody` tags, including the header row. It is therefore advisable (and when row-stripes are required, essential) to use `thead`, `tbody` (and if appropriate, `tfoot`) tags in your markup:
+`thead` and `tbody` tags should be used in your markup and where appropriate `tfoot` should also be used. Each of these elements must contain `tr` children to wrap any `td` or `th` element:
 
 ```html
 <table class="o-table">
@@ -62,6 +66,11 @@ When they're are not present, browsers will implicitly wrap table contents in `t
 			<th data-o-table-data-type="numeric" class="o-table__cell--numeric">Value</th>
 		</tr>
 	</thead>
+	<tfoot>
+		<tr>
+			<td colspan="2">footer content</td>
+		</tr>
+	</tfoot>
 	<tbody>
 		<tr>
 			<td>FTSE 100</td>
@@ -195,7 +204,7 @@ const OTable = require('o-table');
 oTable = new OTable(document.body);
 ```
 
-Sorting numbers works if the column has been declared as a numeric column via `data-o-table-data-type="numeric" class="o-table__cell--numeric"`.
+Sorting numbers works if the column has been declared as a numeric column via `data-o-table-data-type="numeric"`.
 
 ##### Sorting declaratively
 If you are wanting to sort by a custom pattern, you can apply the sorting values to each row as a data attribute:
@@ -204,7 +213,9 @@ If you are wanting to sort by a custom pattern, you can apply the sorting values
 ``` html
 <table class="o-table" data-o-component="o-table">
 	<thead>
-		<th>Things</th>
+		<tr>
+			<th>Things</th>
+		</tr>
 	</thead>
 	<tbody>
 		<tr>

--- a/README.md
+++ b/README.md
@@ -123,6 +123,12 @@ Additional classes may be added to the table root element to also apply the foll
 
 #### Content styles
 
+Class: `.o-table__multi-level-header`
+
+Adds styles to a multi-level table header, i.e. a header of a header. A multi-level header should span columns and be within the first row of a table header (`thead > tr:first-child > th[colspan][scope="colgroup"].o-table__multi-level-header`).
+
+The responsive scroll and flat table variants do not support multi level headers on mobile.
+
 Class: `o-table__cell--content-secondary`, Mixin: `oTableCellContentSecondary`
 
 Reduce the size of some text in a cell and display block to start a new line. The class should be applied to a `<span>` or `<div>` element inside of the table cell.
@@ -224,12 +230,23 @@ Known issues:
 
 ## Migration guide
 
-### How to upgrade from v4.x.x to v5.x.x?
+### How to upgrade from v6.x.x to v7.x.x?
+
+- `thead` elements must have `tr` children i.e. `thead > tr > th`.
+- The data attribute `data-o-table--js`, which is automatically set with JavaScript when the table is instantiated, is now `data-o-table-js`.
+- The default vertical lines have been removed from the flat responsive variant (`.o-table--responsive-flat` `oTableResponsiveFlat()`) but these can be reinstated if required using the vertical lines class `.o-table--vertical-lines` or mixin `oTableVerticalLines()`.
+
+### How to upgrade from v5.x.x to v6.x.x?
 
 This major takes the new o-colors and o-typography. Some of the colors and typography have changed slightly from v4 to v5. The font size and line heights of the table data has increased to sit in line with the new typography scale. Some of the colors have changed as there isn't an exact mapping from one color to the other in o-colors.
 
 The `oTableCellContentPrimary` mixin (deprecated in v5) has been removed.
 The concrete classes `.primary-data` and `.secondary-data` (deprecated in v5) have been removed.
+
+
+### How to upgrade from v4.x.x to v5.x.x?
+
+To support new responsive tables this major introduces a dependency on `o-grid`. Confirm this version of `o-grid` is compatible with other dependencies in your project.
 
 ### How to upgrade from v3.x.x to v4.x.x?
 

--- a/demos/src/basic.mustache
+++ b/demos/src/basic.mustache
@@ -1,9 +1,11 @@
 <table class="o-table {{modifierClass}}" data-o-component="o-table">
 	<thead>
-		<th>Cheese <span class="o-table__cell--content-secondary">Type of cheese</span></th>
-		<th>Bread <span class="o-table__cell--content-secondary">Type of bread</span></th>
-		<th data-o-table-data-type="numeric" class="o-table__cell--numeric">Cost <span class="o-table__cell--content-secondary">(GBP)</span></th>
-		<th data-o-table-data-type="numeric" class="o-table__cell--numeric">Cost <span class="o-table__cell--content-secondary">(EUR)</span></th>
+		<tr>
+			<th>Cheese <span class="o-table__cell--content-secondary">Type of cheese</span></th>
+			<th>Bread <span class="o-table__cell--content-secondary">Type of bread</span></th>
+			<th data-o-table-data-type="numeric" class="o-table__cell--numeric">Cost <span class="o-table__cell--content-secondary">(GBP)</span></th>
+			<th data-o-table-data-type="numeric" class="o-table__cell--numeric">Cost <span class="o-table__cell--content-secondary">(EUR)</span></th>
+		</tr>
 	</thead>
 	<tbody>
 		<tr>
@@ -29,10 +31,18 @@
 
 <table class="o-table {{modifierClass}}" data-o-component="o-table">
 	<thead>
-		<th>Cheese</th>
-		<th>Bread</th>
-		<th data-o-table-data-type="numeric" class="o-table__cell--numeric">Cost (GBP)</th>
-		<th data-o-table-data-type="numeric" class="o-table__cell--numeric">Cost (EUR)</th>
+		<tr>
+			<th></th>
+			<th></th>
+			<th class="o-table__multi-level-header" colspan="2" scope="colgroup">Cost Per Combination</th>
+			<th></th>
+		</tr>
+		<tr>
+			<th>Cheese <span class="o-table__cell--content-secondary">Type of cheese</span></th>
+			<th>Bread <span class="o-table__cell--content-secondary">Type of bread</span></th>
+			<th data-o-table-data-type="numeric" class="o-table__cell--numeric">Cost <span class="o-table__cell--content-secondary">(GBP)</span></th>
+			<th data-o-table-data-type="numeric" class="o-table__cell--numeric">Cost <span class="o-table__cell--content-secondary">(EUR)</span></th>
+		</tr>
 	</thead>
 	<tbody>
 		<tr>
@@ -45,7 +55,7 @@
 			<td>stilton</td>
 			<td>wholemeal</td>
 			<td class="o-table__cell--numeric">2</td>
-			<td  class="o-table__cell--numeric">1.85</td>
+			<td class="o-table__cell--numeric">1.85</td>
 		</tr>
 		<tr>
 			<td>red leicester</td>

--- a/demos/src/captions.mustache
+++ b/demos/src/captions.mustache
@@ -5,12 +5,57 @@
 	<caption class="o-table__caption--bottom">
 		Bottom caption
 	</caption>
+	<thead>
+		<tr>
+			<th>Heading</th>
+			<th>Heading</th>
+			<th data-o-table-data-type="numeric" class="o-table__cell--numeric">Heading</th>
+			<th data-o-table-data-type="numeric" class="o-table__cell--numeric">Heading</th>
+		</tr>
+	</thead>
 	<tr>
-		<th>Heading</th>
-		<th>Heading</th>
-		<th data-o-table-data-type="numeric" class="o-table__cell--numeric">Heading</th>
-		<th data-o-table-data-type="numeric" class="o-table__cell--numeric">Heading</th>
+		<td>text data</td>
+		<td>text data</td>
+		<td class="o-table__cell--numeric">123</td>
+		<td class="o-table__cell--numeric">123.45</td>
 	</tr>
+	<tr>
+		<td>text data</td>
+		<td>text data</td>
+		<td class="o-table__cell--numeric">22</td>
+		<td class="o-table__cell--numeric">22.2</td>
+	</tr>
+	<tr>
+		<td>text data</td>
+		<td>text data</td>
+		<td class="o-table__cell--numeric">3</td>
+		<td class="o-table__cell--numeric">3.0</td>
+	</tr>
+</table>
+
+<table class="o-table" data-o-component="o-table">
+	<caption class="o-table__caption--top">
+		Top caption (default)
+	</caption>
+	<caption class="o-table__caption--bottom">
+		Bottom caption
+	</caption>
+	<thead>
+		<tr>
+			<th></th>
+			<th></th>
+			<th class="o-table__multi-level-header" colspan="2" scope="colgroup">
+				Cost Per Combination
+			</th>
+			<th></th>
+		</tr>
+		<tr>
+			<th>Heading</th>
+			<th>Heading</th>
+			<th data-o-table-data-type="numeric" class="o-table__cell--numeric">Heading</th>
+			<th data-o-table-data-type="numeric" class="o-table__cell--numeric">Heading</th>
+		</tr>
+	</thead>
 	<tr>
 		<td>text data</td>
 		<td>text data</td>

--- a/demos/src/responsive-flat.mustache
+++ b/demos/src/responsive-flat.mustache
@@ -1,10 +1,53 @@
 <table class="o-table o-table--responsive-flat" data-o-component="o-table" data-o-table-responsive="flat">
 	<thead>
-		<th>Cheese</th>
-		<th>Bread</th>
-		<th data-o-table-data-type="numeric" class="o-table__cell--numeric">Cost (GBP)</th>
-		<th data-o-table-data-type="numeric" class="o-table__cell--numeric">Cost (EUR)</th>
-		<th>Taste Note</th>
+		<tr>
+			<th>Cheese</th>
+			<th>Bread</th>
+			<th data-o-table-data-type="numeric" class="o-table__cell--numeric">Cost (GBP)</th>
+			<th data-o-table-data-type="numeric" class="o-table__cell--numeric">Cost (EUR)</th>
+			<th>Taste Note</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>cheddar</td>
+			<td>rye</td>
+			<td class="o-table__cell--numeric">2</td>
+			<td class="o-table__cell--numeric">1.56</td>
+			<td>sharp</td>
+		</tr>
+		<tr>
+			<td>stilton</td>
+			<td>wholemeal</td>
+			<td class="o-table__cell--numeric">2</td>
+			<td class="o-table__cell--numeric">1.85</td>
+			<td>strong</td>
+		</tr>
+		<tr>
+			<td>red leicester</td>
+			<td>white</td>
+			<td class="o-table__cell--numeric">3</td>
+			<td class="o-table__cell--numeric">2.72</td>
+			<td>sweet</td>
+		</tr>
+	</tbody>
+</table>
+
+<table class="o-table o-table--responsive-flat o-table--vertical-lines o-table--vertical-lines" data-o-component="o-table" data-o-table-responsive="flat">
+	<thead>
+		<tr>
+			<th></th>
+			<th></th>
+			<th class="o-table__multi-level-header" colspan="2" scope="colgroup">Cost Per Combination</th>
+			<th></th>
+		</tr>
+		<tr>
+			<th>Cheese</th>
+			<th>Bread</th>
+			<th data-o-table-data-type="numeric" class="o-table__cell--numeric">Cost (GBP)</th>
+			<th data-o-table-data-type="numeric" class="o-table__cell--numeric">Cost (EUR)</th>
+			<th>Taste Note</th>
+		</tr>
 	</thead>
 	<tbody>
 		<tr>

--- a/demos/src/responsive-flat.mustache
+++ b/demos/src/responsive-flat.mustache
@@ -33,7 +33,7 @@
 	</tbody>
 </table>
 
-<table class="o-table o-table--responsive-flat o-table--vertical-lines o-table--vertical-lines" data-o-component="o-table" data-o-table-responsive="flat">
+<table class="o-table o-table--responsive-flat" data-o-component="o-table" data-o-table-responsive="flat">
 	<thead>
 		<tr>
 			<th></th>

--- a/demos/src/responsive-overflow.mustache
+++ b/demos/src/responsive-overflow.mustache
@@ -1,10 +1,53 @@
 <table class="o-table o-table--responsive-overflow o-table--row-stripes" data-o-component="o-table">
 	<thead>
-		<th>Cheese</th>
-		<th>Bread</th>
-		<th data-o-table-data-type="numeric" class="o-table__cell--numeric">Cost (GBP)</th>
-		<th data-o-table-data-type="numeric" class="o-table__cell--numeric">Cost (EUR)</th>
-		<th>Taste Note</th>
+		<tr>
+			<th>Cheese</th>
+			<th>Bread</th>
+			<th data-o-table-data-type="numeric" class="o-table__cell--numeric">Cost (GBP)</th>
+			<th data-o-table-data-type="numeric" class="o-table__cell--numeric">Cost (EUR)</th>
+			<th>Taste Note</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>cheddar</td>
+			<td>rye</td>
+			<td class="o-table__cell--numeric">2</td>
+			<td class="o-table__cell--numeric">1.56</td>
+			<td>sharp</td>
+		</tr>
+		<tr>
+			<td>stilton</td>
+			<td>wholemeal</td>
+			<td class="o-table__cell--numeric">2</td>
+			<td class="o-table__cell--numeric">1.85</td>
+			<td>strong</td>
+		</tr>
+		<tr>
+			<td>red leicester</td>
+			<td>white</td>
+			<td class="o-table__cell--numeric">3</td>
+			<td class="o-table__cell--numeric">2.72</td>
+			<td>sweet</td>
+		</tr>
+	</tbody>
+</table>
+
+<table class="o-table o-table--responsive-overflow o-table--row-stripes" data-o-component="o-table">
+	<thead>
+		<tr>
+			<th></th>
+			<th></th>
+			<th class="o-table__multi-level-header" colspan="2" scope="colgroup">Cost Per Combination</th>
+			<th></th>
+		</tr>
+		<tr>
+			<th>Cheese</th>
+			<th>Bread</th>
+			<th data-o-table-data-type="numeric" class="o-table__cell--numeric">GBP</th>
+			<th data-o-table-data-type="numeric" class="o-table__cell--numeric">EUR</th>
+			<th>Taste Note</th>
+		</tr>
 	</thead>
 	<tbody>
 		<tr>

--- a/demos/src/responsive-scroll.mustache
+++ b/demos/src/responsive-scroll.mustache
@@ -1,10 +1,74 @@
 <table class="o-table o-table--responsive-scroll" data-o-component="o-table">
 	<thead>
-		<th>Cheese</th>
-		<th>Bread</th>
-		<th data-o-table-data-type="numeric" class="o-table__cell--numeric">Cost (GBP)</th>
-		<th data-o-table-data-type="numeric" class="o-table__cell--numeric">Cost (EUR)</th>
-		<th>Taste Note</th>
+		<tr>
+			<th>Cheese</th>
+			<th>Bread</th>
+			<th data-o-table-data-type="numeric" class="o-table__cell--numeric">Cost (GBP)</th>
+			<th data-o-table-data-type="numeric" class="o-table__cell--numeric">Cost (EUR)</th>
+			<th>Taste Note</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>cheddar</td>
+			<td>rye</td>
+			<td class="o-table__cell--numeric">2</td>
+			<td class="o-table__cell--numeric">1.56</td>
+			<td>sharp</td>
+		</tr>
+		<tr>
+			<td>stilton</td>
+			<td>wholemeal</td>
+			<td class="o-table__cell--numeric">2</td>
+			<td class="o-table__cell--numeric">1.85</td>
+			<td>strong</td>
+		</tr>
+		<tr>
+			<td>red leicester</td>
+			<td>white</td>
+			<td class="o-table__cell--numeric">3</td>
+			<td class="o-table__cell--numeric">2.72</td>
+			<td>sweet</td>
+		</tr>
+		<tr>
+			<td>cheddar</td>
+			<td>rye</td>
+			<td class="o-table__cell--numeric">2</td>
+			<td class="o-table__cell--numeric">1.56</td>
+			<td>sharp</td>
+		</tr>
+		<tr>
+			<td>stilton</td>
+			<td>wholemeal</td>
+			<td class="o-table__cell--numeric">2</td>
+			<td class="o-table__cell--numeric">1.85</td>
+			<td>strong</td>
+		</tr>
+		<tr>
+			<td>red leicester</td>
+			<td>white</td>
+			<td class="o-table__cell--numeric">3</td>
+			<td class="o-table__cell--numeric">2.72</td>
+			<td>sweet</td>
+		</tr>
+	</tbody>
+</table>
+
+<table class="o-table o-table--responsive-scroll" data-o-component="o-table">
+	<thead>
+		<tr>
+			<th></th>
+			<th></th>
+			<th class="o-table__multi-level-header" colspan="2" scope="colgroup">Cost Per Combination</th>
+			<th></th>
+		</tr>
+		<tr>
+			<th>Cheese</th>
+			<th>Bread</th>
+			<th data-o-table-data-type="numeric" class="o-table__cell--numeric">Cost (GBP)</th>
+			<th data-o-table-data-type="numeric" class="o-table__cell--numeric">Cost (EUR)</th>
+			<th>Taste Note</th>
+		</tr>
 	</thead>
 	<tbody>
 		<tr>

--- a/src/js/oTable.js
+++ b/src/js/oTable.js
@@ -25,13 +25,16 @@ function OTable(rootEl) {
 
 		// Get tables headers from the last header row (not headers of headers).
 		this.tableHeaders = Array.from(this.rootEl.querySelectorAll('thead tr:last-of-type th'));
+		const firstDataRow = this.rootEl.querySelectorAll('tbody tr:first-of-type td');
 		// Sort is only supported where each header maps to a single column.
-		this.tableHeaders.forEach((th, columnIndex) => {
-			const listener = this._sortByColumn(columnIndex);
-			this.listeners.push(listener);
-			th.addEventListener('click', listener);
-			th.classList.add('o-table__sortable-header');
-		});
+		if (firstDataRow.length == this.tableHeaders.length) {
+			this.tableHeaders.forEach((th, columnIndex) => {
+				const listener = this._sortByColumn(columnIndex);
+				this.listeners.push(listener);
+				th.addEventListener('click', listener);
+				th.classList.add('o-table__sortable-header');
+			});
+		}
 
 		// "o-table--responsive-flat" configuration only works when there is a
 		// `<thead>` block containing the table headers. If there are no headers

--- a/src/js/oTable.js
+++ b/src/js/oTable.js
@@ -27,7 +27,7 @@ function OTable(rootEl) {
 		this.tableHeaders = Array.from(this.rootEl.querySelectorAll('thead tr:last-of-type th'));
 		const firstDataRow = this.rootEl.querySelectorAll('tbody tr:first-of-type td');
 		// Sort is only supported where each header maps to a single column.
-		if (firstDataRow.length == this.tableHeaders.length) {
+		if (firstDataRow.length === this.tableHeaders.length) {
 			this.tableHeaders.forEach((th, columnIndex) => {
 				const listener = this._sortByColumn(columnIndex);
 				this.listeners.push(listener);

--- a/src/js/oTable.js
+++ b/src/js/oTable.js
@@ -19,15 +19,18 @@ function OTable(rootEl) {
 	if (this.rootEl !== undefined) {
 		this.listeners = [];
 		this.isResponsive = false;
-		this.rootEl.setAttribute('data-o-table--js', '');
+		this.rootEl.setAttribute('data-o-table-js', '');
 
-		this.tableHeaders = Array.from(this.rootEl.querySelectorAll('thead th'));
 		const tableRows = Array.from(this.rootEl.getElementsByTagName('tr'));
 
+		// Get tables headers from the last header row (not headers of headers).
+		this.tableHeaders = Array.from(this.rootEl.querySelectorAll('thead tr:last-of-type th'));
+		// Sort is only supported where each header maps to a single column.
 		this.tableHeaders.forEach((th, columnIndex) => {
 			const listener = this._sortByColumn(columnIndex);
 			this.listeners.push(listener);
 			th.addEventListener('click', listener);
+			th.classList.add('o-table__sortable-header');
 		});
 
 		// "o-table--responsive-flat" configuration only works when there is a
@@ -191,7 +194,7 @@ OTable.prototype.destroy = function() {
 		clearTimeout(this._timeoutID);
 		this._timeoutID = undefined;
 	}
-	this.rootEl.removeAttribute('data-o-table--js');
+	this.rootEl.removeAttribute('data-o-table-js');
 	this.removeEventListeners();
 	delete this.rootEl;
 };

--- a/src/scss/_base.scss
+++ b/src/scss/_base.scss
@@ -23,7 +23,7 @@
 		@include oColorsFor(o-table-header, color);
 	}
 
-	&[data-o-table--js] thead th {
+	&[data-o-table-js] &__sortable-header {
 		cursor: pointer;
 		user-select: none;
 		padding-right: 20px;
@@ -66,6 +66,11 @@
 		padding: 8px;
 		text-align: left;
 		vertical-align: top;
+	}
+
+	th#{&}__multi-level-header {
+		border-bottom: 3px solid oColorsGetColorFor(o-table-data, color);
+		text-align: center;
 	}
 
 	th:not([scope=row]) {

--- a/src/scss/_lines.scss
+++ b/src/scss/_lines.scss
@@ -12,7 +12,7 @@
 
 /// Add verticle lines to a table
 @mixin oTableVerticalLines {
-	th:not(:last-child):not(:first-child),
+	thead tr:last-of-type th:not(:last-child):not(:first-child),
 	td:not(:last-child):not(:first-child) {
 		border-left: 1px solid oColorsGetColorFor(o-table-row, border);
 		border-right: 1px solid oColorsGetColorFor(o-table-row, border);

--- a/src/scss/_responsive-flat.scss
+++ b/src/scss/_responsive-flat.scss
@@ -29,7 +29,6 @@
 		width: 50%;
 
 		@include oGridRespondTo(S) {
-			border-right: 1px solid oColorsGetColorFor(o-table-row-right, border-right);
 			display: table-cell;
 		}
 	} // td
@@ -39,7 +38,6 @@
 		padding: 8px;
 
 		@include oGridRespondTo(S) {
-			border-right: 1px solid oColorsGetColorFor(o-table-row-right, border-right);
 			display: table-cell;
 		}
 	} // thead th

--- a/src/scss/_responsive-scroll.scss
+++ b/src/scss/_responsive-scroll.scss
@@ -58,4 +58,11 @@
 		}
 	}
 
+
+	thead tr:not(:last-of-type) {
+		@include oGridRespondTo($until: S) {
+			display: none;
+		}
+	}
+
 } // mixin

--- a/src/scss/_row-stripes.scss
+++ b/src/scss/_row-stripes.scss
@@ -5,9 +5,13 @@
 
 /// Add this to the table element to get row stripes
 @mixin oTableRowStripes {
-	background-color: oColorsGetColorFor(o-table-striped o-table page, background);
 
 	caption {
+		background-color: oColorsGetColorFor(o-table-striped o-table page, background);
+	}
+
+	tbody tr, 
+	thead tr:last-of-type {
 		background-color: oColorsGetColorFor(o-table-striped o-table page, background);
 	}
 

--- a/test/oTable.test.js
+++ b/test/oTable.test.js
@@ -158,7 +158,7 @@ describe('An oTable instance', () => {
 
 	it('sets a data attribute on the root element of the component to indicate the JS has executed', () => {
 		testOTable = new OTable(oTableEl);
-		proclaim.isTrue(oTableEl.hasAttribute('data-o-table--js'));
+		proclaim.isTrue(oTableEl.hasAttribute('data-o-table-js'));
 	});
 
 	it('has an `isResponsive` property set to `false`', () => {
@@ -266,7 +266,7 @@ describe('Init', () => {
 		const oTables = OTable.init();
 		const tables = oTables.map(oTable => oTable.rootEl);
 		tables.forEach(table => {
-			proclaim.isTrue(table.hasAttribute('data-o-table--js'));
+			proclaim.isTrue(table.hasAttribute('data-o-table-js'));
 		});
 	});
 });
@@ -341,6 +341,6 @@ describe('Destroying an oTable instance', () => {
 	it('when destroyed, removes the data attribute which was added during JS initialisation', () => {
 		testOTable = new OTable(oTableEl);
 		testOTable.destroy();
-		proclaim.isFalse(oTableEl.hasAttribute('data-o-table--js'));
+		proclaim.isFalse(oTableEl.hasAttribute('data-o-table-js'));
 	});
 });

--- a/test/oTableSort.test.js
+++ b/test/oTableSort.test.js
@@ -260,7 +260,7 @@ describe('oTable sorting', () => {
 		const testOTableHeader = document.querySelector('th:first-of-type');
 		testOTable = new OTable(oTableEl);
 		oTableEl.addEventListener('oTable.sorted', (done) => {
-			proclaim.fail(true, false, 'The table was sorted when sort should be disabled.', '===');			
+			proclaim.fail(true, false, 'The table was sorted when sort should be disabled.', '===');
 			done();
 		});
 		testOTableHeader.click();

--- a/test/oTableSort.test.js
+++ b/test/oTableSort.test.js
@@ -231,4 +231,39 @@ describe('oTable sorting', () => {
 			done();
 		});
 	});
+
+	it('is not enabled if the number of headers do not map directly to a column of data.', done => {
+		sandbox.reset();
+		sandbox.init();
+		sandbox.setContents(`
+			<table id="tableHeaderMismatch" class="o-table" data-o-component="o-table">
+				<thead>
+					<th colspan="2" scope="colgroup">Things</th>
+				</thead>
+				<tbody>
+					<tr>
+						<td>1</td>
+						<td>extra data column</td>
+					</tr>
+					<tr>
+						<td>2</td>
+						<td>extra data column</td>
+					</tr>
+					<tr>
+						<td>3</td>
+						<td>extra data column</td>
+					</tr>
+				</tbody>
+			</table>
+		`);
+		const oTableEl = document.getElementById('tableHeaderMismatch');
+		const testOTableHeader = document.querySelector('th:first-of-type');
+		testOTable = new OTable(oTableEl);
+		oTableEl.addEventListener('oTable.sorted', (done) => {
+			proclaim.fail(true, false, 'The table was sorted when sort should be disabled.', '===');			
+			done();
+		});
+		testOTableHeader.click();
+		done();
+	});
 });


### PR DESCRIPTION
**Part of a new major, v7, which introduces theming among other changes.**
_

**Key Updates**
-  Adds headers of headers `.o-table__multi-level-header`. Some responsive tables do not support multi level headers on mobile (scroll and flat).
- `o-table__sortable-header` is automatically added to sortable headers. This way headers are only styled when we're actually listening to click events, rather than assuming all headers are sortable.
- Only applies sort against headers where the number of headers match the number of data columns i.e. no colspan. Also only applies sort to the last `thead` row, with the assumption that any row above is for a multi level header.

**Other Changes**
- Updates docs for these changes and begins migration guide (assumes this work will be released as part of v7). Also adds missing migration guide for v4-v5.
- `[data-o-table--js]` is now `[data-o-table-js]`
- Default vertical lines removed from the desktop view of the responsive flat base variant.

**Screenshots**

👉 The style of these headers are open to change with further design feedback as part of improving theming in a later PR  _(especially the gross captions variant)_.

![screen shot 2017-10-06 at 11 10 56](https://user-images.githubusercontent.com/10405691/31274892-e78401e0-aa8c-11e7-82e6-ce0e0021baa4.png)
![screen shot 2017-10-06 at 11 50 45](https://user-images.githubusercontent.com/10405691/31274893-e78466f8-aa8c-11e7-8e2a-db775a3a19b9.png)
![screen shot 2017-10-06 at 11 52 33](https://user-images.githubusercontent.com/10405691/31274894-e7869e32-aa8c-11e7-9990-2a6c61d529f3.png)