### PR TITLE
Caption default table

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Or to disable sort per table column, add `data-o-table-heading-disable-sort` to 
 
 There are three options for small viewports where the table does not fit.
 
-1. [overflow](https://www.ft.com/__origami/service/build/v2/demos/o-table/responsive-overflow) (default) - Scroll the whole table including headings horizontally. This option also supports an [expander](#expander).
+1. [overflow](https://www.ft.com/__origami/service/build/v2/demos/o-table/responsive-overflow) - Scroll the whole table including headings horizontally. This option also supports an [expander](#expander).
 2. [scroll](https://www.ft.com/__origami/service/build/v2/demos/o-table/responsive-scroll) - Flip the table so headings are in the first column and sticky, data is scrollable horizontally.
 3. [flat](https://www.ft.com/__origami/service/build/v2/demos/o-table/responsive-flat) - Split each row into an individual item and repeat headings.
 
@@ -233,7 +233,7 @@ const OTable = require('o-table');
 oTable = new OTable(document.body);
 ```
 
-This will return an instance of `OverflowTable` (default), `FlatTable`, or `ScrollTable` depending on the value of `data-o-table-responsive`. All three table types extend `BaseTable`.
+This will return an instance of `BasicTable` (default), `OverflowTable`, `FlatTable`, or `ScrollTable` depending on the value of `data-o-table-responsive`. All four table types extend `BaseTable`.
 
 Instantiation will add column sorting to all tables. It will also add scroll controls and, if configured, an [expander](#expander) to any `OverflowTable`. These can be configured with [data attributes](#disable-sort) or imperatively with an options object:
 
@@ -404,7 +404,7 @@ The following events are fired by `o-table`.
 `oTable.ready` fires when the table has been initialised.
 
 The event provides the following properties:
-- `detail.instance` - The initialised `o-table` instance _(FlatTable | ScrollTable | OverflowTable)_.
+- `detail.instance` - The initialised `o-table` instance _(FlatTable | ScrollTable | OverflowTable | BasicTable)_.
 
 ##### oTable.sorted
 
@@ -413,7 +413,7 @@ The event provides the following properties:
 The event provides the following properties:
 - `detail.sortOrder` - The sort order e.g. "ascending" _(String)_.
 - `detail.columnIndex` - The index of the sorted column heading _(Number)_.
-- `detail.instance` - The effected `o-table` instance _(FlatTable | ScrollTable | OverflowTable)_.
+- `detail.instance` - The effected `o-table` instance _(FlatTable | ScrollTable | OverflowTable | BasicTable)_.
 
 ```js
 document.addEventListener('oTable.sorted', (event) => {
@@ -428,7 +428,7 @@ This event is fired just before a table sorts based on user interaction. It may 
 The event provides the following properties:
 - `detail.sortOrder` - The sort requested e.g. "ascending" _(String)_.
 - `detail.columnIndex` - The index of the column heading which will be sorted _(Number)_.
-- `detail.instance` - The effected `o-table` instance _(FlatTable | ScrollTable | OverflowTable)_.
+- `detail.instance` - The effected `o-table` instance _(FlatTable | ScrollTable | OverflowTable | BasicTable)_.
 
 When intercepting the default sort the `sorted` method must be called with relevant parameters when the custom sort is completed.
 
@@ -513,7 +513,7 @@ Known issues:
 + @include oTableResponsiveFlat;
 ```
 - JS updates:
-	- `OTable` returns an instance of `FlatTable`, `ScrollTable`, `OverflowTable` on construction, according to the type of table. All extend from `BaseTable`.
+	- `OTable` returns an instance of `BasicTable`, `FlatTable`, `ScrollTable`, `OverflowTable` on construction, according to the type of table. All extend from `BaseTable`.
 	- Table properties removed or made private: `isResponsive`, `listeners`.
 	- Table methods removed or made private:
 		- `wrap`: for a responsive table manually wrap the table in a container and wrapper class.

--- a/origami.json
+++ b/origami.json
@@ -127,6 +127,7 @@
 				"expanded": "true"
 			},
 			"documentClasses": "o-table-demo-pad",
+			"hidden": true,
 			"description": "Open demo and shrink browser to preview. When expanding Responsive Overflow tables are tall and can be scrolled past, the left/right arrows \"dock\" next to the \"show more\" expand button."
 		},
 		{

--- a/src/js/Tables/BasicTable.js
+++ b/src/js/Tables/BasicTable.js
@@ -12,12 +12,12 @@ class BasicTable extends BaseTable {
 	 * @param {Bool} opts.sortable [true]
 	 * @returns {BasicTable}
 	 */
-    constructor(rootEl, sorter, opts = {}) {
-        super(rootEl, sorter, opts);
-        window.requestAnimationFrame(this.addSortButtons.bind(this));
-        this._ready();
-        return this;
-    }
+	constructor(rootEl, sorter, opts = {}) {
+		super(rootEl, sorter, opts);
+		window.requestAnimationFrame(this.addSortButtons.bind(this));
+		this._ready();
+		return this;
+	}
 }
 
 export default BasicTable;

--- a/src/js/Tables/BasicTable.js
+++ b/src/js/Tables/BasicTable.js
@@ -1,0 +1,23 @@
+import BaseTable from './BaseTable';
+
+class BasicTable extends BaseTable {
+
+	/**
+	 * Initialises an `o-table` component without responsive behaviour.
+	 *
+	 * @access public
+	 * @param {HTMLElement} rootEl - The `o-table` element.
+	 * @param {TableSorter} sorter
+	 * @param {Object} opts [{}]
+	 * @param {Bool} opts.sortable [true]
+	 * @returns {BasicTable}
+	 */
+    constructor(rootEl, sorter, opts = {}) {
+        super(rootEl, sorter, opts);
+        window.requestAnimationFrame(this.addSortButtons.bind(this));
+        this._ready();
+        return this;
+    }
+}
+
+export default BasicTable;

--- a/src/js/oTable.js
+++ b/src/js/oTable.js
@@ -1,6 +1,7 @@
 import FlatTable from './Tables/FlatTable';
 import ScrollTable from './Tables/ScrollTable';
 import OverflowTable from './Tables/OverflowTable';
+import BasicTable from './Tables/BasicTable';
 
 import TableSorter from './Sort/TableSorter';
 const sorter = new TableSorter();
@@ -21,7 +22,7 @@ class OTable {
 	 *
 	 * @param {HTMLElement} - An o-table element.
 	 * @param {...OTable~opts} opts - A table options object.
-	 * @returns {FlatTable | ScrollTable | OverflowTable} - A table instance.
+	 * @returns {FlatTable | ScrollTable | OverflowTable | BasicTable} - A table instance.
 	 */
 	constructor(rootEl, opts = {}) {
 		const tableType = rootEl.getAttribute('data-o-table-responsive');
@@ -33,8 +34,11 @@ class OTable {
 			case 'scroll':
 				Table = ScrollTable;
 				break;
-			default:
+			case 'overflow':
 				Table = OverflowTable;
+				break;
+			default:
+				Table = BasicTable;
 				break;
 		}
 		return new Table(rootEl, sorter, opts);
@@ -46,7 +50,7 @@ class OTable {
 	 * @access public
 	 * @param {(HTMLElement|string)} [el=document.body] - Element where to search for o-table components. You can pass an HTMLElement or a selector string.
 	 * @param {...OTable~opts} opts - A table options object.
-	 * @returns {Array<FlatTable | ScrollTable | OverflowTable> | FlatTable | ScrollTable | OverflowTable} - A table instance or array of table instances.
+	 * @returns {Array<FlatTable | ScrollTable | OverflowTable | BasicTable> | FlatTable | ScrollTable | OverflowTable | BasicTable} - A table instance or array of table instances.
 	 */
 	static init(el = document.body, opts = {}) {
 		if (!(el instanceof HTMLElement)) {

--- a/src/scss/_base.scss
+++ b/src/scss/_base.scss
@@ -55,6 +55,7 @@
 		}
 	}
 
+	.o-table .o-table-footnote,
 	.o-table-footnote {
 		@include oTypographyCaption();
 	}

--- a/test/BasicTable.test.js
+++ b/test/BasicTable.test.js
@@ -1,6 +1,7 @@
 /* eslint-env mocha */
 
 import proclaim from 'proclaim';
+import sinon from 'sinon/pkg/sinon';
 import * as sandbox from './helpers/sandbox';
 import * as fixtures from './helpers/fixtures';
 import BasicTable from './../src/js/Tables/BasicTable';
@@ -9,36 +10,36 @@ import TableSorter from './../src/js/Sort/TableSorter';
 const sorter = new TableSorter();
 
 describe.only("BasicTable", () => {
-    let oTableEl;
+	let oTableEl;
 
-    beforeEach(() => {
-        sandbox.init();
-        sandbox.setContents(fixtures.shortTableWithContainer);
-        oTableEl = document.querySelector('[data-o-component=o-table]');
-    });
+	beforeEach(() => {
+		sandbox.init();
+		sandbox.setContents(fixtures.shortTableWithContainer);
+		oTableEl = document.querySelector('[data-o-component=o-table]');
+	});
 
-    it('it fires an "oTable.ready" event when constructed', done => {
-        window.addEventListener('oTable.ready', function () {
-            done();
-        });
-        new BasicTable(oTableEl, sorter);
-    });
+	it('it fires an "oTable.ready" event when constructed', done => {
+		window.addEventListener('oTable.ready', function () {
+			done();
+		});
+		new BasicTable(oTableEl, sorter);
+	});
 
-    it('it extends BaseTable', () => {
-        const table = new BasicTable(oTableEl, sorter);
-        proclaim.isInstanceOf(table, BaseTable);
-    });
+	it('it extends BaseTable', () => {
+		const table = new BasicTable(oTableEl, sorter);
+		proclaim.isInstanceOf(table, BaseTable);
+	});
 
-    it('adds sort buttons', (done) => {
-        const addSortSpy = sinon.spy(BasicTable.prototype, "addSortButtons");
-        new BasicTable(oTableEl, sorter);
-        setTimeout(() => {
-            try {
-                proclaim.isTrue(addSortSpy.calledOnce);
-            } catch (error) {
-                done(error);
-            }
-            done();
-        }, 2); // wait for window.requestAnimationFrame
-    });
+	it('adds sort buttons', (done) => {
+		const addSortSpy = sinon.spy(BasicTable.prototype, "addSortButtons");
+		new BasicTable(oTableEl, sorter);
+		setTimeout(() => {
+			try {
+				proclaim.isTrue(addSortSpy.calledOnce);
+			} catch (error) {
+				done(error);
+			}
+			done();
+		}, 2); // wait for window.requestAnimationFrame
+	});
 });

--- a/test/BasicTable.test.js
+++ b/test/BasicTable.test.js
@@ -9,7 +9,7 @@ import BaseTable from './../src/js/Tables/BaseTable';
 import TableSorter from './../src/js/Sort/TableSorter';
 const sorter = new TableSorter();
 
-describe.only("BasicTable", () => {
+describe("BasicTable", () => {
 	let oTableEl;
 
 	beforeEach(() => {
@@ -39,6 +39,7 @@ describe.only("BasicTable", () => {
 			} catch (error) {
 				done(error);
 			}
+			addSortSpy.restore();
 			done();
 		}, 2); // wait for window.requestAnimationFrame
 	});

--- a/test/BasicTable.test.js
+++ b/test/BasicTable.test.js
@@ -1,0 +1,44 @@
+/* eslint-env mocha */
+
+import proclaim from 'proclaim';
+import * as sandbox from './helpers/sandbox';
+import * as fixtures from './helpers/fixtures';
+import BasicTable from './../src/js/Tables/BasicTable';
+import BaseTable from './../src/js/Tables/BaseTable';
+import TableSorter from './../src/js/Sort/TableSorter';
+const sorter = new TableSorter();
+
+describe.only("BasicTable", () => {
+    let oTableEl;
+
+    beforeEach(() => {
+        sandbox.init();
+        sandbox.setContents(fixtures.shortTableWithContainer);
+        oTableEl = document.querySelector('[data-o-component=o-table]');
+    });
+
+    it('it fires an "oTable.ready" event when constructed', done => {
+        window.addEventListener('oTable.ready', function () {
+            done();
+        });
+        new BasicTable(oTableEl, sorter);
+    });
+
+    it('it extends BaseTable', () => {
+        const table = new BasicTable(oTableEl, sorter);
+        proclaim.isInstanceOf(table, BaseTable);
+    });
+
+    it('adds sort buttons', (done) => {
+        const addSortSpy = sinon.spy(BasicTable.prototype, "addSortButtons");
+        new BasicTable(oTableEl, sorter);
+        setTimeout(() => {
+            try {
+                proclaim.isTrue(addSortSpy.calledOnce);
+            } catch (error) {
+                done(error);
+            }
+            done();
+        }, 2); // wait for window.requestAnimationFrame
+    });
+});

--- a/test/oTable.test.js
+++ b/test/oTable.test.js
@@ -9,6 +9,7 @@ import BaseTable from './../src/js/Tables/BaseTable';
 import OverflowTable from './../src/js/Tables/OverflowTable';
 import FlatTable from './../src/js/Tables/FlatTable';
 import ScrollTable from './../src/js/Tables/ScrollTable';
+import BasicTable from './../src/js/Tables/BasicTable';
 
 describe('OTable constructs', () => {
 	let oTableEl;
@@ -43,6 +44,18 @@ describe('OTable constructs', () => {
 		oTableEl.setAttribute('data-o-table-responsive', 'flat');
 		testOTable = new OTable(oTableEl);
 		proclaim.isInstanceOf(testOTable, FlatTable);
+	});
+
+	it('a BasicTable when the table has attribute data-o-table-responsive=""', () => {
+		oTableEl.setAttribute('data-o-table-responsive', '');
+		testOTable = new OTable(oTableEl);
+		proclaim.isInstanceOf(testOTable, BasicTable);
+	});
+
+	it('a BasicTable when the table does not have the data-o-table-responsive attribute', () => {
+		oTableEl.removeAttribute('data-o-table-responsive');
+		testOTable = new OTable(oTableEl);
+		proclaim.isInstanceOf(testOTable, BasicTable);
 	});
 });
 


### PR DESCRIPTION
1. Adds a `BasicTable` class so `OverflowTable` is not the default.
2. Hide [a demo](http://localhost:8080/components/o-table@7.0.0-beta.1/#demo-expanding-table-with-arrow-dock) which is useful for dev but doesn't add much for users in the registry.
3. Fixes a specificity issue which cased footnotes to display incorrectly when within the table.
Before:
<img width="632" alt="screen shot 2018-10-09 at 15 08 56" src="https://user-images.githubusercontent.com/10405691/46675048-871b8380-cbd5-11e8-94e7-e82c389357e0.png">

After:
<img width="640" alt="screen shot 2018-10-09 at 15 09 03" src="https://user-images.githubusercontent.com/10405691/46675038-8125a280-cbd5-11e8-8436-989c6d35e3d0.png">
