### PR TITLE
Add events to enable the interception of sort for a custom implementation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,64 @@ If you are wanting to sort by a custom pattern, you can apply the sorting values
 </table>
 ```
 
+#### Events
+
+The following events are fired by `o-table`.
+
+- `oTable.ready`
+- `oTable.sorting`
+- `oTable.sorted`
+
+##### oTable.sorted
+
+`oTable.sorted` indicates a table has finished sorting. It includes details of the current sort status of the table.
+
+The event provides the following properties:
+- `detail.sort` - The sort e.g. "ASC" _(String)_.
+- `detail.columnIndex` - The index of the sorted column heading _(Number)_.
+- `detail.oTable` - The effected `o-table` instance _(oTable)_.
+
+```js
+document.addEventListener('oTable.sorted', (event) => {
+	console.log(`The target table was just sorted by column ${event.detail.columnIndex} in an ${event.detail.sort} order.`);
+});
+```
+
+##### oTable.sorting
+
+This event is fired just before a table sorts based on user interaction. It may be prevented to implement custom sort functionality. This may be useful to sort a paginated table server-side.
+
+The event provides the following properties:
+- `detail.sort` - The sort requested e.g. "ASC" _(String)_.
+- `detail.columnIndex` - The index of the column heading which will be sorted _(Number)_.
+- `detail.oTable` - The effected `o-table` instance _(oTable)_.
+
+When intercepting the default sort the `sorted` method must be called with relevant parameters when the custom sort is completed.
+
+```js
+document.addEventListener('oTable.sorting', (event) => {
+	// Prevent default sorting.
+	event.preventDefault();
+	// Update the table with a custom sort.
+	console.log(`Update the table with sorted data here.`);
+	// Fire the sorted event, passing along the column index and sort.
+	event.detail.instance.sorted(event.detail.columnIndex, event.detail.sort);
+});
+```
+
+###### Get The Sorted Column Heading From A Sort Event
+
+`o-table` sort events provide a `columnIndex`. This index maps to a column heading. To retrieve the column heading use `getTableHeader`.
+
+```js
+document.addEventListener('oTable.sorting', (event) => {
+	const table = event.detail.oTable;
+	const columnIndex = event.detail.columnIndex;
+	// Get the table header from the column index.
+	console.log(table.getTableHeader(columnIndex));
+});
+```
+
 ## Troubleshooting
 
 Known issues:

--- a/README.md
+++ b/README.md
@@ -249,6 +249,13 @@ The following events are fired by `o-table`.
 - `oTable.sorting`
 - `oTable.sorted`
 
+##### oTable.ready
+
+`oTable.ready` fires when the table has been initialised.
+
+The event provides the following properties:
+- `detail.oTable` - The initialised `o-table` instance _(oTable)_.
+
 ##### oTable.sorted
 
 `oTable.sorted` indicates a table has finished sorting. It includes details of the current sort status of the table.
@@ -282,7 +289,7 @@ document.addEventListener('oTable.sorting', (event) => {
 	// Update the table with a custom sort.
 	console.log(`Update the table with sorted data here.`);
 	// Fire the sorted event, passing along the column index and sort.
-	event.detail.instance.sorted(event.detail.columnIndex, event.detail.sort);
+	event.detail.oTable.sorted(event.detail.columnIndex, event.detail.sort);
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ document.addEventListener('oTable.sorting', (event) => {
 });
 ```
 
-###### Get The Sorted Column Heading From A Sort Event
+##### Get The Sorted Column Heading From A Sort Event
 
 `o-table` sort events provide a `columnIndex`. This index maps to a column heading. To retrieve the column heading use `getTableHeader`.
 

--- a/src/js/oTable.js
+++ b/src/js/oTable.js
@@ -261,7 +261,6 @@ OTable.prototype._sortByColumn = function _sortByColumn(columnIndex) {
 		 * which handled this event called Event.preventDefault(). Otherwise it returns true.
 		 * https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/dispatchEvent
 		 */
-		const heading = this.getTableHeader(columnIndex);
 		const customSort = !event.currentTarget.dispatchEvent(new CustomEvent('oTable.sorting', {
 			detail: {
 				sort,

--- a/test/oTable.test.js
+++ b/test/oTable.test.js
@@ -347,6 +347,7 @@ describe('Destroying an oTable instance', () => {
 
 describe("getTableHeader()", () => {
 	let oTableEl;
+	let testOTable;
 
 	beforeEach(() => {
 		sandbox.init();

--- a/test/oTable.test.js
+++ b/test/oTable.test.js
@@ -344,3 +344,53 @@ describe('Destroying an oTable instance', () => {
 		proclaim.isFalse(oTableEl.hasAttribute('data-o-table--js'));
 	});
 });
+
+describe("getTableHeader()", () => {
+	let oTableEl;
+
+	beforeEach(() => {
+		sandbox.init();
+		sandbox.setContents(`
+			<table class="o-table" data-o-component="o-table">
+				<thead>
+					<th id="firstHeader">Cheese</th>
+					<th id="secondHeader">Letter</th>
+				</thead>
+				<tbody>
+					<tr>
+						<td>cheddar</td>
+						<td>a</td>
+					</tr>
+					<tr>
+						<td>stilton</td>
+						<td>b</td>
+					</tr>
+					<tr>
+						<td>red leicester</td>
+						<td>c</td>
+					</tr>
+				</tbody>
+			</table>
+		`);
+		oTableEl = document.querySelector('[data-o-component=o-table]');
+		testOTable = new OTable(oTableEl);
+	});
+
+	afterEach(() => {
+		sandbox.reset();
+	});
+
+	it('gets the first header for a column index of "0"', () => {
+		const columnIndex = 0;
+		const actual = testOTable.getTableHeader(columnIndex);
+		const expected = document.getElementById('firstHeader');
+		proclaim.equal(actual, expected);
+	});
+
+	it('gets the first header for a column index of "1"', () => {
+		const columnIndex = 1;
+		const actual = testOTable.getTableHeader(columnIndex);
+		const expected = document.getElementById('secondHeader');
+		proclaim.equal(actual, expected);
+	});
+});

--- a/test/oTableSort.test.js
+++ b/test/oTableSort.test.js
@@ -360,7 +360,7 @@ describe('oTable sorting', () => {
 		});
 	});
 
-	it.only('can be intercepted for a custom sort implementation', done => {
+	it('can be intercepted for a custom sort implementation', done => {
 		sandbox.reset();
 		sandbox.init();
 		sandbox.setContents(`
@@ -406,6 +406,62 @@ describe('oTable sorting', () => {
 			}, 0);
 		});
 		click('thead th');
+	});
+
+	it('can update sort attributes independently', () => {
+		sandbox.reset();
+		sandbox.init();
+		sandbox.setContents(`
+			<table class="o-table" data-o-component="o-table">
+				<thead>
+					<tr>
+						<th>Things</th>
+						<th>Other Things</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<th data-o-table-order="c">snowman</th>
+						<th data-o-table-order="c">snowman</th>
+					</tr>
+					<tr>
+						<th data-o-table-order="a">42</th>
+						<th data-o-table-order="a">42</th>
+					</tr>
+					<tr>
+						<th data-o-table-order="b">pangea</th>
+						<th data-o-table-order="b">pangea</th>
+					</tr>
+				</tbody>
+			</table>
+		`);
+		oTableEl = document.querySelector('[data-o-component=o-table]');
+		testOTable = new OTable(oTableEl);
+		const oTableElHeaders = Array.from(oTableEl.querySelectorAll('thead th'));
+
+		[{
+			sortedHeaderIndex: 0,
+			sort: 'ASC',
+			expectedAriaValue: 'ascending'
+		}, {
+			sortedHeaderIndex: 1,
+			sort: 'DESC',
+			expectedAriaValue: 'descending'
+		}, {
+			sortedHeaderIndex: null,
+			sort: null,
+			expectedAriaValue: 'none'
+		}, {
+			sortedHeaderIndex: 0,
+			sort: null,
+			expectedAriaValue: 'none'
+		}].forEach(data => {
+			const sortedHeaderIndex = data.sortedHeaderIndex || 0;
+			const otherHeaderIndex = 1 - sortedHeaderIndex;
+			testOTable.updateSortAttributes(sortedHeaderIndex, data.sort);
+			proclaim.equal(oTableElHeaders[sortedHeaderIndex].getAttribute('aria-sort'), data.expectedAriaValue);
+			proclaim.equal(oTableElHeaders[otherHeaderIndex].getAttribute('aria-sort'), 'none');
+		});
 	});
 
 });

--- a/test/oTableSort.test.js
+++ b/test/oTableSort.test.js
@@ -1,5 +1,6 @@
 /* eslint-env mocha, proclaim */
 import proclaim from 'proclaim';
+import sinon from 'sinon/pkg/sinon';
 
 import * as sandbox from './helpers/sandbox';
 import OTable from './../main';

--- a/test/oTableSort.test.js
+++ b/test/oTableSort.test.js
@@ -457,14 +457,14 @@ describe('oTable sorting', () => {
 			proclaim.equal(oTableElHeaders[sortedHeaderIndex].getAttribute('aria-sort'), expectedAriaValue);
 			proclaim.equal(oTableElHeaders[otherHeaderIndex].getAttribute('aria-sort'), 'none');
 			done();
-		}
+		};
 
 		it('by the first column, ASC', (done) => {
 			const sortedHeaderIndex = 0;
 			const otherHeaderIndex = 1;
 			const sort = 'ASC';
 			const expectedAriaValue = 'ascending';
-			oTableEl.addEventListener('oTable.sorted', (e) => {
+			oTableEl.addEventListener('oTable.sorted', () => {
 				checkExpectations(sortedHeaderIndex, otherHeaderIndex, expectedAriaValue, done);
 			});
 			testOTable.sorted(sortedHeaderIndex, sort);
@@ -475,7 +475,7 @@ describe('oTable sorting', () => {
 			const otherHeaderIndex = 0;
 			const sort = 'DES';
 			const expectedAriaValue = 'descending';
-			oTableEl.addEventListener('oTable.sorted', (e) => {
+			oTableEl.addEventListener('oTable.sorted', () => {
 				checkExpectations(sortedHeaderIndex, otherHeaderIndex, expectedAriaValue, done);
 			});
 			testOTable.sorted(sortedHeaderIndex, sort);
@@ -486,7 +486,7 @@ describe('oTable sorting', () => {
 			const otherHeaderIndex = 1;
 			const sort = null;
 			const expectedAriaValue = 'none';
-			oTableEl.addEventListener('oTable.sorted', (e) => {
+			oTableEl.addEventListener('oTable.sorted', () => {
 				checkExpectations(sortedHeaderIndex, otherHeaderIndex, expectedAriaValue, done);
 			});
 			testOTable.sorted(sortedHeaderIndex, sort);
@@ -497,7 +497,7 @@ describe('oTable sorting', () => {
 			const otherHeaderIndex = 1;
 			const sort = null;
 			const expectedAriaValue = 'none';
-			oTableEl.addEventListener('oTable.sorted', (e) => {
+			oTableEl.addEventListener('oTable.sorted', () => {
 				checkExpectations(sortedHeaderIndex, otherHeaderIndex, expectedAriaValue, done);
 			});
 			testOTable.sorted(sortedHeaderIndex, sort);


### PR DESCRIPTION
Addresses: https://github.com/Financial-Times/o-table/issues/86

**Update:** This PR overview lies, see the updated readme.

**Adds the following prototype methods:**

- `sorted(columnIndex, sort)`
- `updateSortAttributes(columnIndex, sort)`

The `sorted` method  enables a consumer to fire the sorted event after they have successfully updated the table with new, sorted data.

The `updateSortAttributes` method provides a consumer the ability to update aria attributes independently. This could be useful if a sort has failed after having updated attributes for immediate visual feedback.

**Updated events:**

- Fires a new event `oTable.sorting` to indicate the table is about to be sorted. This includes the `sort` (e.g. "ASC"), `columnIndex` (e.g. "0"), and `instance` (of `oTable`). This event can be intercepted to implement a custom sort mechanism.
```
event.currentTarget.dispatchEvent(new CustomEvent('oTable.sorting', {
	detail: {
		sort,
		columnIndex,
		instance: this
	},
	bubbles: true,
	cancelable: true
}));
```

- Adds data `sort` (ASC) and`columnIndex` (0) to the `oTable.sorted` event.