### PR TITLE
Prevent expanded table button obscuring table content.

### DIFF
--- a/src/scss/_container.scss
+++ b/src/scss/_container.scss
@@ -1,14 +1,16 @@
 /// Styles for a table container, the parent of all other table elements.
 /// Enables child overlays such as to indicate the ability to scroll a table.
-/// Includes standard table margin.
+/// @param {Bool} $expandable [false] - Set to true to output expanded/contracted container modifiers.
 /// @access private
-@mixin _oTableContainer {
+@mixin _oTableContainer($expandable: false) {
 	.o-table-container {
 		position: relative;
 	}
 	// Leave space for controls such as "show more" when expanded/contracted.
-	.o-table-container--expanded,
-	.o-table-container--contracted {
-		padding-bottom: 40px;
+	@if $expandable {
+		.o-table-container--expanded .o-table,
+		.o-table-container--contracted .o-table {
+			margin-bottom: 40px;
+		}
 	}
 }

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -27,7 +27,7 @@
 	// Respnsive solutions.
 	@if $flat-enabled or $scroll-enabled or $overflow-enabled {
 		@include _oTableWrapper;
-		@include _oTableContainer;
+		@include _oTableContainer($expandable: $overflow-enabled);
 	}
 	@if $overflow-enabled {
 		@include _oTableResponsiveOverflow;


### PR DESCRIPTION
The "overflow" responsive table has a bottom margin on its container when expanding is enabled. This is a bug, the margin should have been applied to the table within to ensure the "show more / show fewer" button doesn't obscure table data.

Fixes: https://github.com/Financial-Times/o-table/issues/124