### PR TITLE
Final `o-table` changes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,7 +487,7 @@ Known issues:
 		}
 	```
 - Mixin updates:
-	- All `o-table` mixins have been made private except for a new mixin `@include oTable($opts)`. It accepts an feature list `$opts` to include `o-table` styles granularly. Replace previous mixins with one call to the [`oTable` mixin with an optional `$opts` flag](#silent-mode). Please [contact us](#contact) if this does not suit you product.
+	- All `o-table` mixins have been made private except for a new mixin `@include oTable($opts)`. It accepts an feature list `$opts` to include `o-table` styles granularly. Replace previous mixins with one call to the [`oTable` mixin with an optional `$opts` flag](#silent-mode). Please [contact us](#contact) if this does not suit your product.
 	- `oTableAll` has been replaced with `oTable`, which does not accept a class name `$classname`. Instead use the default `o-table` class name in your markup. As the mixin now output classes directly, they must not be wrapped in an `.o-table` class manually.
 ```diff
 -.o-table {

--- a/README.md
+++ b/README.md
@@ -479,6 +479,13 @@ Known issues:
 +   </div>
 +</div>
 ```
+- Style updates:
+	- The default bottom margin of `o-table` has been removed. Please apply the margin as needed, depending on the context of the table e.g. within an article:
+	```scss
+		.o-table
+			margin-bottom: oTypographySpacingSize($units: 4);
+		}
+	```
 - Mixin updates:
 	- All `o-table` mixins have been made private except for a new mixin `@include oTable($opts)`. It accepts an feature list `$opts` to include `o-table` styles granularly. Replace previous mixins with one call to the [`oTable` mixin with an optional `$opts` flag](#silent-mode). Please [contact us](#contact) if this does not suit you product.
 	- `oTableAll` has been replaced with `oTable`, which does not accept a class name `$classname`. Instead use the default `o-table` class name. As the mixin now output classes directly, they must not be wrapped in an `.o-table` class manually.

--- a/README.md
+++ b/README.md
@@ -480,9 +480,9 @@ Known issues:
 +</div>
 ```
 - Style updates:
-	- The default bottom margin of `o-table` has been removed. Please apply the margin as needed, depending on the context of the table e.g. within an article:
+	- The default bottom margin of `o-table` has been removed. Please apply the margin as needed, depending on the context of the table e.g. within typical body copy:
 	```scss
-		.o-table
+		.o-table {
 			margin-bottom: oTypographySpacingSize($units: 4);
 		}
 	```

--- a/README.md
+++ b/README.md
@@ -488,7 +488,7 @@ Known issues:
 	```
 - Mixin updates:
 	- All `o-table` mixins have been made private except for a new mixin `@include oTable($opts)`. It accepts an feature list `$opts` to include `o-table` styles granularly. Replace previous mixins with one call to the [`oTable` mixin with an optional `$opts` flag](#silent-mode). Please [contact us](#contact) if this does not suit you product.
-	- `oTableAll` has been replaced with `oTable`, which does not accept a class name `$classname`. Instead use the default `o-table` class name. As the mixin now output classes directly, they must not be wrapped in an `.o-table` class manually.
+	- `oTableAll` has been replaced with `oTable`, which does not accept a class name `$classname`. Instead use the default `o-table` class name in your markup. As the mixin now output classes directly, they must not be wrapped in an `.o-table` class manually.
 ```diff
 -.o-table {
 -    @include oTableBase;

--- a/README.md
+++ b/README.md
@@ -510,7 +510,7 @@ Known issues:
 		- `wrap`: for a responsive table manually wrap the table in a container and wrapper class.
 		```html
 		<div class="o-table-container">
-			<div class="o-table-wrapper">
+			<div class="o-table-scroll-wrapper">
 				<!-- table -->
 			</div>
 		</div>

--- a/README.md
+++ b/README.md
@@ -170,54 +170,43 @@ To add a footnote to an expandable table, for example with disclaimers or source
 </div>
 ```
 
-### Sass
-
-#### Table Utility Styles
+#### Additional markup
+- `o-table--compact` - Apply to the table for smaller typography and padding.
 - `o-table--row-stripes` - Apply to the table for alternating stripes on the table rows.
 - `o-table-footnote` - Style a `tfoot` element subtily for sources, disclaimers, etc.
 - `o-table__cell--numeric` - Apply to numeric cells to align content to the right.
 - `o-table__cell--vertically-center` - Apply to cells which should center vertically.
 
-See more styles in the registry: [o-table demos](https://registry.origami.ft.com/components/o-table).
+See more in the registry: [o-table demos](https://registry.origami.ft.com/components/o-table).
 
+### Sass
 
 #### Silent mode
 
-If using `o-table` in silent mode, `@include oTableAll` includes every feature. Alternatively features may be included granularly:
+If using `o-table` in silent mode, `@include oTable()` includes styles for all features. Alternatively styles may be included granularly with an `$opts` map.
 
-Required:
+Include all table features:
 ```scss
-// Basic styles and utilities.
-@include oTableBase;
+@include oTable();
 ```
 
-Optional:
+Alternatively include base styles with only selected optional features. E.g. to include only the "overflow" responsive table and styles for table lines:
 ```scss
-// Sortable columns.
-@include oTableSort;
-
-// Respnsive solutions.
-@include oTableWrapper;
-@include oTableContainer;
-@include oTableResponsiveOverflow;
-@include oTableResponsiveFlat;
-@include oTableResponsiveScroll;
-
-// Lines.
-@include oTableHorizontalLines;
-@include oTableVerticalLines;
-@include oTableHorizontalBorders;
-@include oTableVerticalBorders;
-
-// Compact.
-@include oTableCompact;
-
-// Stripes.
-@include oTableRowStripes;
-
-// Row headings.
-@include oTableRowHeadings;
+@include oTable($opts: (
+	'responsive-overflow',
+	'lines'
+));
 ```
+
+| Feature             | Description                                             | Brand support                |
+|---------------------|---------------------------------------------------------|------------------------------|
+| responsive-overflow | See [responsive options](#responsive-options).          | master, internal, whitelabel |
+| responsive-flat     | See [responsive options](#responsive-options).          | master, internal, whitelabel |
+| responsive-scroll   | See [responsive options](#responsive-options).          | master, internal, whitelabel |
+| lines               | Styles for horizontal and vertical lines, plus borders. | master, internal, whitelabel |
+| compact             | A table with smaller typography and padding.            | master, internal, whitelabel |
+| stripes             | Alternating row stripe styles.                          | master, internal             |
+| row-headings        | Row heading styles.                                     | internal                     |
 
 ### JavaScript
 
@@ -464,7 +453,7 @@ Known issues:
 ## Migration guide
 
 ### How to upgrade from v5.x.x to v6.x.x?
-- To prevent errors in IE11, add support for `Array.prototype.findIndex`, `IntersectionObserverEntry`, and `IntersectionObserver` with the [polyfill service](https://polyfill.io/).
+- To prevent errors in IE11, add support for `IntersectionObserverEntry` and `IntersectionObserver` with the [polyfill service](https://polyfill.io/).
 - Data attribute `data-o-table-order` has been removed. To specify a custom sort order on `td` cells use `data-o-table-sort-value` instead.
 - Markup updates:
 	- Previous `o-table` demos omitted `thead` and `tbody` from `table`, including their child `tr` element. Ensure your table markup is correct and includes `thead` and `tbody`.
@@ -491,10 +480,8 @@ Known issues:
 +</div>
 ```
 - Mixin updates:
-	- `oTableCaptionTop`, `oTableCaptionBottom` have been removed. Use only `oTableCaption` instead.
-	- `oTableCellNumeric`, `oTableCellContentSecondary`, `oTableCellVerticallyCenter`, `oTableCaption` have been removed. Their styles are now included as part of `oTableBase`.
-	- `oTableAll`: does not accept a class name `$classname`. Instead use the default `o-table` class name -- please [contact us](#contact) if this is a problem for your team.
-	- All mixins now output classes directly, so must not be wrapped in an `.o-table` class manually.
+	- All `o-table` mixins have been made private except for a new mixin `@include oTable($opts)`. It accepts an feature list `$opts` to include `o-table` styles granularly. Replace previous mixins with one call to the [`oTable` mixin with an optional `$opts` flag](#silent-mode). Please [contact us](#contact) if this does not suit you product.
+	- `oTableAll` has been replaced with `oTable`, which does not accept a class name `$classname`. Instead use the default `o-table` class name. As the mixin now output classes directly, they must not be wrapped in an `.o-table` class manually.
 ```diff
 -.o-table {
 -    @include oTableBase;
@@ -507,10 +494,7 @@ Known issues:
 -    @include oTableContainer;
 -}
 
-+ @include oTableBase;
-+ @include oTableWrapper;
-+ @include oTableContainer;
-+ @include oTableResponsiveFlat;
++ @include oTable($opts: ('responsive-flat'));
 ```
 - JS updates:
 	- `OTable` returns an instance of `BasicTable`, `FlatTable`, `ScrollTable`, `OverflowTable` on construction, according to the type of table. All extend from `BaseTable`.

--- a/demos/src/pa11y.mustache
+++ b/demos/src/pa11y.mustache
@@ -1,251 +1,226 @@
-<table class="o-table {{modifierClass}}" data-o-component="o-table">
-	<thead>
+<div class="o-table-container">
+	<div class="o-table-overlay-wrapper">
+		<div class="o-table-scroll-wrapper">
+			<table aria-describedby="demo-footnote" class="o-table o-table--horizontal-lines o-table--responsive-overflow" data-o-component="o-table" data-o-table-responsive="overflow" data-o-table-minimum-row-count="2" data-o-table-expanded="false">
+				<thead>
+					<tr>
+						<th scope="col" role="columnheader">Fruit</th>
+						<th scope="col" role="columnheader">Genus</th>
+						<th scope="col" role="columnheader">Characteristic</th>
+						<th scope="col" role="columnheader" data-o-table-data-type="numeric" class="o-table__cell--numeric">Cost&nbsp;(GBP)</th>
+						<th scope="col" role="columnheader" data-o-table-data-type="numeric" class="o-table__cell--numeric">Cost&nbsp;(EUR)</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<td>Dragonfruit</td>
+						<td>Stenocereus</td>
+						<td>Juicy</td>
+						<td class="o-table__cell--numeric">3</td>
+						<td class="o-table__cell--numeric">2.72</td>
+					</tr>
+					<tr>
+						<td>Durian</td>
+						<td>Durio</td>
+						<td>Smelly</td>
+						<td class="o-table__cell--numeric">1.75</td>
+						<td class="o-table__cell--numeric">1.33</td>
+					</tr>
+					<tr>
+						<td>Naseberry</td>
+						<td>Manilkara</td>
+						<td>Chewy</td>
+						<td class="o-table__cell--numeric">2</td>
+						<td class="o-table__cell--numeric">1.85</td>
+					</tr>
+					<tr>
+						<td>Strawberry</td>
+						<td>Fragaria</td>
+						<td>Sweet</td>
+						<td class="o-table__cell--numeric">1.5</td>
+						<td class="o-table__cell--numeric">1.69</td>
+					</tr>
+					<tr>
+						<td>Apple</td>
+						<td>Malus</td>
+						<td>Crunchy</td>
+						<td class="o-table__cell--numeric">0.5</td>
+						<td class="o-table__cell--numeric">0.56</td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+	</div>
+	<div id="demo-footnote" class="o-table-footnote">
+		Source: The Origami team's love of fruit.
+	</div>
+</div>
+
+
+<table class="o-table o-table--compact o-table--row-stripes" data-o-component="o-table">
+	<tfoot>
 		<tr>
-			<th>Cheese <span class="o-table__cell--content-secondary">Type of cheese</span></th>
-			<th>Bread <span class="o-table__cell--content-secondary">Type of bread</span></th>
-			<th data-o-table-data-type="numeric" class="o-table__cell--numeric">Cost <span class="o-table__cell--content-secondary">(GBP)</span></th>
-			<th data-o-table-data-type="numeric" class="o-table__cell--numeric">Cost <span class="o-table__cell--content-secondary">(EUR)</span></th>
+			<td colspan=5 class="o-table-footnote">
+				Source: The Origami team's love of fruit.
+			</td>
 		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>cheddar</td>
-			<td>rye</td>
-			<td data-o-table-data-type="numeric" class="o-table__cell--numeric">1</td>
-			<td data-o-table-data-type="numeric" class="o-table__cell--numeric">1.56</td>
-		</tr>
-		<tr>
-			<td>stilton</td>
-			<td>wholemeal</td>
-			<td data-o-table-data-type="numeric" class="o-table__cell--numeric">2</td>
-			<td data-o-table-data-type="numeric" class="o-table__cell--numeric">1.85</td>
-		</tr>
-		<tr>
-			<td>red leicester</td>
-			<td>white</td>
-			<td data-o-table-data-type="numeric" class="o-table__cell--numeric">3</td>
-			<td data-o-table-data-type="numeric" class="o-table__cell--numeric"></td>
-		</tr>
-		<tr>
-			<td>gruyère</td>
-			<td>sourdough</td>
-			<td data-o-table-data-type="numeric" class="o-table__cell--numeric">7</td>
-			<td data-o-table-data-type="numeric" class="o-table__cell--numeric"></td>
-		</tr>
-	</tbody>
+	</tfoot>
+    <thead>
+        <tr>
+            <th scope="col" role="columnheader">Fruit</th>
+            <th scope="col" role="columnheader">Genus</th>
+            <th scope="col" role="columnheader">Characteristic</th>
+            <th scope="col" role="columnheader" data-o-table-data-type="numeric" class="o-table__cell--numeric">Cost&nbsp;(GBP)</th>
+            <th scope="col" role="columnheader" data-o-table-data-type="numeric" class="o-table__cell--numeric">Cost&nbsp;(EUR)</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>Dragonfruit</td>
+            <td>Stenocereus</td>
+            <td>Juicy</td>
+            <td class="o-table__cell--numeric">3</td>
+            <td class="o-table__cell--numeric">2.72</td>
+        </tr>
+        <tr>
+            <td>Durian</td>
+            <td>Durio</td>
+            <td>Smelly</td>
+            <td class="o-table__cell--numeric">1.75</td>
+            <td class="o-table__cell--numeric">1.33</td>
+        </tr>
+        <tr>
+            <td>Naseberry</td>
+            <td>Manilkara</td>
+            <td>Chewy</td>
+            <td class="o-table__cell--numeric">2</td>
+            <td class="o-table__cell--numeric">1.85</td>
+        </tr>
+        <tr>
+            <td>Strawberry</td>
+            <td>Fragaria</td>
+            <td>Sweet</td>
+            <td class="o-table__cell--numeric">1.5</td>
+            <td class="o-table__cell--numeric">1.69</td>
+        </tr>
+        <tr>
+            <td>Apple</td>
+            <td>Malus</td>
+            <td>Crunchy</td>
+            <td class="o-table__cell--numeric">0.5</td>
+            <td class="o-table__cell--numeric">0.56</td>
+        </tr>
+    </tbody>
 </table>
 
-<table class="o-table {{modifierClass}}" data-o-component="o-table">
-	<thead>
-		<th>Cheese</th>
-		<th>Bread</th>
-		<th data-o-table-data-type="numeric" class="o-table__cell--numeric">Cost (GBP)</th>
-		<th data-o-table-data-type="numeric" class="o-table__cell--numeric">Cost (EUR)</th>
-	</thead>
-	<tbody>
+<table class="o-table o-table--row-stripes" data-o-component="o-table">
+	<tfoot>
 		<tr>
-			<td>cheddar</td>
-			<td>rye</td>
-			<td data-o-table-data-type="numeric" class="o-table__cell--numeric">1</td>
-			<td data-o-table-data-type="numeric" class="o-table__cell--numeric">1.13</td>
+			<td colspan=5 class="o-table-footnote">
+				Source: The Origami team's love of fruit.
+			</td>
 		</tr>
-		<tr>
-			<td>stilton</td>
-			<td>wholemeal</td>
-			<td data-o-table-data-type="numeric" class="o-table__cell--numeric">2</td>
-			<td data-o-table-data-type="numeric" class="o-table__cell--numeric">2.25</td>
-		</tr>
-		<tr>
-			<td>red leicester</td>
-			<td>white</td>
-			<td data-o-table-data-type="numeric" class="o-table__cell--numeric">3</td>
-			<td data-o-table-data-type="numeric" class="o-table__cell--numeric"></td>
-		</tr>
-		<tr>
-			<td>gruyère</td>
-			<td>sourdough</td>
-			<td data-o-table-data-type="numeric" class="o-table__cell--numeric">7</td>
-			<td data-o-table-data-type="numeric" class="o-table__cell--numeric">7.89</td>
-		</tr>
-	</tbody>
+	</tfoot>
+    <thead>
+        <tr>
+            <th scope="col" role="columnheader">Fruit</th>
+            <th scope="col" role="columnheader">Genus</th>
+            <th scope="col" role="columnheader">Characteristic</th>
+            <th scope="col" role="columnheader" data-o-table-data-type="numeric" class="o-table__cell--numeric">Cost&nbsp;(GBP)</th>
+            <th scope="col" role="columnheader" data-o-table-data-type="numeric" class="o-table__cell--numeric">Cost&nbsp;(EUR)</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>Dragonfruit</td>
+            <td>Stenocereus</td>
+            <td>Juicy</td>
+            <td class="o-table__cell--numeric">3</td>
+            <td class="o-table__cell--numeric">2.72</td>
+        </tr>
+        <tr>
+            <td>Durian</td>
+            <td>Durio</td>
+            <td>Smelly</td>
+            <td class="o-table__cell--numeric">1.75</td>
+            <td class="o-table__cell--numeric">1.33</td>
+        </tr>
+        <tr>
+            <td>Naseberry</td>
+            <td>Manilkara</td>
+            <td>Chewy</td>
+            <td class="o-table__cell--numeric">2</td>
+            <td class="o-table__cell--numeric">1.85</td>
+        </tr>
+        <tr>
+            <td>Strawberry</td>
+            <td>Fragaria</td>
+            <td>Sweet</td>
+            <td class="o-table__cell--numeric">1.5</td>
+            <td class="o-table__cell--numeric">1.69</td>
+        </tr>
+        <tr>
+            <td>Apple</td>
+            <td>Malus</td>
+            <td>Crunchy</td>
+            <td class="o-table__cell--numeric">0.5</td>
+            <td class="o-table__cell--numeric">0.56</td>
+        </tr>
+    </tbody>
 </table>
 
-<table class="o-table" data-o-component="o-table">
-	<caption class="o-table__caption--top">
-		Top caption (default)
-	</caption>
-	<caption class="o-table__caption--bottom">
-		Bottom caption
-	</caption>
-	<tr>
-		<th>Heading</th>
-		<th>Heading</th>
-		<th data-o-table-data-type="numeric" class="o-table__cell--numeric">Heading</th>
-		<th data-o-table-data-type="numeric" class="o-table__cell--numeric">Heading</th>
-	</tr>
-	<tr>
-		<td>text data</td>
-		<td>text data</td>
-		<td data-o-table-data-type="numeric" class="o-table__cell--numeric">123</td>
-		<td data-o-table-data-type="numeric" class="o-table__cell--numeric">123.45</td>
-	</tr>
-	<tr>
-		<td>text data</td>
-		<td>text data</td>
-		<td data-o-table-data-type="numeric" class="o-table__cell--numeric">22</td>
-		<td data-o-table-data-type="numeric" class="o-table__cell--numeric">22.2</td>
-	</tr>
-	<tr>
-		<td>text data</td>
-		<td>text data</td>
-		<td data-o-table-data-type="numeric" class="o-table__cell--numeric">3</td>
-		<td data-o-table-data-type="numeric" class="o-table__cell--numeric">3.0</td>
-	</tr>
-</table>
-
-<table class="o-table o-table--responsive-flat" data-o-component="o-table" data-o-table-responsive="flat">
-	<thead>
+<table class="o-table o-table--horizontal-lines" data-o-component="o-table">
+	<tfoot>
 		<tr>
-			<th>Cheese</th>
-			<th>Bread</th>
-			<th data-o-table-data-type="numeric" class="o-table__cell--numeric">Cost (GBP)</th>
-			<th data-o-table-data-type="numeric" class="o-table__cell--numeric">Cost (EUR)</th>
-			<th>Taste Note</th>
+			<td colspan=5 class="o-table-footnote">
+				Source: The Origami team's love of fruit.
+			</td>
 		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>cheddar</td>
-			<td>rye</td>
-			<td data-o-table-data-type="numeric" class="o-table__cell--numeric">1</td>
-			<td data-o-table-data-type="numeric" class="o-table__cell--numeric">1.56</td>
-			<td>sharp</td>
-		</tr>
-		<tr>
-			<td>stilton</td>
-			<td>wholemeal</td>
-			<td data-o-table-data-type="numeric" class="o-table__cell--numeric">2</td>
-			<td data-o-table-data-type="numeric" class="o-table__cell--numeric">1.85</td>
-			<td>strong</td>
-		</tr>
-		<tr>
-			<td>red leicester</td>
-			<td>white</td>
-			<td data-o-table-data-type="numeric" class="o-table__cell--numeric">3</td>
-			<td data-o-table-data-type="numeric" class="o-table__cell--numeric">2.72</td>
-			<td>sweet</td>
-		</tr>
-		<tr>
-			<td>gruyère</td>
-			<td>sourdough</td>
-			<td data-o-table-data-type="numeric" class="o-table__cell--numeric">7</td>
-			<td data-o-table-data-type="numeric" class="o-table__cell--numeric">7.89</td>
-			<td>blue</td>
-		</tr>
-	</tbody>
-</table>
-
-<table class="o-table o-table--responsive-overflow o-table--row-stripes" data-o-component="o-table">
-	<thead>
-		<tr>
-			<th>Cheese</th>
-			<th>Bread</th>
-			<th data-o-table-data-type="numeric" class="o-table__cell--numeric">Cost (GBP)</th>
-			<th data-o-table-data-type="numeric" class="o-table__cell--numeric">Cost (EUR)</th>
-			<th>Taste Note</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>cheddar</td>
-			<td>rye</td>
-			<td data-o-table-data-type="numeric" class="o-table__cell--numeric">1</td>
-			<td data-o-table-data-type="numeric" class="o-table__cell--numeric">1.56</td>
-			<td>sharp</td>
-		</tr>
-		<tr>
-			<td>stilton</td>
-			<td>wholemeal</td>
-			<td data-o-table-data-type="numeric" class="o-table__cell--numeric">2</td>
-			<td data-o-table-data-type="numeric" class="o-table__cell--numeric">1.85</td>
-			<td>strong</td>
-		</tr>
-		<tr>
-			<td>red leicester</td>
-			<td>white</td>
-			<td data-o-table-data-type="numeric" class="o-table__cell--numeric">3</td>
-			<td data-o-table-data-type="numeric" class="o-table__cell--numeric">2.72</td>
-			<td>sweet</td>
-		</tr>
-		<tr>
-			<td>gruyère</td>
-			<td>sourdough</td>
-			<td data-o-table-data-type="numeric" class="o-table__cell--numeric">7</td>
-			<td data-o-table-data-type="numeric" class="o-table__cell--numeric">7.89</td>
-			<td>blue</td>
-		</tr>
-	</tbody>
-</table>
-
-<table class="o-table o-table--responsive-scroll" data-o-component="o-table">
-	<thead>
-		<tr>
-			<th>Cheese</th>
-			<th>Bread</th>
-			<th data-o-table-data-type="numeric" class="o-table__cell--numeric">Cost (GBP)</th>
-			<th data-o-table-data-type="numeric" class="o-table__cell--numeric">Cost (EUR)</th>
-			<th>Taste Note</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>cheddar</td>
-			<td>rye</td>
-			<td data-o-table-data-type="numeric" class="o-table__cell--numeric">1</td>
-			<td data-o-table-data-type="numeric" class="o-table__cell--numeric">1.56</td>
-			<td>sharp</td>
-		</tr>
-		<tr>
-			<td>stilton</td>
-			<td>wholemeal</td>
-			<td data-o-table-data-type="numeric" class="o-table__cell--numeric">2</td>
-			<td data-o-table-data-type="numeric" class="o-table__cell--numeric">1.85</td>
-			<td>strong</td>
-		</tr>
-		<tr>
-			<td>red leicester</td>
-			<td>white</td>
-			<td data-o-table-data-type="numeric" class="o-table__cell--numeric">3</td>
-			<td data-o-table-data-type="numeric" class="o-table__cell--numeric">2.72</td>
-			<td>sweet</td>
-		</tr>
-		<tr>
-			<td>cheddar</td>
-			<td>rye</td>
-			<td data-o-table-data-type="numeric" class="o-table__cell--numeric">1</td>
-			<td data-o-table-data-type="numeric" class="o-table__cell--numeric">1.56</td>
-			<td>sharp</td>
-		</tr>
-		<tr>
-			<td>stilton</td>
-			<td>wholemeal</td>
-			<td data-o-table-data-type="numeric" class="o-table__cell--numeric">2</td>
-			<td data-o-table-data-type="numeric" class="o-table__cell--numeric">1.85</td>
-			<td>strong</td>
-		</tr>
-		<tr>
-			<td>red leicester</td>
-			<td>white</td>
-			<td data-o-table-data-type="numeric" class="o-table__cell--numeric">3</td>
-			<td data-o-table-data-type="numeric" class="o-table__cell--numeric">2.72</td>
-			<td>sweet</td>
-		</tr>
-		<tr>
-			<td>gruyère</td>
-			<td>sourdough</td>
-			<td data-o-table-data-type="numeric" class="o-table__cell--numeric">7</td>
-			<td data-o-table-data-type="numeric" class="o-table__cell--numeric">7.89</td>
-			<td>blue</td>
-		</tr>
-	</tbody>
+	</tfoot>
+    <thead>
+        <tr>
+            <th scope="col" role="columnheader">Fruit</th>
+            <th scope="col" role="columnheader">Genus</th>
+            <th scope="col" role="columnheader">Characteristic</th>
+            <th scope="col" role="columnheader" data-o-table-data-type="numeric" class="o-table__cell--numeric">Cost&nbsp;(GBP)</th>
+            <th scope="col" role="columnheader" data-o-table-data-type="numeric" class="o-table__cell--numeric">Cost&nbsp;(EUR)</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>Dragonfruit</td>
+            <td>Stenocereus</td>
+            <td>Juicy</td>
+            <td class="o-table__cell--numeric">3</td>
+            <td class="o-table__cell--numeric">2.72</td>
+        </tr>
+        <tr>
+            <td>Durian</td>
+            <td>Durio</td>
+            <td>Smelly</td>
+            <td class="o-table__cell--numeric">1.75</td>
+            <td class="o-table__cell--numeric">1.33</td>
+        </tr>
+        <tr>
+            <td>Naseberry</td>
+            <td>Manilkara</td>
+            <td>Chewy</td>
+            <td class="o-table__cell--numeric">2</td>
+            <td class="o-table__cell--numeric">1.85</td>
+        </tr>
+        <tr>
+            <td>Strawberry</td>
+            <td>Fragaria</td>
+            <td>Sweet</td>
+            <td class="o-table__cell--numeric">1.5</td>
+            <td class="o-table__cell--numeric">1.69</td>
+        </tr>
+        <tr>
+            <td>Apple</td>
+            <td>Malus</td>
+            <td>Crunchy</td>
+            <td class="o-table__cell--numeric">0.5</td>
+            <td class="o-table__cell--numeric">0.56</td>
+        </tr>
+    </tbody>
 </table>

--- a/main.scss
+++ b/main.scss
@@ -9,7 +9,6 @@ $o-table-is-silent: true !default;
 @import "o-typography/main";
 @import "o-visual-effects/main";
 // Branding
-@import "src/scss/variables";
 @import "src/scss/brand";
 // Main
 @import "src/scss/base";
@@ -27,7 +26,7 @@ $o-table-is-silent: true !default;
 @import "src/scss/wrapper";
 
 @if ($o-table-is-silent == false) {
-	@include oTableAll;
+	@include oTable();
 
 	// Set table to silent again to avoid being output twice
 	$o-table-is-silent: true !global;

--- a/origami.json
+++ b/origami.json
@@ -19,10 +19,8 @@
 	},
 	"browserFeatures": {
 		"required": [
-			"Element.prototype.matches",
 			"IntersectionObserver",
-			"IntersectionObserverEntry",
-			"Array.prototype.findIndex"
+			"IntersectionObserverEntry"
 		]
 	},
 	"demosDefaults": {

--- a/src/js/Sort/CellFormatter.js
+++ b/src/js/Sort/CellFormatter.js
@@ -141,7 +141,7 @@ function extractNumberFromRange(text) {
  * @returns {Number} Number representation of date and/or time for sorting.
  */
 function ftDateTimeToNumber(text) {
-	const months = ['January','February','March','April','May','June','July','August','September','October','November','December'];
+	const monthNames = ['January','February','March','April','May','June','July','August','September','October','November','December'];
 	// FT style for writing dates: is June 23 2016 (no commas, month date year)
 	const date = text.match(/^([A-Za-z]{3,})(?:[\s])(?=[\d])((?:\d{1,2})?(?![\d]))?(?:\s)?(\d{4})?/);
 	// FT style for writing time:
@@ -149,7 +149,10 @@ function ftDateTimeToNumber(text) {
 	const time = text.match(/(?:\s|^)(\d{1,2}(?:[.](\d{2}))?)(pm|am)$/);
 	// Get date.
 	const month = date && date[1] ? date[1] : null;
-	const monthIndex = month ? months.findIndex((name) => name.indexOf(month) !== -1) : null;
+	// Get full month name from a given month e.g. 'January' for 'Jan'.
+	const matchingMonthNames = monthNames.filter((name) => name.indexOf(month) !== -1);
+	// Get the index of the matching month name.
+	const monthIndex = matchingMonthNames && matchingMonthNames[0] ? monthNames.indexOf(matchingMonthNames[0]) : null;
 	const day = date && date[2] ? parseInt(date[2], 10) : null;
 	let year = date && date[3] ? parseInt(date[3], 10) : null;
 	if (month && !year) {

--- a/src/scss/_base.scss
+++ b/src/scss/_base.scss
@@ -1,5 +1,6 @@
 /// Base tables styles and simple utility classes.
-@mixin oTableBase() {
+/// @access private
+@mixin _oTableBase() {
 	.o-table {
 		border-collapse: collapse;
 		border-spacing: 0;

--- a/src/scss/_borders.scss
+++ b/src/scss/_borders.scss
@@ -1,5 +1,5 @@
 /// Horizontal borders
-@mixin oTableHorizontalBorders {
+@mixin _oTableHorizontalBorders {
 	.o-table--horizontal-borders {
 		border-bottom: 1px solid _oTableGet('table-border-color');
 		border-top: 1px solid _oTableGet('table-border-color');
@@ -11,7 +11,7 @@
 }
 
 /// Vertical borders
-@mixin oTableVerticalBorders {
+@mixin _oTableVerticalBorders {
 	.o-table--vertical-borders {
 		border-left: 1px solid _oTableGet('table-border-color');
 		border-right: 1px solid _oTableGet('table-border-color');

--- a/src/scss/_borders.scss
+++ b/src/scss/_borders.scss
@@ -1,4 +1,5 @@
 /// Horizontal borders
+/// @access private
 @mixin _oTableHorizontalBorders {
 	.o-table--horizontal-borders {
 		border-bottom: 1px solid _oTableGet('table-border-color');

--- a/src/scss/_borders.scss
+++ b/src/scss/_borders.scss
@@ -12,6 +12,7 @@
 }
 
 /// Vertical borders
+/// @access private
 @mixin _oTableVerticalBorders {
 	.o-table--vertical-borders {
 		border-left: 1px solid _oTableGet('table-border-color');

--- a/src/scss/_compact.scss
+++ b/src/scss/_compact.scss
@@ -1,5 +1,6 @@
 /// Make a table 'compact'
-@mixin oTableCompact {
+/// @access private
+@mixin _oTableCompact {
 	.o-table--compact {
 		th {
 			@include oTypographySansBold(0);

--- a/src/scss/_container.scss
+++ b/src/scss/_container.scss
@@ -1,10 +1,10 @@
 /// Styles for a table container, the parent of all other table elements.
 /// Enables child overlays such as to indicate the ability to scroll a table.
 /// Includes standard table margin.
-@mixin oTableContainer {
+/// @access private
+@mixin _oTableContainer {
 	.o-table-container {
 		position: relative;
-		margin-bottom: 20px;
 	}
 	// Leave space for controls such as "show more" when expanded/contracted.
 	.o-table-container--expanded,

--- a/src/scss/_lines.scss
+++ b/src/scss/_lines.scss
@@ -1,5 +1,5 @@
 /// Add horizontal lines to a table
-@mixin oTableHorizontalLines {
+@mixin _oTableHorizontalLines {
 	.o-table--horizontal-lines {
 		tr:not(:first-child) {
 			border-top: 1px solid _oTableGet('table-border-color');
@@ -9,7 +9,7 @@
 
 
 /// Add verticle lines to a table
-@mixin oTableVerticalLines {
+@mixin _oTableVerticalLines {
 	.o-table--vertical-lines {
 		th:not(:last-child):not(:first-child),
 		td:not(:last-child):not(:first-child) {

--- a/src/scss/_lines.scss
+++ b/src/scss/_lines.scss
@@ -1,4 +1,5 @@
 /// Add horizontal lines to a table
+/// @access private
 @mixin _oTableHorizontalLines {
 	.o-table--horizontal-lines {
 		tr:not(:first-child) {

--- a/src/scss/_lines.scss
+++ b/src/scss/_lines.scss
@@ -10,6 +10,7 @@
 
 
 /// Add verticle lines to a table
+/// @access private
 @mixin _oTableVerticalLines {
 	.o-table--vertical-lines {
 		th:not(:last-child):not(:first-child),

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -1,5 +1,6 @@
 /// Outputs all features and styles available.
 /// @param $opts {list} [('responsive-overflow', 'responsive-flat', 'responsive-scroll', 'lines', 'compact', 'stripes', 'row-headings')] - Table features to output. Defaults to all table features.
+/// @access public
 @mixin oTable($opts: (
 	'responsive-overflow',
 	'responsive-flat',

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -1,36 +1,63 @@
 /// Outputs all features and styles available.
-@mixin oTableAll() {
+/// @param $opts {list} [('responsive-overflow', 'responsive-flat', 'responsive-scroll', 'lines', 'compact', 'stripes', 'row-headings')] - Table features to output. Defaults to all table features.
+@mixin oTable($opts: (
+	'responsive-overflow',
+	'responsive-flat',
+	'responsive-scroll',
+	'lines',
+	'compact',
+	'stripes',
+	'row-headings',
+)) {
+	$overflow-enabled: index($opts, 'responsive-overflow');
+	$flat-enabled: index($opts, 'responsive-flat');
+	$scroll-enabled: index($opts, 'responsive-scroll');
+	$lines-enabled: index($opts, 'lines');
+	$compact-enabled: index($opts, 'compact');
+	$stripes-enabled: index($opts, 'stripes');
+	$row-headings-enabled: index($opts, 'row-headings');
+
 	// Basic styles and simple utilities.
-	@include oTableBase;
+	@include _oTableBase;
 
 	// Sortable columns.
-	@include oTableSort;
+	@include _oTableSort;
 
 	// Respnsive solutions.
-	@include oTableWrapper;
-	@include oTableContainer;
-	@include oTableResponsiveOverflow;
-	@include oTableResponsiveFlat;
-	@include oTableResponsiveScroll;
+	@if $flat-enabled or $scroll-enabled or $overflow-enabled {
+		@include _oTableWrapper;
+		@include _oTableContainer;
+	}
+	@if $overflow-enabled {
+		@include _oTableResponsiveOverflow;
+	}
+	@if $flat-enabled {
+		@include _oTableResponsiveFlat;
+	}
+	@if $scroll-enabled {
+		@include _oTableResponsiveScroll;
+	}
 
 	// Lines.
-	@include oTableHorizontalLines;
-	@include oTableVerticalLines;
-	@include oTableHorizontalBorders;
-	@include oTableVerticalBorders;
+	@if $lines-enabled {
+		@include _oTableHorizontalLines;
+		@include _oTableVerticalLines;
+		@include _oTableHorizontalBorders;
+		@include _oTableVerticalBorders;
+	}
 
 	// Compact.
-	@if _oTableSupports('compact') {
-		@include oTableCompact;
+	@if $compact-enabled and _oTableSupports('compact') {
+		@include _oTableCompact;
 	}
 
 	// Stripes.
-	@if _oTableSupports('stripes') {
-		@include oTableRowStripes;
+	@if $stripes-enabled and _oTableSupports('stripes') {
+		@include _oTableRowStripes;
 	}
 
 	// Row headings.
-	@if _oTableSupports('row-headings') {
-		@include oTableRowHeadings;
+	@if $row-headings-enabled and _oTableSupports('row-headings') {
+		@include _oTableRowHeadings;
 	}
 }

--- a/src/scss/_responsive-flat.scss
+++ b/src/scss/_responsive-flat.scss
@@ -1,5 +1,6 @@
 /// Styles for a 'FlatTable'
-@mixin oTableResponsiveFlat {
+/// @access private
+@mixin _oTableResponsiveFlat {
 	.o-table.o-table--responsive-flat {
 		width: 100%;
 

--- a/src/scss/_responsive-overflow.scss
+++ b/src/scss/_responsive-overflow.scss
@@ -1,7 +1,8 @@
 /// Styles for an 'OverflowTable'
-/// @require oTableContainer
-/// @require oTableWrapper
-@mixin oTableResponsiveOverflow {
+/// @require _oTableContainer
+/// @require _oTableWrapper
+/// @access private
+@mixin _oTableResponsiveOverflow {
 	@include _oTableOverflowControlsOverlay;
 	@include _oTableOverflowFadeOverlay;
 }

--- a/src/scss/_responsive-scroll.scss
+++ b/src/scss/_responsive-scroll.scss
@@ -1,5 +1,6 @@
 /// Styles for a 'ScrollTable'
-@mixin oTableResponsiveScroll {
+/// @access private
+@mixin _oTableResponsiveScroll {
 	.o-table--responsive-scroll {
 
 		.o-table__duplicate-row {

--- a/src/scss/_row-headings.scss
+++ b/src/scss/_row-headings.scss
@@ -1,6 +1,7 @@
-//// @brand internal
-//// @outputs Highlights table headings.
-@mixin oTableRowHeadings() {
+/// @brand internal
+/// @outputs Highlights table headings.
+/// @access private
+@mixin _oTableRowHeadings() {
 	.o-table--row-headings > tbody th {
 		background-color: _oTableGet('table-alternate-background');
 		border-right: 2px solid _oTableGet('table-data-color');

--- a/src/scss/_row-stripes.scss
+++ b/src/scss/_row-stripes.scss
@@ -1,5 +1,6 @@
 /// Add this to the table element to get row stripes
-@mixin oTableRowStripes() {
+/// @access private
+@mixin _oTableRowStripes() {
 	.o-table--row-stripes {
 		background-color: _oTableGet('table-background');
 

--- a/src/scss/_sort.scss
+++ b/src/scss/_sort.scss
@@ -1,5 +1,6 @@
 /// Tables styles to support sort buttons.
-@mixin oTableSort {
+/// @access private
+@mixin _oTableSort {
 
 	.o-table--sortable thead th:not([data-o-table-heading-disable-sort]) {
 		padding-right: 0; // No header padding with a child sort icon.

--- a/src/scss/_wrapper.scss
+++ b/src/scss/_wrapper.scss
@@ -1,6 +1,7 @@
 /// Styles for a table wrapper to allow table to overflow.
 /// The wrapped table becomes scrollable on small viewports.
-@mixin oTableWrapper {
+/// @access private
+@mixin _oTableWrapper {
 	.o-table-scroll-wrapper {
 		overflow-y: hidden;
 		overflow-x: auto;

--- a/src/scss/variables.scss
+++ b/src/scss/variables.scss
@@ -1,1 +1,0 @@
-$_o-table-bottom-margin: 20px;


### PR DESCRIPTION
- Make all mixins except `oTable` private -- accepts a feature flags in an `$opts` argument.
- Removes the default bottom margin, so the margin can be added or not according to the context of the table.
- Update the pa11y demo.
- Update the cell formatter to avoid the "Array.prototype.findIndex" polyfill.

Please review the readme carefully to make sure it all makes sense. :D