### PR TITLE
Changes weird mix of CJS and ESM to just ESM

### DIFF
--- a/src/js/oTable.js
+++ b/src/js/oTable.js
@@ -102,4 +102,4 @@ class OTable {
 	}
 }
 
-module.exports = OTable;
+export default OTable;


### PR DESCRIPTION
Mixing CJS and ESM was causing Webpack issues, with the latter saying `module.exports` is immutable. It may be a new thing in modern Webpack.

N.b., I haven't tested this with OBT but my feeling is that it shouldn't be breaking given oTable.js is imported via its `default` export in `main.js`.

Additionally: is there any appetite to get rid of [`babel-plugin-add-module-exports`](https://github.com/59naga/babel-plugin-add-module-exports) in OBT, which is unsupported and encourages non-standard module use? Making Webpack/Babel behaviour more prosaic would help facilitate implementing Origami outside the Build Service, such as we frequently do on IG. Could probably be done as a non-breaking change in most modules, happy to help.