### PR TITLE
doc: remove mutually exclusive classnames

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,9 @@ To enable these set `data-o-table-responsive` to the type of responsive table de
 <div class="o-table-container">
 	<div class="o-table-overlay-wrapper">
 		<div class="o-table-scroll-wrapper">
-			<table class="o-table o-table--horizontal-lines o-table--responsive-overflow o-table--responsive-flat" data-o-component="o-table" data-o-table-responsive="overflow">
+			<table class="o-table o-table--horizontal-lines o-table--responsive-overflow"
+			data-o-component="o-table"
+			data-o-table-responsive="overflow">
 				...
 			</table>
 		</div>
@@ -146,7 +148,7 @@ The "overflow" style of responsive table ([see above](#responsive-options)) supp
 <div class="o-table-container">
 	<div class="o-table-overlay-wrapper">
 		<div class="o-table-scroll--wrapper">
-			<table class="o-table o-table--horizontal-lines o-table--responsive-overflow o-table--responsive-flat"
+			<table class="o-table o-table--horizontal-lines o-table--responsive-overflow"
 			data-o-component="o-table"
 			data-o-table-responsive="overflow"
 			data-o-table-expanded="false"


### PR DESCRIPTION
Responsive-overflow and responsive-flat are mutually exclusive so we shouldn't apply both classnames at the same time in the same table.