### PR TITLE
Introduce theming to o-tables.

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,44 @@ If using __o-table__ in silent mode, use the mixin `oTableBase' in your table st
 }
 ```
 
+#### Themes
+
+Themes allow Bower and Build Service users to request `o-table` with a different look and feel. Default themes include:
+
+1. primary - The primary FT brand, which includes uses of the FT paper colour.
+2. internal - A more neutral theme useful for internal products, tooling, or tech documentation.
+
+Using themes is not required and mixins can continue to be used without setting a theme, however doing so is a quick way to customise the look and feel of `o-table`. For base styles, which outputs minimal css, leave the theme unset.
+
+##### Origami Build Service Users
+
+To set the theme modify your Origami Build Service request to include your desired theme e.g. `o-table@^6.2.1:primary`. If the theme is not set or found only base styles will be returned.
+
+##### Bower Users
+
+To use a default theme set `$o-table-theme` to the theme you would like to use, e.g. `$o-table-theme: 'primary';`. 
+
+If you are a Bower user you may also configure your own theme.
+
+```sass
+$o-table-theme: 'my-theme';
+@include oTableThemeSetTheme('my-theme', (
+	stripes: (
+		background: oColorsGetColorFor(o-table-row-primary o-table-row page, background),
+		alt-background: oColorsGetColorFor(o-table-row-alt-primary o-table-row-alt page, background)
+	)
+));
+```
+
+Now calling `@include oTableAll` will output using your theme configuration. Alternatively in [silent mode](#silent-mode) you may use your chosen theme per mixin.
+
+```sass
+.my-table {
+	$strip-config: oTableThemeGetFor($theme:$o-table-theme, $state:'stripes');
+	@include oTableRowStripes($strip-config...);
+}
+```
+
 #### Variant classes and placeholders
 
 Additional classes may be added to the table root element to also apply the following styling options. They can be combined as required.
@@ -144,9 +182,11 @@ Reduce the size of some text in a cell and display block to start a new line. Th
 
 #### Row stripes
 
-Class: `o-table--row-stripes`, Mixin: `oTableRowStripes`
+Class: `o-table--row-stripes` _(themes: primary, internal)_
 
-A background colour will be set on the whole table, and alternate rows within the `tbody` will have their background colour set to a pink tint.
+Mixin: `oTableRowStripes`
+
+A background colour will be set on the whole table, and alternate rows within the `tbody` will have their background colour set.
 
 #### Horizontal lines
 
@@ -243,6 +283,10 @@ Known issues:
 
 ### How to upgrade from v6.x.x to v7.x.x?
 
+- Themes have been introduced and should be set as needed to retain the correct look and feel, see [theme documentation](#themes).
+- The following colour usecases are renamed:
+	- `o-table-striped` is now `o-table-row-primary`.
+	- `o-table-row-alt` is now `o-table-row-alt-primary`.
 - `thead` elements must have `tr` children i.e. `thead > tr > th`.
 - The data attribute `data-o-table--js`, which is automatically set with JavaScript when the table is instantiated, is now `data-o-table-js`.
 - The default vertical lines have been removed from the flat responsive variant (`.o-table--responsive-flat` `oTableResponsiveFlat()`) but these can be reinstated if required using the vertical lines class `.o-table--vertical-lines` or mixin `oTableVerticalLines()`.

--- a/README.md
+++ b/README.md
@@ -130,18 +130,18 @@ If using __o-table__ in silent mode, use the mixin `oTableBase' in your table st
 
 Themes allow Bower and Build Service users to request `o-table` with a different look and feel. Default themes include:
 
-1. primary - The primary FT brand, which includes uses of the FT paper colour.
+1. masterbrand - The masterbrand FT brand, which includes uses of the FT paper colour.
 2. internal - A more neutral theme useful for internal products, tooling, or tech documentation.
 
 Using themes is not required and mixins can continue to be used without setting a theme, however doing so is a quick way to customise the look and feel of `o-table`. For base styles, which outputs minimal css, leave the theme unset.
 
 ##### Origami Build Service Users
 
-To set the theme modify your Origami Build Service request to include your desired theme e.g. `o-table@^6.2.1:primary`. If the theme is not set or found only base styles will be returned.
+To set the theme modify your Origami Build Service request to include your desired theme e.g. `o-table@^6.2.1:masterbrand`. If the theme is not set or found only base styles will be returned.
 
 ##### Bower Users
 
-To use a default theme set `$o-table-theme` to the theme you would like to use, e.g. `$o-table-theme: 'primary';`. 
+To use a default theme set `$o-table-theme` to the theme you would like to use, e.g. `$o-table-theme: 'masterbrand';`. 
 
 If you are a Bower user you may also configure your own theme.
 
@@ -149,8 +149,8 @@ If you are a Bower user you may also configure your own theme.
 $o-table-theme: 'my-theme';
 @include oTableThemeSetTheme('my-theme', (
 	stripes: (
-		background: oColorsGetColorFor(o-table-row-primary o-table-row page, background),
-		alt-background: oColorsGetColorFor(o-table-row-alt-primary o-table-row-alt page, background)
+		background: oColorsGetColorFor(o-table-row-masterbrand o-table-row page, background),
+		alt-background: oColorsGetColorFor(o-table-row-alt-masterbrand o-table-row-alt page, background)
 	)
 ));
 ```
@@ -182,7 +182,7 @@ Reduce the size of some text in a cell and display block to start a new line. Th
 
 #### Row stripes
 
-Class: `o-table--row-stripes` _(themes: primary, internal)_
+Class: `o-table--row-stripes` _(themes: masterbrand, internal)_
 
 Mixin: `oTableRowStripes`
 
@@ -285,8 +285,8 @@ Known issues:
 
 - Themes have been introduced and should be set as needed to retain the correct look and feel, see [theme documentation](#themes).
 - The following colour usecases are renamed:
-	- `o-table-striped` is now `o-table-row-primary`.
-	- `o-table-row-alt` is now `o-table-row-alt-primary`.
+	- `o-table-striped` is now `o-table-row-masterbrand`.
+	- `o-table-row-alt` is now `o-table-row-alt-masterbrand`.
 - `thead` elements must have `tr` children i.e. `thead > tr > th`.
 - The data attribute `data-o-table--js`, which is automatically set with JavaScript when the table is instantiated, is now `data-o-table-js`.
 - The default vertical lines have been removed from the flat responsive variant (`.o-table--responsive-flat` `oTableResponsiveFlat()`) but these can be reinstated if required using the vertical lines class `.o-table--vertical-lines` or mixin `oTableVerticalLines()`.

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Using themes is not required and mixins can continue to be used without setting 
 
 ##### Origami Build Service Users
 
-To set the theme modify your Origami Build Service request to include your desired theme e.g. `o-table@^6.2.1:masterbrand`. If the theme is not set or found only base styles will be returned.
+To set the theme modify your Origami Build Service request to include your desired theme e.g. `o-table@^7.0.0&theme=masterbrand`. If the theme is not set or found only base styles will be returned.
 
 ##### Bower Users
 

--- a/main.scss
+++ b/main.scss
@@ -1,4 +1,5 @@
 $o-table-is-silent: true !default;
+$o-table-theme: null !default;
 
 @import "o-colors/main";
 @import "o-grid/main";
@@ -6,6 +7,9 @@ $o-table-is-silent: true !default;
 @import "o-typography/main";
 
 @import "src/scss/color-use-cases";
+@import "src/scss/theme-helpers";
+@import "src/scss/themes";
+
 @import "src/scss/mixins";
 @import "src/scss/captions";
 @import "src/scss/base";

--- a/src/scss/_color-use-cases.scss
+++ b/src/scss/_color-use-cases.scss
@@ -1,9 +1,9 @@
 @include oColorsSetUseCase(o-table, background, 'transparent');
 // Row
 @include oColorsSetUseCase(o-table-row, border, 'black-20');
-@include oColorsSetUseCase(o-table-row-primary, background, 'paper')
+@include oColorsSetUseCase(o-table-row-masterbrand, background, 'paper')
 // Row alt (i.e. striped)
-@include oColorsSetUseCase(o-table-row-alt-primary, background, 'wheat');
+@include oColorsSetUseCase(o-table-row-alt-masterbrand, background, 'wheat');
 // Header
 @include oColorsSetUseCase(o-table-header-row, border, 'black-30');
 @include oColorsSetUseCase(o-table-header, color, 'black-90');

--- a/src/scss/_color-use-cases.scss
+++ b/src/scss/_color-use-cases.scss
@@ -1,8 +1,13 @@
 @include oColorsSetUseCase(o-table, background, 'transparent');
-@include oColorsSetUseCase(o-table-striped, background, 'paper');
+// Row
 @include oColorsSetUseCase(o-table-row, border, 'black-20');
-@include oColorsSetUseCase(o-table-row-alt, background, 'wheat');
+@include oColorsSetUseCase(o-table-row-primary, background, 'paper')
+// Row alt (i.e. striped)
+@include oColorsSetUseCase(o-table-row-alt-primary, background, 'wheat');
+// Header
 @include oColorsSetUseCase(o-table-header-row, border, 'black-30');
 @include oColorsSetUseCase(o-table-header, color, 'black-90');
+// Data
 @include oColorsSetUseCase(o-table-data, color, 'black-70');
+// Border
 @include oColorsSetUseCase(o-table-row-right, border-right, 'black-20');

--- a/src/scss/_deprecated.scss
+++ b/src/scss/_deprecated.scss
@@ -1,0 +1,2 @@
+@include oColorsSetUseCase(o-table-striped, _deprecated, 'paper');
+@include oColorsSetUseCase(o-table-row-alt, _deprecated, 'paper');

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -7,7 +7,7 @@
 /// Generates all styles available, with a set of modifiers for alternative styles
 ///
 /// @param {string} $classname
-@mixin oTableAll($classname: o-table) {
+@mixin oTableAll($classname: o-table, $theme: $o-table-theme) {
 	.#{$classname}-wrapper {
 		@include oTableWrapper;
 	}
@@ -33,10 +33,7 @@
 		.#{$classname}__cell--content-secondary {
 			@include oTableCellContentSecondary;
 		}
-	}
-	.#{$classname}--row-stripes {
-		@include oTableRowStripes;
-	}
+	}	
 	.#{$classname}--horizontal-lines {
 		@include oTableHorizontalLines;
 	}
@@ -60,5 +57,13 @@
 	}
 	.#{$classname}--responsive-scroll {
 		@include oTableResponsiveScroll;
+	}
+	// Only include `.o-table--row-stripes` if the theme configures it.
+	// Stripes do not make sense for a unstyled base table.
+	@if oTableThemeStateConfigured($theme, 'stripes') {
+		.#{$classname}--row-stripes {
+			$strip-config: oTableThemeGetFor($theme: $theme, $state: 'stripes');
+			@include oTableRowStripes($strip-config...);
+		}	
 	}
 }

--- a/src/scss/_row-stripes.scss
+++ b/src/scss/_row-stripes.scss
@@ -3,20 +3,31 @@
 /// @link http://registry.origami.ft.com/components/o-table
 ////
 
-/// Add this to the table element to get row stripes
-@mixin oTableRowStripes {
-
-	caption {
-		background-color: oColorsGetColorFor(o-table-striped o-table page, background);
-	}
-
+/// Table row stripes.
+///
+/// @example
+/// .my-stripy-table {
+/// 	@include oTableRowStripes($background: #fff, $alt-background: #000);
+/// }
+/// 
+/// @param {String} $color The color property for the tables main rows.
+/// @param {String} $background The background color property for the tables main rows.
+/// @param {String} $alt-color The color property for the tables alternative (even) rows.
+/// @param {String} $alt-background The background color property for the tables alternative (even) rows.
+@mixin oTableRowStripes($background, $alt-background, $color: null, $alt-color: null) {
+	caption,
 	tbody tr, 
 	thead tr:last-of-type {
-		background-color: oColorsGetColorFor(o-table-striped o-table page, background);
+		background-color: $background;
+		@if	$color {
+			color: $color;
+		}
 	}
 
 	tbody tr:nth-child(even) {
-		background-color: oColorsGetColorFor(o-table-row-alt o-table, background);
+		background-color: $alt-background;
+		@if $alt-color {
+			color: $alt-color;
+		}
 	}
-
 }

--- a/src/scss/_theme-helpers.scss
+++ b/src/scss/_theme-helpers.scss
@@ -1,0 +1,96 @@
+// These mixins are build in a component agnostic way, this is why they set 
+// a component name. To break these mixins out into a reusable theming component 
+// rename to remove table references and introduce a `$component-name` argument.
+$_o-table-themes-avalible: () !default;
+
+
+// Set a new table theme.
+//
+// @include oTableThemeSetTheme('minimal', (
+// 	stripes: (
+// 		color: black,
+// 		alt-color: white,
+// 		background: white,
+// 		alt-background: black
+// 	)
+// ));
+//
+// @param {String} $theme - The name of the theme being configured, e.g. "primary".
+// @param {Map} $theme-states - A map of theme states, a theme state is a key value map of configuration.
+@mixin oTableThemeSetTheme($theme, $theme-states) {
+	$component-name: "o-table";
+	// Get all themes for the provided component name.
+	$themes-for-component: map-get($_o-table-themes-avalible, $component-name);
+	// If no themes are yet set for this component create an empty map to contain them.
+	@if type-of($themes-for-component) != map {
+		$themes-for-component: ();
+	}
+	// Set the new states for this theme.
+	$themes-for-component: map-merge(
+		$themes-for-component,
+		($theme: (states: $theme-states))
+	);
+	// Merge the updated component themes.
+	$_o-table-themes-avalible: map-merge(
+		$_o-table-themes-avalible,
+		($component-name: $themes-for-component)
+	) !global;
+}
+
+// Get table theme configuration for a given state.
+//
+// @include oTableThemeGetFor('minimal', 'stripes');
+//
+// @param {String} $theme - The name of the theme to retrieve a state for, e.g. "primary".
+// @param {String} $state - The state (i.e. specific portion of theme configuration) to return.
+// @return {Map|null}
+@function oTableThemeGetFor($theme, $state) {
+	$component-name: "o-table";
+	// If no theme is requested return no state config.
+	@if $theme == null {
+		@return null;
+	}
+	// Get all themes for the provided component name.
+	$themes-for-component: map-get($_o-table-themes-avalible, $component-name);
+	// Error if the theme is not set for this component.
+	@if type-of($themes-for-component) != map or not map-has-key($themes-for-component, $theme) {
+		@error "No theme '#{$theme}' is set for the component #{$component-name}.";
+	}
+	// Get the theme states.
+	$theme-states: map-get($themes-for-component, $theme);
+	$theme-states: map-get($theme-states, 'states');
+	@if type-of($theme-states) != map or not map-has-key($theme-states, $state) {
+		@error "Could not get '#{$state}' configuration for the #{$component-name} #{$theme} theme.";
+	}
+
+	@return map-get($theme-states, $state);
+}
+
+// Check for the existence of theme configuration for a given state.
+//
+// @include oTableThemeStateConfigured('minimal', 'stripes');
+//
+// @param {String} $theme - The name of the theme to retrieve a state for, e.g. "primary".
+// @param {String} $state - The state (i.e. specific portion of theme configuration) to check exists.
+// @return {Boolean}
+@function oTableThemeStateConfigured($theme, $state) {
+	$component-name: "o-table";
+	// If no theme is requested the state cannot be set.
+	@if $theme == null {
+		@return false;
+	}
+	// Get all themes for the provided component name.
+	$themes-for-component: map-get($_o-table-themes-avalible, $component-name);
+	// If the theme is not set for this component no state can be configured.
+	@if type-of($themes-for-component) != map or not map-has-key($themes-for-component, $theme) {
+		@return false;
+	}
+	// Attempt to find the theme state.
+	$theme-states: map-get($themes-for-component, $theme);
+	$theme-states: map-get($theme-states, 'states');
+	@if type-of($theme-states) != map or not map-has-key($theme-states, $state) {
+		@return false;
+	}
+
+	@return true;
+}

--- a/src/scss/_theme-helpers.scss
+++ b/src/scss/_theme-helpers.scss
@@ -15,7 +15,7 @@ $_o-table-themes-avalible: () !default;
 // 	)
 // ));
 //
-// @param {String} $theme - The name of the theme being configured, e.g. "primary".
+// @param {String} $theme - The name of the theme being configured, e.g. "masterbrand".
 // @param {Map} $theme-states - A map of theme states, a theme state is a key value map of configuration.
 @mixin oTableThemeSetTheme($theme, $theme-states) {
 	$component-name: "o-table";
@@ -41,7 +41,7 @@ $_o-table-themes-avalible: () !default;
 //
 // @include oTableThemeGetFor('minimal', 'stripes');
 //
-// @param {String} $theme - The name of the theme to retrieve a state for, e.g. "primary".
+// @param {String} $theme - The name of the theme to retrieve a state for, e.g. "masterbrand".
 // @param {String} $state - The state (i.e. specific portion of theme configuration) to return.
 // @return {Map|null}
 @function oTableThemeGetFor($theme, $state) {
@@ -70,7 +70,7 @@ $_o-table-themes-avalible: () !default;
 //
 // @include oTableThemeStateConfigured('minimal', 'stripes');
 //
-// @param {String} $theme - The name of the theme to retrieve a state for, e.g. "primary".
+// @param {String} $theme - The name of the theme to retrieve a state for, e.g. "masterbrand".
 // @param {String} $state - The state (i.e. specific portion of theme configuration) to check exists.
 // @return {Boolean}
 @function oTableThemeStateConfigured($theme, $state) {

--- a/src/scss/_themes.scss
+++ b/src/scss/_themes.scss
@@ -1,0 +1,14 @@
+@include oTableThemeSetTheme('primary', (
+	stripes: (
+		background: oColorsGetColorFor(o-table-row-primary, background),
+		alt-background: oColorsGetColorFor(o-table-row-alt-primary, background)
+	)
+));
+
+@include oTableThemeSetTheme('internal', (
+	stripes: (
+		background: transparent,
+		alt-background: oColorsMix(black, white, 5)
+	)
+));
+

--- a/src/scss/_themes.scss
+++ b/src/scss/_themes.scss
@@ -1,7 +1,7 @@
-@include oTableThemeSetTheme('primary', (
+@include oTableThemeSetTheme('masterbrand', (
 	stripes: (
-		background: oColorsGetColorFor(o-table-row-primary, background),
-		alt-background: oColorsGetColorFor(o-table-row-alt-primary, background)
+		background: oColorsGetColorFor(o-table-row-masterbrand, background),
+		alt-background: oColorsGetColorFor(o-table-row-alt-masterbrand, background)
 	)
 ));
 


### PR DESCRIPTION
**Part of a new major, v7, which introduces theming among other changes.**

Introduces the concept of theming to `o-tables` using "a configuring theme map". Hopefully the readme is clear, I have copied it to the PR description.

More details here: https://docs.google.com/document/d/13W760HeCkFP2Lf_P2bE21pLHbY2-9JBlCH9A5aperFU/edit#heading=h.2z5pggur81m

## Todo: Build Service

The build service will need to accept a theme name parameter for this approach. I have suggested in the README that this would look like `o-table@^7.0.0&theme=masterbrand` ~`o-table@^6.2.1:primary` but this was thrown in at a whim, I'm not even sure it's legal~. We should discuss.

## Todo: Demos & Registry

Currently the demos only display base styles and do not include themes, they are therefore not very useful and quite confusing. If the build service were to support theming we could update `o-table` demos to be theme specific quite easily, otherwise we would have to configure the themes in demo css.

A better longer-term approach might be to assign demos to themes in `origami.json` and allow users to filter/tab through demos per theme in the registry. Perhaps this is something for next year?

## The `o-table` Theme Readme

Themes allow Bower and Build Service users to request `o-table` with a different look and feel. Default themes include:

1. primary - The primary FT brand, which includes uses of the FT paper colour.
2. internal - A more neutral theme useful for internal products, tooling, or tech documentation.

Using themes is not required and mixins can continue to be used without setting a theme, however doing so is a quick way to customise the look and feel of `o-table`. For base styles, which outputs minimal css, leave the theme unset.

### Origami Build Service Users

To set the theme modify your Origami Build Service request to include your desired theme e.g. `o-table@^7.0.0&theme=masterbrand`. If the theme is not set or found only base styles will be returned.

### Bower Users

To use a default theme set `$o-table-theme` to the theme you would like to use, e.g. `$o-table-theme: 'primary';`. 

If you are a Bower user you may also configure your own theme.

```sass
$o-table-theme: 'my-theme';
@include oTableThemeSetTheme('my-theme', (
	stripes: (
		background: oColorsGetColorFor(o-table-row-primary o-table-row page, background),
		alt-background: oColorsGetColorFor(o-table-row-alt-primary o-table-row-alt page, background)
	)
));
```

Now calling `@include oTableAll` will output using your theme configuration. Alternatively in [silent mode](#silent-mode) you may use your chosen theme per mixin.

```sass
.my-table {
	$strip-config: oTableThemeGetFor($theme:$o-table-theme, $state:'stripes');
	@include oTableRowStripes($strip-config...);
}
```