### PR TITLE
Add tfoot helper class and an overlay wrapper.

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ The "overflow" style of responsive table ([see above](#responsive-options)) supp
 
 #### Table Utility Styles
 - `o-table--row-stripes` - Apply to the table for alternating stripes on the table rows.
+- `o-table__footnote` - Style a `tfoot` element subtily for sources, disclaimers, etc.
 - `o-table__cell--numeric` - Apply to numeric cells to align content to the right.
 - `o-table__cell--vertically-center` - Apply to cells which should center vertically.
 

--- a/README.md
+++ b/README.md
@@ -45,13 +45,34 @@ Where table headings (`th`) are used as row headings, `scope="row"` attributes m
 </table>
 ```
 
-Table `caption` elements should include a header of the appropriate level and style for the table's context.
+The table's `caption` element should include a header of the appropriate level and style for the table's context.
 
 ```html
 <table class="o-table" data-o-component="o-table">
 	<caption class="o-table__caption">
 		<h2>My Table Caption</h2>
 	</caption>
+	<thead>
+		...
+	</thead>
+	<tbody>
+		...
+	</tbody>
+	...
+</table>
+```
+
+The table's footer `tfoot` element may use the helper class `o-table-footnote` to display sources, disclaimers, etc.
+
+```html
+<table class="o-table" data-o-component="o-table">
+	<tfoot>
+		<tr>
+			<td colspan=2 class="o-table-footnote">
+				Source: The Origami team.
+			</td>
+		</tr>
+	</tfoot>
 	<thead>
 		...
 	</thead>
@@ -97,14 +118,16 @@ There are three options for small viewports where the table does not fit.
 2. [scroll](https://www.ft.com/__origami/service/build/v2/demos/o-table/responsive-scroll) - Flip the table so headings are in the first column and sticky, data is scrollable horizontally.
 3. [flat](https://www.ft.com/__origami/service/build/v2/demos/o-table/responsive-flat) - Split each row into an individual item and repeat headings.
 
-To enable these set `data-o-table-responsive` to the type of responsive table desired and add the classes for that type of table. Then wrap the table in `o-table-container` and `o-table-wrapper`. E.g for an "overflow" table:
+To enable these set `data-o-table-responsive` to the type of responsive table desired and add the classes for that type of table. Then wrap the table in `o-table-container`, `o-table-overlay-wrapper`, `o-table-scroll-wrapper`. E.g for an "overflow" table:
 
 ```html
 <div class="o-table-container">
-	<div class="o-table-wrapper">
-		<table class="o-table o-table--row-stripes o-table--responsive-overflow o-table--responsive-flat" data-o-component="o-table" data-o-table-responsive="overflow">
-			...
-		</table>
+	<div class="o-table-overlay-wrapper">
+		<div class="o-table-scroll-wrapper">
+			<table class="o-table o-table--row-stripes o-table--responsive-overflow o-table--responsive-flat" data-o-component="o-table" data-o-table-responsive="overflow">
+				...
+			</table>
+		</div>
 	</div>
 </div>
 ```
@@ -117,11 +140,33 @@ The "overflow" style of responsive table ([see above](#responsive-options)) supp
 
 ```html
 <div class="o-table-container">
-	<div class="o-table-wrapper">
-		<table class="o-table o-table--row-stripes o-table--responsive-overflow o-table--responsive-flat" data-o-component="o-table" data-o-table-responsive="overflow" data-o-table-expanded="false" data-o-table-minimum-row-count="10">
-			...
-		</table>
+	<div class="o-table-overlay-wrapper">
+		<div class="o-table-scroll--wrapper">
+			<table class="o-table o-table--row-stripes o-table--responsive-overflow o-table--responsive-flat"
+			data-o-component="o-table"
+			data-o-table-responsive="overflow"
+			data-o-table-expanded="false"
+			data-o-table-minimum-row-count="10">
+				...
+			</table>
+		</div>
 	</div>
+</div>
+```
+
+To add a footnote to an expandable table, for example with disclaimers or sources, add the footnote within the container and link to the table with an id and the `aria-describedby` attribute. If not working on an expandable table, [use the `tfoot` element instead](#basic-table).
+```diff
+<div class="o-table-container">
+	<div class="o-table-overlay-wrapper">
+		<div class="o-table-scroll--wrapper">
++			<table aria-describedby="demo-footnote">
+				...
+			</table>
+		</div>
+	</div>
++	<div id="demo-footnode" class="o-table-footnote">
++		Source: The Origami team's love of fruit.
++	</div>
 </div>
 ```
 
@@ -414,7 +459,7 @@ document.addEventListener('oTable.sorting', (event) => {
 ## Troubleshooting
 
 Known issues:
-* IE11 or below need the [polyfill service](https://polyfill.io/)
+* IE11 and below need the [polyfill service](https://polyfill.io/)
 
 ## Migration guide
 
@@ -424,20 +469,25 @@ Known issues:
 - Markup updates:
 	- Previous `o-table` demos omitted `thead` and `tbody` from `table`, including their child `tr` element. Ensure your table markup is correct and includes `thead` and `tbody`.
 	- `o-table__caption--top` and `o-table__caption--bottom` have been removed. Remove these classes and add a heading within the caption (e.g. a `<h2>`) with appropriate styling.
-	- Responsive tables are now wrapped in a container class and the type of responsive table should be specified.
+	- `o-table-wrapper` is now `o-table-scroll-wrapper`
+	- Responsive tables are now wrapped in a container div `o-table-container` and overlay div `o-table-overlay-wrapper`.
+	- Responsive tables should now have their type specified via a data attribute e.g. `data-o-table-responsive="overflow"`.
 ```diff
 +<div class="o-table-container">
-     <div class="o-table-wrapper">
--        <table data-o-component="o-table" class="o-table--responsive-overflow">
-+        <table data-o-component="o-table" class="o-table--responsive-overflow" data-o-table-responsive="overflow">
--            <caption class="o-table__caption o-table__caption--bottom">
-+            <caption class="o-table__caption">
--                My Table Caption
-+                <h2>My Table Caption</h2>
-             </caption>
-             <!-- thead, tbody -->
-        </table>
-    </div>
++    <div class="o-table-overlay-wrapper">
++     	<div class="o-table-scroll-wrapper">
+-    	<div class="o-table-wrapper">
+-        	<table data-o-component="o-table" class="o-table--responsive-overflow">
++        	<table data-o-component="o-table" class="o-table--responsive-overflow" data-o-table-responsive="overflow">
+-            	<caption class="o-table__caption o-table__caption--bottom">
++            	<caption class="o-table__caption">
+-                	My Table Caption
++                	<h2>My Table Caption</h2>
+             	</caption>
+             	<!-- thead, tbody -->
+        	</table>
+    	</div>
++   </div>
 +</div>
 ```
 - Mixin updates:

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "o-grid": "^4.0.6",
     "o-icons": ">=4.0.0 <6",
     "o-typography": "^5.0.0",
-    "o-brand": "^3.0.1",
+    "o-brand": "^3.1.1",
     "o-visual-effects": "^2.0.3",
     "o-buttons": "^5.14.0"
   },

--- a/demos/src/base.mustache
+++ b/demos/src/base.mustache
@@ -1,52 +1,57 @@
 <div class="o-table-container">
-	<div class="o-table-wrapper">
-		<table class="o-table {{modifierClass}} {{#tableType}}o-table--responsive-{{tableType}}{{/tableType}}" data-o-component="o-table" {{#tableType}}data-o-table-responsive="{{tableType}}"{{/tableType}}>
-			<thead>
-				<tr>
-					<th scope="col" role="columnheader">Fruit</th>
-					<th scope="col" role="columnheader">Genus</th>
-					<th scope="col" role="columnheader">Characteristic</th>
-					<th scope="col" role="columnheader" data-o-table-data-type="numeric" class="o-table__cell--numeric">Cost&nbsp;(GBP)</th>
-					<th scope="col" role="columnheader" data-o-table-data-type="numeric" class="o-table__cell--numeric">Cost&nbsp;(EUR)</th>
-				</tr>
-			</thead>
-			<tbody>
-				<tr>
-					<td>Dragonfruit</td>
-					<td>Stenocereus</td>
-					<td>Juicy</td>
-					<td class="o-table__cell--numeric">3</td>
-					<td class="o-table__cell--numeric">2.72</td>
-				</tr>
-				<tr>
-					<td>Durian</td>
-					<td>Durio</td>
-					<td>Smelly</td>
-					<td class="o-table__cell--numeric">1.75</td>
-					<td class="o-table__cell--numeric">1.33</td>
-				</tr>
-				<tr>
-					<td>Naseberry</td>
-					<td>Manilkara</td>
-					<td>Chewy</td>
-					<td class="o-table__cell--numeric">2</td>
-					<td class="o-table__cell--numeric">1.85</td>
-				</tr>
-				<tr>
-					<td>Strawberry</td>
-					<td>Fragaria</td>
-					<td>Sweet</td>
-					<td class="o-table__cell--numeric">1.5</td>
-					<td class="o-table__cell--numeric">1.69</td>
-				</tr>
-				<tr>
-					<td>Apple</td>
-					<td>Malus</td>
-					<td>Crunchy</td>
-					<td class="o-table__cell--numeric">0.5</td>
-					<td class="o-table__cell--numeric">0.56</td>
-				</tr>
-			</tbody>
-		</table>
+	<div class="o-table-overlay-wrapper">
+		<div class="o-table-scroll-wrapper">
+			<table aria-describedby="demo-footnote" class="o-table {{modifierClass}} {{#tableType}}o-table--responsive-{{tableType}}{{/tableType}}" data-o-component="o-table" {{#tableType}}data-o-table-responsive="{{tableType}}"{{/tableType}}>
+				<thead>
+					<tr>
+						<th scope="col" role="columnheader">Fruit</th>
+						<th scope="col" role="columnheader">Genus</th>
+						<th scope="col" role="columnheader">Characteristic</th>
+						<th scope="col" role="columnheader" data-o-table-data-type="numeric" class="o-table__cell--numeric">Cost&nbsp;(GBP)</th>
+						<th scope="col" role="columnheader" data-o-table-data-type="numeric" class="o-table__cell--numeric">Cost&nbsp;(EUR)</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<td>Dragonfruit</td>
+						<td>Stenocereus</td>
+						<td>Juicy</td>
+						<td class="o-table__cell--numeric">3</td>
+						<td class="o-table__cell--numeric">2.72</td>
+					</tr>
+					<tr>
+						<td>Durian</td>
+						<td>Durio</td>
+						<td>Smelly</td>
+						<td class="o-table__cell--numeric">1.75</td>
+						<td class="o-table__cell--numeric">1.33</td>
+					</tr>
+					<tr>
+						<td>Naseberry</td>
+						<td>Manilkara</td>
+						<td>Chewy</td>
+						<td class="o-table__cell--numeric">2</td>
+						<td class="o-table__cell--numeric">1.85</td>
+					</tr>
+					<tr>
+						<td>Strawberry</td>
+						<td>Fragaria</td>
+						<td>Sweet</td>
+						<td class="o-table__cell--numeric">1.5</td>
+						<td class="o-table__cell--numeric">1.69</td>
+					</tr>
+					<tr>
+						<td>Apple</td>
+						<td>Malus</td>
+						<td>Crunchy</td>
+						<td class="o-table__cell--numeric">0.5</td>
+						<td class="o-table__cell--numeric">0.56</td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+	</div>
+	<div id="demo-footnote" class="o-table-footnote">
+		Source: The Origami team's love of fruit.
 	</div>
 </div>

--- a/demos/src/basic.mustache
+++ b/demos/src/basic.mustache
@@ -4,6 +4,15 @@
             <h2 class="o-typography-heading-level-2">Table Caption</h2>
         </caption>
     {{/showCaption}}
+    {{#showFootnote}}
+        <tfoot>
+            <tr>
+                <td colspan=5 class="o-table__footnote">
+                    Source: The Origami team's love of fruit.
+                </td>
+            </tr>
+        </tfoot>
+    {{/showFootnote}}
     <thead>
         <tr>
             <th scope="col" role="columnheader">Fruit</th>

--- a/demos/src/basic.mustache
+++ b/demos/src/basic.mustache
@@ -4,15 +4,15 @@
             <h2 class="o-typography-heading-level-2">Table Caption</h2>
         </caption>
     {{/showCaption}}
-    {{#showFootnote}}
+    {{#showFooter}}
         <tfoot>
             <tr>
-                <td colspan=5 class="o-table__footnote">
+                <td colspan=5 class="o-table-footnote">
                     Source: The Origami team's love of fruit.
                 </td>
             </tr>
         </tfoot>
-    {{/showFootnote}}
+    {{/showFooter}}
     <thead>
         <tr>
             <th scope="col" role="columnheader">Fruit</th>

--- a/demos/src/expanding.mustache
+++ b/demos/src/expanding.mustache
@@ -1,157 +1,162 @@
 <div class="o-table-container">
-	<div class="o-table-wrapper">
-		<table class="o-table o-table--row-stripes o-table--responsive-overflow"  data-o-component="o-table" data-o-table-responsive="overflow" data-o-table-minimum-row-count="10" data-o-table-expanded="{{expanded}}">
-			<thead>
-				<tr>
-					<th scope="col" role="columnheader">Fruit</th>
-					<th scope="col" role="columnheader">Genus</th>
-					<th scope="col" role="columnheader">Characteristic</th>
-					<th scope="col" role="columnheader" data-o-table-data-type="numeric" class="o-table__cell--numeric">Cost&nbsp;(GBP)</th>
-					<th scope="col" role="columnheader" data-o-table-data-type="numeric" class="o-table__cell--numeric">Cost&nbsp;(EUR)</th>
-				</tr>
-			</thead>
-			<tbody>
-				<tr>
-					<td>Dragonfruit</td>
-					<td>Stenocereus</td>
-					<td>Juicy</td>
-					<td class="o-table__cell--numeric">3</td>
-					<td class="o-table__cell--numeric">2.72</td>
-				</tr>
-				<tr>
-					<td>Durian</td>
-					<td>Durio</td>
-					<td>Smelly</td>
-					<td class="o-table__cell--numeric">1.75</td>
-					<td class="o-table__cell--numeric">1.33</td>
-				</tr>
-				<tr>
-					<td>Naseberry</td>
-					<td>Manilkara</td>
-					<td>Chewy</td>
-					<td class="o-table__cell--numeric">2</td>
-					<td class="o-table__cell--numeric">1.85</td>
-				</tr>
-				<tr>
-					<td>Strawberry</td>
-					<td>Fragaria</td>
-					<td>Sweet</td>
-					<td class="o-table__cell--numeric">1.5</td>
-					<td class="o-table__cell--numeric">1.69</td>
-				</tr>
-				<tr>
-					<td>Apple</td>
-					<td>Malus</td>
-					<td>Crunchy</td>
-					<td class="o-table__cell--numeric">0.5</td>
-					<td class="o-table__cell--numeric">0.56</td>
-				</tr>
-				<tr>
-					<td>Dragonfruit</td>
-					<td>Stenocereus</td>
-					<td>Juicy</td>
-					<td class="o-table__cell--numeric">3</td>
-					<td class="o-table__cell--numeric">2.72</td>
-				</tr>
-				<tr>
-					<td>Durian</td>
-					<td>Durio</td>
-					<td>Smelly</td>
-					<td class="o-table__cell--numeric">1.75</td>
-					<td class="o-table__cell--numeric">1.33</td>
-				</tr>
-				<tr>
-					<td>Naseberry</td>
-					<td>Manilkara</td>
-					<td>Chewy</td>
-					<td class="o-table__cell--numeric">2</td>
-					<td class="o-table__cell--numeric">1.85</td>
-				</tr>
-				<tr>
-					<td>Strawberry</td>
-					<td>Fragaria</td>
-					<td>Sweet</td>
-					<td class="o-table__cell--numeric">1.5</td>
-					<td class="o-table__cell--numeric">1.69</td>
-				</tr>
-				<tr>
-					<td>Apple</td>
-					<td>Malus</td>
-					<td>Crunchy</td>
-					<td class="o-table__cell--numeric">0.5</td>
-					<td class="o-table__cell--numeric">0.56</td>
-				</tr>
-				<tr>
-					<td>Dragonfruit</td>
-					<td>Stenocereus</td>
-					<td>Juicy</td>
-					<td class="o-table__cell--numeric">3</td>
-					<td class="o-table__cell--numeric">2.72</td>
-				</tr>
-				<tr>
-					<td>Durian</td>
-					<td>Durio</td>
-					<td>Smelly</td>
-					<td class="o-table__cell--numeric">1.75</td>
-					<td class="o-table__cell--numeric">1.33</td>
-				</tr>
-				<tr>
-					<td>Naseberry</td>
-					<td>Manilkara</td>
-					<td>Chewy</td>
-					<td class="o-table__cell--numeric">2</td>
-					<td class="o-table__cell--numeric">1.85</td>
-				</tr>
-				<tr>
-					<td>Strawberry</td>
-					<td>Fragaria</td>
-					<td>Sweet</td>
-					<td class="o-table__cell--numeric">1.5</td>
-					<td class="o-table__cell--numeric">1.69</td>
-				</tr>
-				<tr>
-					<td>Apple</td>
-					<td>Malus</td>
-					<td>Crunchy</td>
-					<td class="o-table__cell--numeric">0.5</td>
-					<td class="o-table__cell--numeric">0.56</td>
-				</tr>
-				<tr>
-					<td>Dragonfruit</td>
-					<td>Stenocereus</td>
-					<td>Juicy</td>
-					<td class="o-table__cell--numeric">3</td>
-					<td class="o-table__cell--numeric">2.72</td>
-				</tr>
-				<tr>
-					<td>Durian</td>
-					<td>Durio</td>
-					<td>Smelly</td>
-					<td class="o-table__cell--numeric">1.75</td>
-					<td class="o-table__cell--numeric">1.33</td>
-				</tr>
-				<tr>
-					<td>Naseberry</td>
-					<td>Manilkara</td>
-					<td>Chewy</td>
-					<td class="o-table__cell--numeric">2</td>
-					<td class="o-table__cell--numeric">1.85</td>
-				</tr>
-				<tr>
-					<td>Strawberry</td>
-					<td>Fragaria</td>
-					<td>Sweet</td>
-					<td class="o-table__cell--numeric">1.5</td>
-					<td class="o-table__cell--numeric">1.69</td>
-				</tr>
-				<tr>
-					<td>Apple</td>
-					<td>Malus</td>
-					<td>Crunchy</td>
-					<td class="o-table__cell--numeric">0.5</td>
-					<td class="o-table__cell--numeric">0.56</td>
-				</tr>
-			</tbody>
-		</table>
+	<div class="o-table-overlay-wrapper">
+		<div class="o-table-scroll-wrapper">
+			<table class="o-table o-table--row-stripes o-table--responsive-overflow"  data-o-component="o-table" data-o-table-responsive="overflow" data-o-table-minimum-row-count="10" data-o-table-expanded="{{expanded}}">
+				<thead>
+					<tr>
+						<th scope="col" role="columnheader">Fruit</th>
+						<th scope="col" role="columnheader">Genus</th>
+						<th scope="col" role="columnheader">Characteristic</th>
+						<th scope="col" role="columnheader" data-o-table-data-type="numeric" class="o-table__cell--numeric">Cost&nbsp;(GBP)</th>
+						<th scope="col" role="columnheader" data-o-table-data-type="numeric" class="o-table__cell--numeric">Cost&nbsp;(EUR)</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<td>Dragonfruit</td>
+						<td>Stenocereus</td>
+						<td>Juicy</td>
+						<td class="o-table__cell--numeric">3</td>
+						<td class="o-table__cell--numeric">2.72</td>
+					</tr>
+					<tr>
+						<td>Durian</td>
+						<td>Durio</td>
+						<td>Smelly</td>
+						<td class="o-table__cell--numeric">1.75</td>
+						<td class="o-table__cell--numeric">1.33</td>
+					</tr>
+					<tr>
+						<td>Naseberry</td>
+						<td>Manilkara</td>
+						<td>Chewy</td>
+						<td class="o-table__cell--numeric">2</td>
+						<td class="o-table__cell--numeric">1.85</td>
+					</tr>
+					<tr>
+						<td>Strawberry</td>
+						<td>Fragaria</td>
+						<td>Sweet</td>
+						<td class="o-table__cell--numeric">1.5</td>
+						<td class="o-table__cell--numeric">1.69</td>
+					</tr>
+					<tr>
+						<td>Apple</td>
+						<td>Malus</td>
+						<td>Crunchy</td>
+						<td class="o-table__cell--numeric">0.5</td>
+						<td class="o-table__cell--numeric">0.56</td>
+					</tr>
+					<tr>
+						<td>Dragonfruit</td>
+						<td>Stenocereus</td>
+						<td>Juicy</td>
+						<td class="o-table__cell--numeric">3</td>
+						<td class="o-table__cell--numeric">2.72</td>
+					</tr>
+					<tr>
+						<td>Durian</td>
+						<td>Durio</td>
+						<td>Smelly</td>
+						<td class="o-table__cell--numeric">1.75</td>
+						<td class="o-table__cell--numeric">1.33</td>
+					</tr>
+					<tr>
+						<td>Naseberry</td>
+						<td>Manilkara</td>
+						<td>Chewy</td>
+						<td class="o-table__cell--numeric">2</td>
+						<td class="o-table__cell--numeric">1.85</td>
+					</tr>
+					<tr>
+						<td>Strawberry</td>
+						<td>Fragaria</td>
+						<td>Sweet</td>
+						<td class="o-table__cell--numeric">1.5</td>
+						<td class="o-table__cell--numeric">1.69</td>
+					</tr>
+					<tr>
+						<td>Apple</td>
+						<td>Malus</td>
+						<td>Crunchy</td>
+						<td class="o-table__cell--numeric">0.5</td>
+						<td class="o-table__cell--numeric">0.56</td>
+					</tr>
+					<tr>
+						<td>Dragonfruit</td>
+						<td>Stenocereus</td>
+						<td>Juicy</td>
+						<td class="o-table__cell--numeric">3</td>
+						<td class="o-table__cell--numeric">2.72</td>
+					</tr>
+					<tr>
+						<td>Durian</td>
+						<td>Durio</td>
+						<td>Smelly</td>
+						<td class="o-table__cell--numeric">1.75</td>
+						<td class="o-table__cell--numeric">1.33</td>
+					</tr>
+					<tr>
+						<td>Naseberry</td>
+						<td>Manilkara</td>
+						<td>Chewy</td>
+						<td class="o-table__cell--numeric">2</td>
+						<td class="o-table__cell--numeric">1.85</td>
+					</tr>
+					<tr>
+						<td>Strawberry</td>
+						<td>Fragaria</td>
+						<td>Sweet</td>
+						<td class="o-table__cell--numeric">1.5</td>
+						<td class="o-table__cell--numeric">1.69</td>
+					</tr>
+					<tr>
+						<td>Apple</td>
+						<td>Malus</td>
+						<td>Crunchy</td>
+						<td class="o-table__cell--numeric">0.5</td>
+						<td class="o-table__cell--numeric">0.56</td>
+					</tr>
+					<tr>
+						<td>Dragonfruit</td>
+						<td>Stenocereus</td>
+						<td>Juicy</td>
+						<td class="o-table__cell--numeric">3</td>
+						<td class="o-table__cell--numeric">2.72</td>
+					</tr>
+					<tr>
+						<td>Durian</td>
+						<td>Durio</td>
+						<td>Smelly</td>
+						<td class="o-table__cell--numeric">1.75</td>
+						<td class="o-table__cell--numeric">1.33</td>
+					</tr>
+					<tr>
+						<td>Naseberry</td>
+						<td>Manilkara</td>
+						<td>Chewy</td>
+						<td class="o-table__cell--numeric">2</td>
+						<td class="o-table__cell--numeric">1.85</td>
+					</tr>
+					<tr>
+						<td>Strawberry</td>
+						<td>Fragaria</td>
+						<td>Sweet</td>
+						<td class="o-table__cell--numeric">1.5</td>
+						<td class="o-table__cell--numeric">1.69</td>
+					</tr>
+					<tr>
+						<td>Apple</td>
+						<td>Malus</td>
+						<td>Crunchy</td>
+						<td class="o-table__cell--numeric">0.5</td>
+						<td class="o-table__cell--numeric">0.56</td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+	</div>
+	<div class="o-table-footnote">
+		Source: The Origami team's love of fruit.
 	</div>
 </div>

--- a/demos/src/row-headings.mustache
+++ b/demos/src/row-headings.mustache
@@ -1,5 +1,5 @@
 <div class="o-table-container">
-	<div class="o-table-wrapper">
+	<div class="o-table-scroll-wrapper">
 		<table class="o-table o-table--row-headings" data-o-component="o-table">
 			<tr>
 				<th scope="row" role="rowheader">Item</th>

--- a/demos/src/sorting.mustache
+++ b/demos/src/sorting.mustache
@@ -1,5 +1,5 @@
 <div class="o-table-container">
-	<div class="o-table-wrapper">
+	<div class="o-table-scroll-wrapper">
 		<table class="o-table" data-o-component="o-table">
 			<thead>
 				<tr>

--- a/origami.json
+++ b/origami.json
@@ -136,14 +136,15 @@
 			"description": "This demo shows sorting columns of various data types, including FT style dates, times, and abbreviated numbers. The demo also shows a column with sort disabled."
 		},
 		{
-			"title": "Caption",
+			"title": "Caption and footnote",
 			"name": "captions",
 			"template": "demos/src/basic.mustache",
 			"data": {
-				"showCaption": true
+				"showCaption": true,
+				"showFootnote": true
 			},
 			"documentClasses": "o-table-demo-constrain",
-			"description": "Caption elements may include flow content such as a heading, this demo uses o-typography to add a h2."
+			"description": "Caption elements may include flow content such as a heading, this demo uses o-typography to add a h2. The footer may also include any flow content, but in this case uses the footnote class to style a source."
 		},
 		{
 			"title": "Borders",

--- a/origami.json
+++ b/origami.json
@@ -141,7 +141,7 @@
 			"template": "demos/src/basic.mustache",
 			"data": {
 				"showCaption": true,
-				"showFootnote": true
+				"showFooter": true
 			},
 			"documentClasses": "o-table-demo-constrain",
 			"description": "Caption elements may include flow content such as a heading, this demo uses o-typography to add a h2. The footer may also include any flow content, but in this case uses the footnote class to style a source."

--- a/src/js/Tables/BaseTable.js
+++ b/src/js/Tables/BaseTable.js
@@ -21,8 +21,9 @@ class BaseTable {
 		this.tbody = this.rootEl.querySelector('tbody');
 		this.tableHeaders = this.thead ? Array.from(this.thead.querySelectorAll('th')) : [];
 		this.tableRows = this.tbody ? Array.from(this.tbody.getElementsByTagName('tr')) : [];
-		this.wrapper = this.rootEl.closest('.o-table-wrapper');
+		this.wrapper = this.rootEl.closest('.o-table-scroll-wrapper');
 		this.container = this.rootEl.closest('.o-table-container');
+		this.overlayWrapper = this.rootEl.closest('.o-table-overlay-wrapper');
 	}
 
 	/**

--- a/src/js/Tables/OverflowTable.js
+++ b/src/js/Tables/OverflowTable.js
@@ -157,9 +157,9 @@ class OverflowTable extends BaseTable {
 	 * @returns {undefined}
 	 */
 	_addControlsToDom() {
-		if (this.container && !this.controls) {
+		if (this.overlayWrapper && !this.controls) {
 			const supportsArrows = OverflowTable._supportsArrows();
-			this.container.insertAdjacentHTML('beforeend', `
+			this.overlayWrapper.insertAdjacentHTML('beforeend', `
 				${this.wrapper ? `
 					<div class="o-table-overflow-fade-overlay" style="display: none;"></div>
 				` : ''}
@@ -185,11 +185,11 @@ class OverflowTable extends BaseTable {
 			`);
 
 			this.controls = {
-				controlsOverlay: this.container.querySelector('.o-table-overflow-control-overlay'),
-				fadeOverlay: this.container.querySelector('.o-table-overflow-fade-overlay'),
-				expanderButton: this.container.querySelector('.o-table-control--expander'),
-				forwardButton: this.container.querySelector('.o-table-control--forward'),
-				backButton: this.container.querySelector('.o-table-control--back')
+				controlsOverlay: this.overlayWrapper.querySelector('.o-table-overflow-control-overlay'),
+				fadeOverlay: this.overlayWrapper.querySelector('.o-table-overflow-fade-overlay'),
+				expanderButton: this.overlayWrapper.querySelector('.o-table-control--expander'),
+				forwardButton: this.overlayWrapper.querySelector('.o-table-control--forward'),
+				backButton: this.overlayWrapper.querySelector('.o-table-control--back')
 			};
 		}
 	}
@@ -201,7 +201,7 @@ class OverflowTable extends BaseTable {
 	 */
 	_setupScroll() {
 		// Does not warn of a missing wrapper: assumes no overflow is desired.
-		if (this.container && !this.wrapper) {
+		if (this.container && this.overlayWrapper && !this.wrapper) {
 			console.warn(
 				'Controls to scroll table left/right could not be added to "o-table" as it is missing markup. ' +
 				'Please add the container and wrapper elements according to the documentation https://registry.origami.ft.com/components/o-table.',
@@ -210,7 +210,7 @@ class OverflowTable extends BaseTable {
 		}
 
 		// Can not add controls without a container or wrapper.
-		if (!this.container || !this.wrapper) {
+		if (!this.container || !this.overlayWrapper || !this.wrapper) {
 			return;
 		}
 
@@ -298,7 +298,7 @@ class OverflowTable extends BaseTable {
 			return;
 		}
 
-		if (!this.container || !this.wrapper) {
+		if (!this.container || !this.overlayWrapper || !this.wrapper) {
 			throw new Error(
 				'Controls to expand/contract the table could not be added to "o-table" as it is missing markup.' +
 				'Please add the container and wrapper element according to the documentation https://registry.origami.ft.com/components/o-table.'

--- a/src/scss/_base.scss
+++ b/src/scss/_base.scss
@@ -53,5 +53,10 @@
 		.o-table__cell--vertically-center {
 			vertical-align: middle;
 		}
+
+		.o-table__footnote {
+			@include oTypographySize(-1);
+			color: _oTableGet('table-footnote-color');
+		}
 	}
 }

--- a/src/scss/_base.scss
+++ b/src/scss/_base.scss
@@ -53,10 +53,13 @@
 		.o-table__cell--vertically-center {
 			vertical-align: middle;
 		}
+	}
 
-		.o-table__footnote {
-			@include oTypographySize(-1);
-			color: _oTableGet('table-footnote-color');
-		}
+	.o-table-footnote {
+		@include oTypographyCaption();
+	}
+
+	.o-table-container > .o-table-footnote {
+		margin-left: 10px;
 	}
 }

--- a/src/scss/_brand.scss
+++ b/src/scss/_brand.scss
@@ -10,40 +10,48 @@
     @return oBrandSupportsVariant($component: 'o-table', $variant: $variant);
 }
 
-@include oBrandDefine('o-table', 'master', (
-	'variables': (
-		table-background: oColorsGetPaletteColor('paper'),
-		table-alternate-background: oColorsGetPaletteColor('wheat'),
-		table-header-color: oColorsGetPaletteColor('black-90'),
-		table-border-color: oColorsGetPaletteColor('black-20'),
-		table-caption-border-color: oColorsGetPaletteColor('black-30'),
-		table-data-color: oColorsGetPaletteColor('black-70'),
-	),
-	'supports-variants': (
-		'stripes',
-		'compact'
-	)
-));
+@if oBrandGetCurrentBrand() == 'master' {
+	@include oBrandDefine('o-table', 'master', (
+		'variables': (
+			table-background: oColorsGetPaletteColor('paper'),
+			table-alternate-background: oColorsGetPaletteColor('wheat'),
+			table-header-color: oColorsGetPaletteColor('black-90'),
+			table-border-color: oColorsGetPaletteColor('black-20'),
+			table-caption-border-color: oColorsGetPaletteColor('black-30'),
+			table-data-color: oColorsGetPaletteColor('black-70'),
+			table-footnote-color: oColorsGetPaletteColor('black-60')
+		),
+		'supports-variants': (
+			'stripes',
+			'compact'
+		)
+	));
+}
 
-@include oBrandDefine('o-table', 'internal', (
-	'variables': (
-		table-background: oColorsGetPaletteColor('white'),
-		table-alternate-background: oColorsGetPaletteColor('slate-white-5'),
-		table-header-color: oColorsGetPaletteColor('black-90'),
-		table-border-color: oColorsGetPaletteColor('black-20'),
-		table-caption-border-color: oColorsGetPaletteColor('black-30'),
-		table-data-color: oColorsGetPaletteColor('black-70'),
-	),
-	'supports-variants': (
-		'stripes',
-		'compact',
-		'row-headings'
-	)
-));
+@if oBrandGetCurrentBrand() == 'internal' {
+	@include oBrandDefine('o-table', 'internal', (
+		'variables': (
+			table-background: oColorsGetPaletteColor('white'),
+			table-alternate-background: oColorsGetPaletteColor('slate-white-5'),
+			table-header-color: oColorsGetPaletteColor('black-90'),
+			table-border-color: oColorsGetPaletteColor('black-20'),
+			table-caption-border-color: oColorsGetPaletteColor('black-30'),
+			table-data-color: oColorsGetPaletteColor('black-70'),
+			table-footnote-color: oColorsGetPaletteColor('black-60')
+		),
+		'supports-variants': (
+			'stripes',
+			'compact',
+			'row-headings'
+		)
+	));
+}
 
-@include oBrandDefine('o-table', 'whitelabel', (
-	'variables': (),
-	'supports-variants': (
-		'compact'
-	)
-));
+@if oBrandGetCurrentBrand() == 'whitelabel' {
+	@include oBrandDefine('o-table', 'whitelabel', (
+		'variables': (),
+		'supports-variants': (
+			'compact'
+		)
+	));
+}

--- a/src/scss/_wrapper.scss
+++ b/src/scss/_wrapper.scss
@@ -1,12 +1,16 @@
 /// Styles for a table wrapper to allow table to overflow.
 /// The wrapped table becomes scrollable on small viewports.
 @mixin oTableWrapper {
-	.o-table-wrapper {
+	.o-table-scroll-wrapper {
 		overflow-y: hidden;
 		overflow-x: auto;
 		width: 100%;
 		scroll-snap-type: x proximity;
 		-webkit-overflow-scrolling: touch; //sass-lint:disable-line no-vendor-prefixes
+	}
+
+	.o-table-overlay-wrapper {
+		position: relative;
 	}
 }
 

--- a/test/OverflowTable.test.js
+++ b/test/OverflowTable.test.js
@@ -24,7 +24,7 @@ function canScrollTable() {
 }
 
 function scrollTable(oTableEl, { toEnd }) {
-	const wrapper = oTableEl.closest('.o-table-wrapper');
+	const wrapper = oTableEl.closest('.o-table-scroll-wrapper');
 	const scrollTo = toEnd ? oTableEl.getBoundingClientRect().width : 0;
 	setTimeout(() => {
 		wrapper.scrollLeft = scrollTo;

--- a/test/Sort/TableSorter.test.js
+++ b/test/Sort/TableSorter.test.js
@@ -56,7 +56,7 @@ describe("BaseTable", () => {
 		function getTableElementWithData(type, dataArray) {
 			const markup = `
 				<div class="o-table-container">
-					<div class="o-table-wrapper">
+					<div class="o-table-scroll-wrapper">
 						<table class="o-table" data-o-component="o-table">
 							<thead>
 								<tr>
@@ -295,7 +295,7 @@ describe("BaseTable", () => {
 		it('sorts by attribute "data-o-table-sort-value" value if set', done => {
 			sandbox.setContents(`
 				<div class="o-table-container">
-					<div class="o-table-wrapper">
+					<div class="o-table-scroll-wrapper">
 						<table class="o-table" data-o-component="o-table">
 							<thead>
 								<tr>
@@ -329,7 +329,7 @@ describe("BaseTable", () => {
 		it('sorts row headers', done => {
 			sandbox.setContents(`
 				<div class="o-table-container">
-					<div class="o-table-wrapper">
+					<div class="o-table-scroll-wrapper">
 						<table class="o-table" data-o-component="o-table">
 							<thead>
 								<tr>

--- a/test/helpers/fixtures.js
+++ b/test/helpers/fixtures.js
@@ -1,7 +1,8 @@
 
 const longTableWithContainer = `
 <div class="o-table-container">
-		<div class="o-table-wrapper">
+	<div class="o-table-overlay-wrapper">
+		<div class="o-table-scroll-wrapper">
 			<table class="o-table" data-o-component="o-table">
 				<thead>
 					<tr>
@@ -192,11 +193,13 @@ const longTableWithContainer = `
 			</table>
 		</div>
 	</div>
+</div>
 `;
 
 const shortTableWithContainer = `
 <div class="o-table-container">
-		<div class="o-table-wrapper">
+	<div class="o-table-overlay-wrapper">
+		<div class="o-table-scroll-wrapper">
 			<table class="o-table" data-o-component="o-table">
 				<thead>
 					<tr>
@@ -247,6 +250,7 @@ const shortTableWithContainer = `
 			</table>
 		</div>
 	</div>
+</div>
 `;
 
 export {


### PR DESCRIPTION
- Add a footnote helper class.
- Adds an 'overlay wrapper' and renames the current wrapper to a 'scroll wrapper', which allows content to be placed below an expandable table but within the table container. 
- Also updates o-brand and wraps the called to oBrandDefine in a conditional.

Disliking the number of wrappers. Suggestions welcome. 😞 

<img width="592" alt="screen shot 2018-10-03 at 12 38 16" src="https://user-images.githubusercontent.com/10405691/46416409-6491f200-c71f-11e8-8bf7-f8286bb878ec.png">

<img width="1138" alt="screen shot 2018-10-03 at 15 18 19" src="https://user-images.githubusercontent.com/10405691/46416514-94d99080-c71f-11e8-8e27-3991184231ca.png">