### PR TITLE
Reduce colours and brand variables.

### DIFF
--- a/src/scss/_base.scss
+++ b/src/scss/_base.scss
@@ -7,7 +7,7 @@
 		width: 100%;
 
 		thead {
-			border-bottom: 2px solid _oTableGet('table-header-border-color');
+			border-bottom: 2px solid _oTableGet('table-data-color');
 		}
 
 		th,
@@ -15,11 +15,11 @@
 			padding: 10px;
 			text-align: left;
 			vertical-align: top;
+			color: _oTableGet('table-data-color');
 		}
 
 		th {
 			@include oTypographySansBold(1);
-			color: _oTableGet('table-header-color');
 			background-color: _oTableGet('header-background');
 			&:not([scope=row]) {
 				vertical-align: bottom;
@@ -28,7 +28,6 @@
 
 		td {
 			@include oTypographySans(1);
-			color: _oTableGet('table-data-color');
 			scroll-snap-align: none center;
 			&:empty:before {
 				@include oIconsGetIcon('minus', $container-width: 15,  $container-height: 15, $iconset-version: 1);

--- a/src/scss/_brand.scss
+++ b/src/scss/_brand.scss
@@ -15,11 +15,8 @@
 		'variables': (
 			table-background: oColorsGetPaletteColor('paper'),
 			table-alternate-background: oColorsGetPaletteColor('wheat'),
-			table-header-color: oColorsGetPaletteColor('black-90'),
-			table-header-border-color: oColorsGetPaletteColor('black-80'),
 			table-border-color: oColorsGetPaletteColor('black-20'),
-			table-caption-border-color: oColorsGetPaletteColor('black-30'),
-			table-data-color: oColorsGetPaletteColor('black-70'),
+			table-data-color: oColorsGetColorFor(body, text),
 			table-footnote-color: oColorsGetPaletteColor('black-60')
 		),
 		'supports-variants': (
@@ -34,11 +31,8 @@
 		'variables': (
 			table-background: oColorsGetPaletteColor('white'),
 			table-alternate-background: oColorsGetPaletteColor('slate-white-5'),
-			table-header-color: oColorsGetPaletteColor('black-90'),
-			header-border-border-color: oColorsGetPaletteColor('black-80'),
 			table-border-color: oColorsGetPaletteColor('black-20'),
-			table-caption-border-color: oColorsGetPaletteColor('black-30'),
-			table-data-color: oColorsGetPaletteColor('black-70'),
+			table-data-color: oColorsGetColorFor(body, text),
 			table-footnote-color: oColorsGetPaletteColor('black-60')
 		),
 		'supports-variants': (

--- a/src/scss/_responsive-flat.scss
+++ b/src/scss/_responsive-flat.scss
@@ -69,7 +69,7 @@
 			}
 
 			tbody tr:not(:first-child) {
-				border-top: 2px solid _oTableGet('table-header-border-color');
+				border-top: 2px solid _oTableGet('table-data-color');
 			}
 		}
 	}

--- a/src/scss/_responsive-scroll.scss
+++ b/src/scss/_responsive-scroll.scss
@@ -38,7 +38,7 @@
 					right: 0;
 					bottom: 0;
 					left: 0;
-					border-right: 2px solid _oTableGet('table-header-border-color');
+					border-right: 2px solid _oTableGet('table-data-color');
 				}
 			}
 

--- a/src/scss/_row-headings.scss
+++ b/src/scss/_row-headings.scss
@@ -3,6 +3,6 @@
 @mixin oTableRowHeadings() {
 	.o-table--row-headings > tbody th {
 		background-color: _oTableGet('table-alternate-background');
-		border-right: 2px solid _oTableGet('table-header-border-color');
+		border-right: 2px solid _oTableGet('table-data-color');
 	}
 }


### PR DESCRIPTION
Spot the difference! Update approved by Caroline.

Before:
Headers: black-90
Data: black-70
Normal body copy: black-80
<img width="874" alt="screen shot 2018-10-19 at 13 56 36" src="https://user-images.githubusercontent.com/10405691/47219641-44149980-d3a7-11e8-8d12-dce2804ac16f.png">

After:
Headers: black-80
Data: black-80
Normal body copy: black-80
<img width="874" alt="screen shot 2018-10-19 at 13 58 32" src="https://user-images.githubusercontent.com/10405691/47219650-4a0a7a80-d3a7-11e8-8484-0f4c37136da2.png">
