### PR TITLE
Support non-interactive, phrasing content in column sort buttons.

### DIFF
--- a/demos/src/sorting.mustache
+++ b/demos/src/sorting.mustache
@@ -5,14 +5,14 @@
 				<tr>
 					<th scope="col" role="columnheader">Links</th>
 					<th scope="col" role="columnheader" data-o-table-data-type="date">Date</th>
-					<th scope="col" role="columnheader" data-o-table-data-type="date">Abbreviated&nbsp;Date</th>
+					<th scope="col" role="columnheader" data-o-table-data-type="date"><abbr title="Abbreviated">ABBR</abbr>&nbsp;Date</th>
 					<th scope="col" role="columnheader" data-o-table-data-type="date">Date&nbsp;&amp;&nbsp;Time</th>
 					<th scope="col" role="columnheader" data-o-table-data-type="date">Time</th>
 					<th scope="col" role="columnheader" data-o-table-data-type="number">Formatted&nbsp;numbers</th>
-					<th scope="col" role="columnheader" data-o-table-data-type="number">Abbreviated&nbsp;numbers</th>
+					<th scope="col" role="columnheader" data-o-table-data-type="number"><abbr title="Abbreviated">ABBR</abbr>&nbsp;numbers</th>
 					<th scope="col" role="columnheader" data-o-table-data-type="number">Ranged&nbsp;numbers</th>
 					<th scope="col" role="columnheader" data-o-table-data-type="currency">Ranged&nbsp;currency</th>
-					<th scope="col" role="columnheader" data-o-table-data-type="currency">Abbreviated&nbsp;currency</th>
+					<th scope="col" role="columnheader" data-o-table-data-type="currency"><abbr title="Abbreviated">ABBR</abbr>&nbsp;currency</th>
 					<th scope="col" role="columnheader" data-o-table-data-type="percent">Percentage</th>
 					<!-- do not show the actions column as sortable -->
 					<th scope="col" role="columnheader" data-o-table-heading-disable-sort>Actions</th>

--- a/src/js/Tables/BaseTable.js
+++ b/src/js/Tables/BaseTable.js
@@ -85,12 +85,24 @@ class BaseTable {
 			}
 			// Move heading text into button.
 			const sortButton = document.createElement('button');
-			const heading = th.textContent;
-			sortButton.textContent = heading;
+			const headingNodes = Array.from(th.childNodes);
+			const headingHTML = headingNodes.reduce((html, node) => {
+				// Maintain child elements of the heading which make sense in a button.
+				const maintainedElements = ['ABBR', 'B', 'BDI', 'BDO', 'BR', 'CODE', 'CITE', 'DATA', 'DFN', 'DEL', 'EM', 'I', 'S', 'SMALL', 'SPAN', 'STRONG', 'SUB', 'SUP', 'TIME', 'U', 'VAR', 'WBR'];
+				if (node.nodeType === Node.ELEMENT_NODE && maintainedElements.includes(node.nodeName)) {
+					return html + node.outerHTML;
+				}
+				// Otherwise return text content.
+				if (node.nodeType === Node.ELEMENT_NODE) {
+					console.warn(`o-table has removed the element "${node.nodeName}" from the table heading to add a sort button on the column. Please remove this element from your table heading, disable sort on this column, or contact the Origami team for help.`, th);
+				}
+				return html + node.textContent;
+			}, '');
+			sortButton.innerHTML = headingHTML;
 			// In VoiceOver, button `aria-label` is repeated when moving from one column of tds to the next.
 			// Using `title` avoids this, but risks not being announced by other screen readers.
 			sortButton.classList.add('o-table__sort');
-			sortButton.setAttribute('title', `sort table by ${heading}`);
+			sortButton.setAttribute('title', `sort table by ${th.innerText}`);
 			th.innerHTML = '';
 			th.appendChild(sortButton);
 			// Add click event to buttons.

--- a/test/BaseTable.test.js
+++ b/test/BaseTable.test.js
@@ -45,6 +45,32 @@ describe("BaseTable", () => {
 			}, 100);
 		});
 
+		it('maintains heading phrasing content within generated sort buttons', done => {
+			// https://html.spec.whatwg.org/#the-button-element
+			sandbox.init();
+			sandbox.setContents(fixtures.tableWithContainerAndComplexHeadings);
+			oTableEl = document.querySelector('[data-o-component=o-table]');
+			table = new BaseTable(oTableEl, sorter);
+			table.addSortButtons();
+
+			setTimeout(() => {
+				try {
+					const thead = oTableEl.querySelector('thead');
+					const sortButtons = thead.querySelectorAll('button');
+					// `abbr` has been maintained
+					proclaim.equal(sortButtons[0].innerHTML, '<abbr title="Fruit">F</abbr>');
+					// `b` has been maintained
+					proclaim.equal(sortButtons[1].innerHTML, '<b>Genus</b>');
+					// `div` has been removed
+					proclaim.equal(sortButtons[2].innerHTML, 'Characteristic');
+				} catch (error) {
+					done(error);
+				} finally {
+					done();
+				}
+			}, 100);
+		});
+
 		it('does not add sort button to column header with attribute "data-o-table-heading-disable-sort"', done => {
 			const thead = oTableEl.querySelector('thead');
 			// Disable sort on first column.

--- a/test/helpers/fixtures.js
+++ b/test/helpers/fixtures.js
@@ -252,8 +252,38 @@ const shortTableWithContainer = `
 	</div>
 </div>
 `;
+const tableWithContainerAndComplexHeadings = `
+<div class="o-table-container">
+	<div class="o-table-overlay-wrapper">
+		<div class="o-table-scroll-wrapper">
+			<table class="o-table" data-o-component="o-table">
+				<thead>
+					<tr>
+						<th scope="col" role="columnheader"><abbr title="Fruit">F</abbr></th>
+						<th scope="col" role="columnheader"><b>Genus</b></th>
+						<th scope="col" role="columnheader"><div>Characteristic</div></th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<td>Dragonfruit</td>
+						<td>Stenocereus</td>
+						<td>Juicy</td>
+					</tr>
+					<tr>
+						<td>Durian</td>
+						<td>Durio</td>
+						<td>Smelly</td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+	</div>
+</div>
+`;
 
 export {
 	longTableWithContainer,
 	shortTableWithContainer,
+	tableWithContainerAndComplexHeadings,
 };


### PR DESCRIPTION
o-table takes text content from column headings and puts it within a sort button. However this removes elements like `abbr` which should be maintained. More details here: https://github.com/Financial-Times/o-table/issues/132

This PR maintains a whitelist of child elements to keep when creating the sort button. All elements within the whitelist are valid within a button. That is [phrasing content](https://html.spec.whatwg.org/#phrasing-content-2) which is not [interactive content](https://html.spec.whatwg.org/#interactive-content-2). With some exceptions, which either don't feel relevant for a table heading or require more thought (mark, slots, autonomous custom elements) -- we might want to allow them in the future.