### PR TITLE
Idea: Add ability to use Heroku Review Apps

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,0 +1,8 @@
+{
+  "name": "o-table",
+  "scripts": {},
+  "env": {},
+  "formation": {},
+  "addons": [],
+  "buildpacks": ["heroku/nodejs"]
+}

--- a/package.json
+++ b/package.json
@@ -1,5 +1,9 @@
 {
   "name": "o-table",
   "description": "FT-branded tables",
-  "private": true
+  "private": true,
+  "scripts": {
+    "heroku-postbuild": "npx origami-build-tools install",
+    "start": "npx origami-build-tools demo --run-server"
+  }
 }


### PR DESCRIPTION
I was thinking that having Heroku Review Apps which surface the demos of a component for each pull-request might help with reviewing changes. Reviewers would no longer have to pull down the branch, install the dependencies and build the demos to review a pull-request.