### PR TITLE
Flat table design updates.

### DIFF
--- a/demos/src/cell-styles.mustache
+++ b/demos/src/cell-styles.mustache
@@ -7,23 +7,26 @@
 	</thead>
 	<tbody>
 		<tr>
-			<td class="o-table__cell--vertically-center">Vertically centred</td>
+			<td class="o-table__cell--vertically-center">Vertically centred row</td>
 			<td class="o-table__cell--vertically-center">
 				<div><a class="o-typography-link" href="#">View</a></div>
+				<div><a class="o-typography-link" href="#">Edit</a></div>
 				<div><a class="o-typography-link" href="#">Download</a></div>
 			</td>
 		</tr>
 		<tr>
-			<td class="o-table__cell--vertically-center">with</td>
+			<td class="o-table__cell--vertically-center">Another vertically centred row</td>
 			<td class="o-table__cell--vertically-center">
 				<div><a class="o-typography-link" href="#">View</a></div>
+				<div><a class="o-typography-link" href="#">Edit</a></div>
 				<div><a class="o-typography-link" href="#">Download</a></div>
 			</td>
 		</tr>
 		<tr>
-			<td class="o-table__cell--vertically-center">.o-table__cell--vertically-center class</td>
+			<td class="o-table__cell--vertically-center">A third vertically centred row</td>
 			<td class="o-table__cell--vertically-center">
 				<div><a class="o-typography-link" href="#">View</a></div>
+				<div><a class="o-typography-link" href="#">Edit</a></div>
 				<div><a class="o-typography-link" href="#">Download</a></div>
 			</td>
 		</tr>

--- a/origami.json
+++ b/origami.json
@@ -53,15 +53,15 @@
 			"description": ""
 		},
 		{
-			"title": "Row Stripes",
-			"name": "row-stripes",
+			"title": "Caption and footnote",
+			"name": "captions",
 			"template": "demos/src/basic.mustache",
 			"data": {
-				"modifierClass": "o-table--row-stripes",
-				"isStriped": true
+				"showCaption": true,
+				"showFooter": true
 			},
 			"documentClasses": "o-table-demo-constrain",
-			"description": "Adds a modifier class to make alternate table rows striped. An alternative to lined tables."
+			"description": "Caption elements may include flow content such as a heading, this demo uses o-typography to add a h2. The footer may also include any flow content, but in this case uses the footnote class to style a source."
 		},
 		{
 			"title": "Row headings",
@@ -71,13 +71,6 @@
 			"template": "demos/src/row-headings.mustache",
 			"description": ""
 		},
-        {
-			"title": "Cell styles",
-			"name": "cell-styles",
-			"template": "demos/src/cell-styles.mustache",
-			"documentClasses": "o-table-demo-constrain",
-			"description": ""
-        },
 		{
 			"title": "Responsive Overflow",
 			"name": "responsive-overflow",
@@ -135,15 +128,22 @@
 			"description": "This demo shows sorting columns of various data types, including FT style dates, times, and abbreviated numbers. The demo also shows a column with sort disabled."
 		},
 		{
-			"title": "Caption and footnote",
-			"name": "captions",
+			"title": "Row Stripes",
+			"name": "row-stripes",
 			"template": "demos/src/basic.mustache",
 			"data": {
-				"showCaption": true,
-				"showFooter": true
+				"modifierClass": "o-table--row-stripes",
+				"isStriped": true
 			},
 			"documentClasses": "o-table-demo-constrain",
-			"description": "Caption elements may include flow content such as a heading, this demo uses o-typography to add a h2. The footer may also include any flow content, but in this case uses the footnote class to style a source."
+			"description": "Adds a modifier class to make alternate table rows striped. An alternative to lined tables."
+		},
+		{
+			"title": "Vertically centre",
+			"name": "cell-styles",
+			"template": "demos/src/cell-styles.mustache",
+			"documentClasses": "o-table-demo-constrain",
+			"description": ""
 		},
 		{
 			"title": "Pa11y",

--- a/src/js/Tables/BaseTable.js
+++ b/src/js/Tables/BaseTable.js
@@ -74,6 +74,7 @@ class BaseTable {
 		if (!this._opts.sortable) {
 			return;
 		}
+		this.rootEl.classList.add('o-table--sortable');
 		this.tableHeaders.forEach(function (th, columnIndex) {
 			// Don't add sort buttons to unsortable columns.
 			if (th.hasAttribute('data-o-table-heading-disable-sort')) {

--- a/src/scss/_brand.scss
+++ b/src/scss/_brand.scss
@@ -17,7 +17,10 @@
 			table-alternate-background: oColorsGetPaletteColor('wheat'),
 			table-border-color: oColorsGetPaletteColor('black-20'),
 			table-data-color: oColorsGetColorFor(body, text),
-			table-footnote-color: oColorsGetPaletteColor('black-60')
+			table-footnote-color: oColorsGetPaletteColor('black-60'),
+			'flat': (
+				table-flat-alternate-background: oColorsMix('wheat', 'paper', 40)
+			)
 		),
 		'supports-variants': (
 			'stripes',
@@ -33,7 +36,10 @@
 			table-alternate-background: oColorsGetPaletteColor('slate-white-5'),
 			table-border-color: oColorsGetPaletteColor('black-20'),
 			table-data-color: oColorsGetColorFor(body, text),
-			table-footnote-color: oColorsGetPaletteColor('black-60')
+			table-footnote-color: oColorsGetPaletteColor('black-60'),
+			'flat': (
+				table-flat-alternate-background: oColorsGetPaletteColor('slate-white-5')
+			)
 		),
 		'supports-variants': (
 			'stripes',

--- a/src/scss/_brand.scss
+++ b/src/scss/_brand.scss
@@ -19,7 +19,7 @@
 			table-data-color: oColorsGetColorFor(body, text),
 			table-footnote-color: oColorsGetPaletteColor('black-60'),
 			'flat': (
-				table-flat-alternate-background: oColorsMix('wheat', 'paper', 40)
+				table-item-alternate-background: oColorsMix('wheat', 'paper', 40)
 			)
 		),
 		'supports-variants': (
@@ -38,7 +38,7 @@
 			table-data-color: oColorsGetColorFor(body, text),
 			table-footnote-color: oColorsGetPaletteColor('black-60'),
 			'flat': (
-				table-flat-alternate-background: oColorsGetPaletteColor('slate-white-5')
+				table-item-alternate-background: oColorsGetPaletteColor('slate-white-5')
 			)
 		),
 		'supports-variants': (

--- a/src/scss/_responsive-flat.scss
+++ b/src/scss/_responsive-flat.scss
@@ -36,13 +36,22 @@
 				display: none;
 			}
 
-			&.o-table--horizontal-lines tbody tr:not(:first-child) {
-				border-top: 2px solid _oTableGet('table-data-color');
+			tbody tr:not(:first-child) {
+				border-top: 1px solid _oTableGet('table-data-color');
 			}
+
+			tbody tr:nth-child(odd) {
+				background-color: _oTableGet('table-alternate-background');
+			}
+
+			&.o-table--horizontal-lines th:not(:last-of-type),
+			&.o-table--horizontal-lines td:not(:last-of-type), {
+				border-bottom: 1px solid _oTableGet('table-border-color');
+			}
+
 
 			.o-table__duplicate-heading {
 				display: block;
-				border-right: 1px solid _oTableGet('table-border-color');
 				float: left;
 				padding: 10px;
 				width: 50%;

--- a/src/scss/_responsive-flat.scss
+++ b/src/scss/_responsive-flat.scss
@@ -1,6 +1,6 @@
 /// Styles for a 'FlatTable'
 @mixin oTableResponsiveFlat {
-	.o-table--responsive-flat {
+	.o-table.o-table--responsive-flat {
 		width: 100%;
 
 		.o-table__duplicate-heading {
@@ -40,8 +40,9 @@
 				border-top: 1px solid _oTableGet('table-data-color');
 			}
 
-			tbody tr:nth-child(odd) {
-				background-color: _oTableGet('table-flat-alternate-background', 'flat');
+			&.o-table--row-stripes tbody tr:nth-child(even) th, // Remove stripes when flat.
+			tbody tr:nth-child(even) {
+				background-color: _oTableGet('table-item-alternate-background', 'flat');
 			}
 
 			&.o-table--horizontal-lines th:not(:last-of-type),
@@ -52,7 +53,6 @@
 					border-bottom: 1px solid _oTableGet('table-border-color');
 				}
 			}
-
 
 			.o-table__duplicate-heading {
 				display: block;

--- a/src/scss/_responsive-flat.scss
+++ b/src/scss/_responsive-flat.scss
@@ -41,12 +41,16 @@
 			}
 
 			tbody tr:nth-child(odd) {
-				background-color: _oTableGet('table-alternate-background');
+				background-color: _oTableGet('table-flat-alternate-background', 'flat');
 			}
 
 			&.o-table--horizontal-lines th:not(:last-of-type),
 			&.o-table--horizontal-lines td:not(:last-of-type), {
-				border-bottom: 1px solid _oTableGet('table-border-color');
+				// When flat, only show row border if a colour is defined.
+				// Else the browser will use a black border.
+				@if _oTableGet('table-border-color') {
+					border-bottom: 1px solid _oTableGet('table-border-color');
+				}
 			}
 
 

--- a/src/scss/_sort.scss
+++ b/src/scss/_sort.scss
@@ -1,5 +1,10 @@
 /// Tables styles to support sort buttons.
 @mixin oTableSort {
+
+	.o-table--sortable thead th:not([data-o-table-heading-disable-sort]) {
+		padding-right: 0; // No header padding with a child sort icon.
+	}
+
 	// Sort button.
 	.o-table__sort {
 		// sass-lint:disable no-vendor-prefixes


### PR DESCRIPTION
Tweaks alignment of sort buttons with right aligned content (before/after).
<img width="622" alt="screen shot 2018-10-29 at 11 20 52" src="https://user-images.githubusercontent.com/10405691/47646722-b5550900-db6c-11e8-9ae0-fc8fa5a9ad43.png">

Updates flat table (before/after):
<img width="807" alt="screen shot 2018-10-29 at 11 24 17" src="https://user-images.githubusercontent.com/10405691/47646864-2d233380-db6d-11e8-9744-312d64f387b1.png">