### PR TITLE
Add the ability to disable sort on individual columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Styling for tables.
 Add an `o-table` class to any table you wish to apply the styles to:
 
 ```html
-<table class="o-table">
+<table class="o-table" data-o-component="o-table">
 	...
 </table>
 ```
@@ -26,7 +26,7 @@ Add an `o-table` class to any table you wish to apply the styles to:
 Where a `td` contains numeric data, or a `th` is for cells containing numeric data, also add the class `.o-table__cell--numeric` and a `data-o-table-data-type="numeric"` attribute (the latter allows the column to be sorted correctly):
 
 ```html
-<table class="o-table">
+<table class="o-table" data-o-component="o-table">
 	<tr>
 		<th>Index</th>
 		<th data-o-table-data-type="numeric" class="o-table__cell--numeric">Value</th>
@@ -42,7 +42,7 @@ Where a `td` contains numeric data, or a `th` is for cells containing numeric da
 Where table headings (`th`) are used as row headings, `scope="row"` attributes must be set on the `th`:
 
 ```html
-<table class="o-table">
+<table class="o-table" data-o-component="o-table">
 	<tr>
 		<th scope="row">FTSE 100</th>
 		<td data-o-table-data-type="numeric" class="o-table__cell--numeric">6685.52</td>
@@ -54,7 +54,7 @@ Where table headings (`th`) are used as row headings, `scope="row"` attributes m
 When they're are not present, browsers will implicitly wrap table contents in `tbody` tags, including the header row. It is therefore advisable (and when row-stripes are required, essential) to use `thead`, `tbody` (and if appropriate, `tfoot`) tags in your markup:
 
 ```html
-<table class="o-table">
+<table class="o-table" data-o-component="o-table">
 	<thead>
 		<tr>
 			<th>Index</th>
@@ -71,13 +71,39 @@ When they're are not present, browsers will implicitly wrap table contents in `t
 </table>
 ```
 
+#### Disable sort on one or more columns
+
+Adding `data-o-table-heading-disable-sort` to a table column heading with disable and hide the sort interface on that column heading. This is useful for columns of a table which do not provide sortable data, such as an edit button related to the data in its row.
+
+```html
+<table class="o-table" data-o-component="o-table">
+	<thead>
+		<tr>
+			<th>Heading One</th>
+			<th>Heading Two</th>
+			<!-- do not show the actions column as sortable -->
+			<th data-o-table-heading-disable-sort>Actions</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>Item One</td>
+			<td>Item Two</td>
+			<td>
+				<a href="#edit">edit</a>
+			</td>
+		</tr>
+	</tbody>
+</table>
+```
+
 #### Small screen rendering
 
 Where there is not enough horizontal space for a table to fit, it can be made horizontally scrollable by wrapping it in an element with a class of `o-table-wrapper`:
 
 ```html
 <div class="o-table-wrapper">
-	<table class="o-table">
+	<table class="o-table" data-o-component="o-table">
 		...
 	</table>
 </div>

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ When they're are not present, browsers will implicitly wrap table contents in `t
 
 #### Disable sort on one or more columns
 
-Adding `data-o-table-heading-disable-sort` to a table column heading with disable and hide the sort interface on that column heading. This is useful for columns of a table which do not provide sortable data, such as an edit button related to the data in its row.
+Adding `data-o-table-heading-disable-sort` to a table column heading will disable and hide the sort interface on that column heading. This is useful for columns of a table which do not provide sortable data, such as an edit button related to the data in its row.
 
 ```html
 <table class="o-table" data-o-component="o-table">

--- a/src/js/oTable.js
+++ b/src/js/oTable.js
@@ -25,6 +25,11 @@ function OTable(rootEl) {
 		const tableRows = Array.from(this.rootEl.getElementsByTagName('tr'));
 
 		this.tableHeaders.forEach((th, columnIndex) => {
+			// Do not sort headers with attribute.
+			if (th.hasAttribute('data-o-table-heading-disable-sort')) {
+				return false;
+			}
+
 			th.setAttribute('tabindex', "0");
 
 			const listener = this._sortByColumn(columnIndex);

--- a/src/scss/_base.scss
+++ b/src/scss/_base.scss
@@ -23,7 +23,7 @@
 		@include oColorsFor(o-table-header, color);
 	}
 
-	&[data-o-table--js] thead th {
+	&[data-o-table--js] thead th:not([data-o-table-heading-disable-sort]) {
 		cursor: pointer;
 		user-select: none;
 		padding-right: 20px;

--- a/test/oTableSort.test.js
+++ b/test/oTableSort.test.js
@@ -58,6 +58,40 @@ describe('oTable sorting', () => {
 		});
 	});
 
+	it('does not sort if the heading has an attribute specifying not to', done => {
+		sandbox.reset();
+		sandbox.init();
+		sandbox.setContents(`
+			<table class="o-table" data-o-component="o-table">
+				<thead>
+					<th data-o-table-heading-disable-sort>Things</th>
+				</thead>
+				<tbody>
+					<tr>
+						<td>a</td>
+					</tr>
+					<tr>
+						<td>c</td>
+					</tr>
+					<tr>
+						<td>b</td>
+					</tr>
+				</tbody>
+			</table>
+		`);
+		oTableEl = document.querySelector('[data-o-component=o-table]');
+		testOTable = new OTable(oTableEl);
+		const click = document.createEvent("MouseEvent");
+		click.initMouseEvent("click", true, true, window,
+			0, 0, 0, 0, 0, false, false, false, false, 0, null);
+		oTableEl.querySelector('thead th[data-o-table-heading-disable-sort]').dispatchEvent(click);
+		setTimeout(() => {
+			const rows = oTableEl.querySelectorAll('tbody tr td');
+			proclaim.equal(rows[1].textContent, 'c', 'The table column sorted with a click when sort was disabled for its header.');
+			done();
+		}, 100);
+	});
+
 	it('adds a sort order data attribute to the root element of the component', done => {
 		testOTable = new OTable(oTableEl);
 		// TODO - Add a click polyfill to polyfill-service


### PR DESCRIPTION
Add `data-o-table-heading-disable-sort` to a column heading to disable sort on that column heading. The sort interface will not display on that heading and it will not be clickable.

Addresses: https://github.com/Financial-Times/o-table/issues/80