### PR TITLE
Export default from oTable

### DIFF
--- a/src/js/oTable.js
+++ b/src/js/oTable.js
@@ -102,4 +102,4 @@ class OTable {
 	}
 }
 
-module.exports = OTable;
+export default OTable;


### PR DESCRIPTION
this should have no drawback, as the babel transform used by the build
service does the magic to make Object.is(module.exports,
module.exports.default)