### PR TITLE
2 column tables for internal brand

### DIFF
--- a/demos/src/row-headings.mustache
+++ b/demos/src/row-headings.mustache
@@ -2,9 +2,11 @@
 	<tr>
 		<th>Item</th>
 		<td>Holiday</td>
+		<td>Lunch</td>
 	</tr>
 	<tr>
 		<th>Cost</th>
-		<td data-o-table-data-type="numeric" class="o-table__cell--numeric">£123.45</td>
+		<td data-o-table-data-type="numeric">£123.45</td>
+		<td data-o-table-data-type="numeric">£7</td>
 	</tr>
 </table>

--- a/demos/src/row-headings.mustache
+++ b/demos/src/row-headings.mustache
@@ -1,0 +1,10 @@
+<table class="o-table o-table--row-headings" data-o-component="o-table">
+	<tr>
+		<th>Item</th>
+		<td>Holiday</td>
+	</tr>
+	<tr>
+		<th>Cost</th>
+		<td data-o-table-data-type="numeric" class="o-table__cell--numeric">£123.45</td>
+	</tr>
+</table>

--- a/main.scss
+++ b/main.scss
@@ -1,4 +1,5 @@
 $o-table-is-silent: true !default;
+
 // Dependancies
 @import "o-brand/main";
 @import "o-colors/main";
@@ -19,6 +20,7 @@ $o-table-is-silent: true !default;
 @import "src/scss/row-stripes";
 @import "src/scss/lines";
 @import "src/scss/borders";
+@import "src/scss/row-headings";
 
 @import "src/scss/deprecated";
 

--- a/origami.json
+++ b/origami.json
@@ -61,6 +61,7 @@
 		{
 			"title": "Row headings",
 			"name": "row-headings",
+			"brands": ["internal"],
 			"template": "demos/src/row-headings.mustache",
 			"description": ""
 		},

--- a/origami.json
+++ b/origami.json
@@ -59,6 +59,12 @@
 			"description": ""
 		},
 		{
+			"title": "Row headings",
+			"name": "row-headings",
+			"template": "demos/src/row-headings.mustache",
+			"description": ""
+		},
+		{
 			"title": "Responsive Flat",
 			"name": "responsive-flat",
 			"template": "demos/src/responsive-flat.mustache",

--- a/src/scss/_brand.scss
+++ b/src/scss/_brand.scss
@@ -13,7 +13,7 @@
 @include oBrandDefine('o-table', 'master', (
 	'variables': (
 		table-background: oColorsGetPaletteColor('paper'),
-		table-stripe-background: oColorsGetPaletteColor('wheat'),
+		table-alternate-background: oColorsGetPaletteColor('wheat'),
 		table-header-color: oColorsGetPaletteColor('black-90'),
 		table-border-color: oColorsGetPaletteColor('black-20'),
 		table-caption-border-color: oColorsGetPaletteColor('black-30'),
@@ -28,8 +28,7 @@
 @include oBrandDefine('o-table', 'internal', (
 	'variables': (
 		table-background: oColorsGetPaletteColor('white'),
-		table-stripe-background: oColorsGetPaletteColor('slate-white-5'),
-		table-row-heading-background: oColorsGetPaletteColor('slate-white-5'),
+		table-alternate-background: oColorsGetPaletteColor('slate-white-5'),
 		table-header-color: oColorsGetPaletteColor('black-90'),
 		table-border-color: oColorsGetPaletteColor('black-20'),
 		table-caption-border-color: oColorsGetPaletteColor('black-30'),

--- a/src/scss/_brand.scss
+++ b/src/scss/_brand.scss
@@ -17,6 +17,7 @@
 	'variables': (
 		table-background: oColorsGetPaletteColor('white'),
 		table-stripe-background: oColorsGetPaletteColor('slate-white-5'),
+		table-row-heading-background: oColorsGetPaletteColor('slate-white-5'),
 		table-header-color: oColorsGetPaletteColor('black-90'),
 		table-border-color: oColorsGetPaletteColor('black-20'),
 		table-caption-border-color: oColorsGetPaletteColor('black-30'),
@@ -24,7 +25,8 @@
 	),
 	'settings': (
 		'stripe': true,
-		'compact': true
+		'compact': true,
+		'row-headings': true
 	)
 ));
 

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -58,7 +58,7 @@
 
 	@if _oTableSupports('row-headings') {
 		.#{$classname}--row-headings {
-			@include _oTableRowHeadings;
+			@include oTableRowHeadings;
 		}
 	}
 

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -56,6 +56,12 @@
 		@include oTableResponsiveScroll;
 	}
 
+	@if _oTableSupports('row-headings') {
+		.#{$classname}--row-headings {
+			@include _oTableRowHeadings;
+		}
+	}
+
 	@if _oTableSupports('compact') {
 		.#{$classname}--compact {
 			@include oTableCompact;

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -56,6 +56,12 @@
 		@include oTableResponsiveScroll;
 	}
 
+	@include oBrandConfigureFor('o-table', 'row-headings') {
+		.#{$classname}--row-headings {
+			@include _oTableRowHeadings;
+		}
+	}
+
 	@include oBrandConfigureFor('o-table', 'compact') {
 		.#{$classname}--compact {
 			@include oTableCompact;

--- a/src/scss/_row-headings.scss
+++ b/src/scss/_row-headings.scss
@@ -5,12 +5,8 @@
 
 //// @access private
 //// @outputs Highlights table headings.
-@mixin oTableRowHeadings() {
-	@include oBrandConfigureFor($component: 'o-table', $variant: 'row-headings') {
-		background-color: oBrandGet('table-background');
-
-		tbody th {
-			background-color: oBrandGet('table-row-heading-background');
-		}
+@mixin _oTableRowHeadings() {
+	tbody th {
+		background-color: _oTableGet('table-alternate-background');
 	}
 }

--- a/src/scss/_row-headings.scss
+++ b/src/scss/_row-headings.scss
@@ -5,7 +5,7 @@
 
 /// Add this to the table element to get row stripes
 @mixin oTableRowStripes() {
-	@include oBrandConfigureFor('o-table--row-headings') {
+	@include oBrandConfigureFor($component: 'o-table', $variant: 'row-headings') {
 		background-color: oBrandGet('table-background');
 
 		tbody th {

--- a/src/scss/_row-headings.scss
+++ b/src/scss/_row-headings.scss
@@ -3,9 +3,9 @@
 /// @link http://registry.origami.ft.com/components/o-table
 ////
 
-//// @access private
+//// @brand internal
 //// @outputs Highlights table headings.
-@mixin _oTableRowHeadings() {
+@mixin oTableRowHeadings() {
 	tbody th {
 		background-color: _oTableGet('table-alternate-background');
 	}

--- a/src/scss/_row-headings.scss
+++ b/src/scss/_row-headings.scss
@@ -3,8 +3,9 @@
 /// @link http://registry.origami.ft.com/components/o-table
 ////
 
-/// Add this to the table element to get row stripes
-@mixin oTableRowStripes() {
+//// @access private
+//// @outputs Highlights table headings.
+@mixin oTableRowHeadings() {
 	@include oBrandConfigureFor($component: 'o-table', $variant: 'row-headings') {
 		background-color: oBrandGet('table-background');
 

--- a/src/scss/_row-headings.scss
+++ b/src/scss/_row-headings.scss
@@ -1,0 +1,15 @@
+////
+/// @group o-table
+/// @link http://registry.origami.ft.com/components/o-table
+////
+
+/// Add this to the table element to get row stripes
+@mixin oTableRowStripes() {
+	@include oBrandConfigureFor('o-table--row-headings') {
+		background-color: oBrandGet('table-background');
+
+		tbody th {
+			background-color: oBrandGet('table-row-heading-background');
+		}
+	}
+}

--- a/src/scss/_row-stripes.scss
+++ b/src/scss/_row-stripes.scss
@@ -12,6 +12,6 @@
 	}
 
 	tbody tr:nth-child(even) {
-		background-color: _oTableGet('table-stripe-background');
+		background-color: _oTableGet('table-alternate-background');
 	}
 }


### PR DESCRIPTION
It'd be good to get your help next week on the workflow for brands - All I've been able to do is generate a set of demos for master

Unrelated to this PR, The readme doesn't have a contributing/installing section either. Is the standard origami workflow deliberately not included in individual readmes? Could do with a link to the centralised docs if there are some (I notice there's been some additions of docs in the registry recently, but nothing on contributing as yet, unless I've missed it)