### PR TITLE
Enable tabular (monospaced) figures.

### DIFF
--- a/src/scss/_base.scss
+++ b/src/scss/_base.scss
@@ -47,6 +47,7 @@
 
 		.o-table__cell--numeric {
 			text-align: right;
+			font-feature-settings: "tnum" 1;
 		}
 
 		.o-table__cell--content-secondary {


### PR DESCRIPTION
Before:
<img width="745" alt="screen shot 2018-10-19 at 13 26 52" src="https://user-images.githubusercontent.com/10405691/47218124-ab7c1a80-d3a2-11e8-8d06-51f96e9bf0e2.png">

After:
<img width="745" alt="screen shot 2018-10-19 at 13 26 37" src="https://user-images.githubusercontent.com/10405691/47218129-b0d96500-d3a2-11e8-867b-a18d81c6356d.png">


If only character alignment was also available: 
https://drafts.csswg.org/css-text-4/#character-alignment