### PR TITLE
Add sort affordance and multi-level heading mixins.

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,9 +284,10 @@ Known issues:
 ### How to upgrade from v6.x.x to v7.x.x?
 
 - Themes have been introduced and should be set as needed to retain the correct look and feel, see [theme documentation](#themes).
-- The following colour usecases are renamed:
+- The following colour usecases must be updated:
 	- `o-table-striped` is now `o-table-row-primary`.
 	- `o-table-row-alt` is now `o-table-row-alt-primary`.
+	- `o-table-row-right` has been removed, `o-table-row` is a suitable alternative.
 - `thead` elements must have `tr` children i.e. `thead > tr > th`.
 - The data attribute `data-o-table--js`, which is automatically set with JavaScript when the table is instantiated, is now `data-o-table-js`.
 - The default vertical lines have been removed from the flat responsive variant (`.o-table--responsive-flat` `oTableResponsiveFlat()`) but these can be reinstated if required using the vertical lines class `.o-table--vertical-lines` or mixin `oTableVerticalLines()`.

--- a/main.scss
+++ b/main.scss
@@ -21,6 +21,7 @@ $o-table-theme: null !default;
 @import "src/scss/row-stripes";
 @import "src/scss/lines";
 @import "src/scss/borders";
+@import "src/scss/sort";
 
 @import "src/scss/deprecated";
 

--- a/src/scss/_base.scss
+++ b/src/scss/_base.scss
@@ -12,6 +12,10 @@
 	margin: 0 0 20px;
 	width: 100%;
 
+	&[data-o-table-js] &__sortable-header {
+		@include oTableSortable;
+	}
+
 	caption {
 		margin: 0;
 		padding: 0;
@@ -21,34 +25,6 @@
 	th {
 		@include oTypographySansBold(1);
 		@include oColorsFor(o-table-header, color);
-	}
-
-	&[data-o-table-js] &__sortable-header {
-		cursor: pointer;
-		user-select: none;
-		padding-right: 20px;
-		&:after {
-			@include oIconsGetIcon('arrows-up-down', $container-width: 20,  $container-height: 20, $iconset-version: 1);
-			content: '';
-			margin-right: -20px;
-			vertical-align: top;
-		}
-		// Show descending icon with DSC sort applied.
-		&[aria-sort='descending'] {
-			&:after {
-				@include oIconsGetIcon('arrow-down', $container-width: 20,  $container-height: 20, $iconset-version: 1);
-				vertical-align: top;
-			}
-		}
-		// Show ascending icon with ASC sort applied or on hover with no sort.
-		&[aria-sort='none']:hover,
-		&:not([aria-sort]):hover,
-		&[aria-sort='ascending'] {
-			&:after {
-				@include oIconsGetIcon('arrow-up', $container-width: 20,  $container-height: 20, $iconset-version: 1);
-				vertical-align: top;
-			}
-		}
 	}
 
 	td {
@@ -69,8 +45,7 @@
 	}
 
 	th#{&}__multi-level-header {
-		border-bottom: 3px solid oColorsGetColorFor(o-table-data, color);
-		text-align: center;
+		@include oTableMultiLevelHeader;
 	}
 
 	th:not([scope=row]) {

--- a/src/scss/_cells.scss
+++ b/src/scss/_cells.scss
@@ -13,3 +13,9 @@
 	@include oTypographySans(0);
 	font-weight: normal;
 }
+
+/// Visually differentiate a header of table headers.
+@mixin oTableMultiLevelHeader {
+	border-bottom: 3px solid oColorsGetColorFor(o-table-data, color);
+	text-align: center;
+}

--- a/src/scss/_color-use-cases.scss
+++ b/src/scss/_color-use-cases.scss
@@ -9,5 +9,3 @@
 @include oColorsSetUseCase(o-table-header, color, 'black-90');
 // Data
 @include oColorsSetUseCase(o-table-data, color, 'black-70');
-// Border
-@include oColorsSetUseCase(o-table-row-right, border-right, 'black-20');

--- a/src/scss/_deprecated.scss
+++ b/src/scss/_deprecated.scss
@@ -1,2 +1,3 @@
 @include oColorsSetUseCase(o-table-striped, _deprecated, 'paper');
 @include oColorsSetUseCase(o-table-row-alt, _deprecated, 'paper');
+@include oColorsSetUseCase(o-table-row-right, _deprecated, 'black-20');

--- a/src/scss/_responsive-flat.scss
+++ b/src/scss/_responsive-flat.scss
@@ -53,7 +53,7 @@
 	} // tr
 
 	tbody tr th {
-		border-right: 1px solid oColorsGetColorFor(o-table-row-right, border-right);
+		border-right: 1px solid oColorsGetColorFor(o-table-row, border);
 		float: left;
 		padding: 8px;
 		width: 50%;

--- a/src/scss/_sort.scss
+++ b/src/scss/_sort.scss
@@ -1,0 +1,27 @@
+@mixin oTableSortable {
+	cursor: pointer;
+	user-select: none;
+	padding-right: 20px;
+	&:after {
+		@include oIconsGetIcon('arrows-up-down', $container-width: 20,  $container-height: 20, $iconset-version: 1);
+		content: '';
+		margin-right: -20px;
+		vertical-align: top;
+	}
+	// Show descending icon with DSC sort applied.
+	&[aria-sort='descending'] {
+		&:after {
+			@include oIconsGetIcon('arrow-down', $container-width: 20,  $container-height: 20, $iconset-version: 1);
+			vertical-align: top;
+		}
+	}
+	// Show ascending icon with ASC sort applied or on hover with no sort.
+	&[aria-sort='none']:hover,
+	&:not([aria-sort]):hover,
+	&[aria-sort='ascending'] {
+		&:after {
+			@include oIconsGetIcon('arrow-up', $container-width: 20,  $container-height: 20, $iconset-version: 1);
+			vertical-align: top;
+		}
+	}
+}


### PR DESCRIPTION
**Part of a new major, v7, which introduces theming among other changes.**

New mixins:
 - oTableSortable
 - oTableMultiLevelHeader

This also removes an unnecessary colour usecase `o-table-row-right`.

No styles are changed.