### PR TITLE
Use dom-delegate for column sort buttons.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,7 +7,8 @@
     "o-typography": "^5.0.0",
     "o-brand": "^3.1.1",
     "o-visual-effects": "^2.0.3",
-    "o-buttons": "^5.14.0"
+    "o-buttons": "^5.14.0",
+    "dom-delegate": "ftdomdelegate#^2.2.0"
   },
   "main": [
     "main.scss",

--- a/src/js/Tables/BaseTable.js
+++ b/src/js/Tables/BaseTable.js
@@ -95,7 +95,7 @@ class BaseTable {
 			th.appendChild(sortButton);
 			// Add click event to buttons.
 			const listener = this._sortButtonHandler.bind(this);
-			this._rootElDomDelegate.on('click', '.o-table__sort', listener)
+			this._rootElDomDelegate.on('click', '.o-table__sort', listener);
 		}.bind(this));
 	}
 


### PR DESCRIPTION
So there is only one listener for all column sort buttons.

There are still individual event listeners for controls in the table (optional) wrapper, but they won't increase with the number of columns.