### PR TITLE
Improve sort and expander performance.

### DIFF
--- a/src/js/Sort/CellFormatter.js
+++ b/src/js/Sort/CellFormatter.js
@@ -284,10 +284,10 @@ class CellFormatter {
 	 */
 	formatCell({ cell, type = 'text' }) {
 		type = type || 'text';
-		let cellClone = cell.cloneNode({ deep: true });
 		let sortValue = cell.getAttribute('data-o-table-sort-value');
 		if (sortValue === null) {
 			if (this.filters[type]) {
+				let cellClone = cell.cloneNode({ deep: true });
 				sortValue = cellClone;
 				this.filters[type].forEach(fn => { sortValue = fn(sortValue); });
 			}

--- a/src/js/Tables/OverflowTable.js
+++ b/src/js/Tables/OverflowTable.js
@@ -20,6 +20,7 @@ class OverflowTable extends BaseTable {
 			expanded: this.rootEl.hasAttribute('data-o-table-expanded') ? this.rootEl.getAttribute('data-o-table-expanded') !== 'false' : null,
 			minimumRowCount: this.rootEl.getAttribute('data-o-table-minimum-row-count')
 		}, this._opts);
+		this._opts.sortBatchNumber = this._opts.minimumRowCount && !this._opts.expanded ? parseInt(this._opts.minimumRowCount, 10) + 5 : null;
 		window.requestAnimationFrame(this.addSortButtons.bind(this));
 		window.requestAnimationFrame(this._setupScroll.bind(this));
 		window.requestAnimationFrame(this._setupExpander.bind(this));
@@ -256,6 +257,7 @@ class OverflowTable extends BaseTable {
 			this._setScrollPosition();
 			this._updateControls();
 		}.bind(this);
+
 		updateScroll();
 
 		// Observe controls scrolling beyond table and update.
@@ -323,9 +325,9 @@ class OverflowTable extends BaseTable {
 		}
 
 		if (this._opts.expanded){
-			this.expandTable();
+			window.requestAnimationFrame(this.expandTable.bind(this));
 		} else {
-			this.contractTable();
+			window.requestAnimationFrame(this.contractTable.bind(this));
 		}
 	}
 

--- a/src/scss/_base.scss
+++ b/src/scss/_base.scss
@@ -17,6 +17,8 @@
 			text-align: left;
 			vertical-align: top;
 			color: _oTableGet('table-data-color');
+			min-width: 3ch; // helps prevent some layout updates
+			box-sizing: border-box;
 		}
 
 		th {

--- a/src/scss/_sort.scss
+++ b/src/scss/_sort.scss
@@ -1,9 +1,10 @@
 /// Tables styles to support sort buttons.
 /// @access private
 @mixin _oTableSort {
+	$_o-table-sort-icon-size: 1.25rem;
 
 	.o-table:not([data-o-table-sortable="false"]) thead th:not([data-o-table-heading-disable-sort]) {
-		padding-right: 20px;
+		padding-right: $_o-table-sort-icon-size;
 		min-width: 60px;
 	}
 
@@ -18,24 +19,27 @@
 		background: none;
 		color: inherit;
 		border: 0;
-		padding: 0;
 		font: inherit;
 		cursor: pointer;
 		user-select: none;
 		text-align: left;
 		min-width: 60px;
+		margin: -($_o-table-sort-icon-size/2) 0;
+		margin-right: -$_o-table-sort-icon-size;
+		padding: 0;
+		padding-right: $_o-table-sort-icon-size;
 		&:after {
-			@include oIconsGetIcon('arrows-up-down', $container-width: 18,  $container-height: 18, $iconset-version: 1);
+			@include oIconsGetIcon('arrows-up-down', $container-width: $_o-table-sort-icon-size,  $container-height: $_o-table-sort-icon-size, $iconset-version: 1);
 			content: '';
-			margin-right: -20px;
 			vertical-align: middle;
+			margin-right: -$_o-table-sort-icon-size;
 		}
 	}
 
 	// Show descending icon in sort button with DSC sort applied.
 	[aria-sort='descending'] .o-table__sort {
 		&:after {
-			@include oIconsGetIcon('arrow-down', $container-width: 18,  $container-height: 18, $iconset-version: 1);
+			@include oIconsGetIcon('arrow-down', $container-width: $_o-table-sort-icon-size,  $container-height: $_o-table-sort-icon-size, $iconset-version: 1);
 			vertical-align: middle;
 		}
 	}
@@ -45,7 +49,7 @@
 	th:not([aria-sort]):hover .o-table__sort, // sass-lint:disable-line no-qualifying-elements
 	[aria-sort='ascending'] .o-table__sort {
 		&:after {
-			@include oIconsGetIcon('arrow-up', $container-width: 18,  $container-height: 18, $iconset-version: 1);
+			@include oIconsGetIcon('arrow-up', $container-width: 1.25rem,  $container-height: 1.25rem, $iconset-version: 1);
 			vertical-align: middle;
 		}
 	}

--- a/src/scss/_sort.scss
+++ b/src/scss/_sort.scss
@@ -24,7 +24,7 @@
 		user-select: none;
 		text-align: left;
 		min-width: 60px;
-		margin: -($_o-table-sort-icon-size/2) 0;
+		margin: 0;
 		margin-right: -$_o-table-sort-icon-size;
 		padding: 0;
 		padding-right: $_o-table-sort-icon-size;
@@ -32,6 +32,7 @@
 			@include oIconsGetIcon('arrows-up-down', $container-width: $_o-table-sort-icon-size,  $container-height: $_o-table-sort-icon-size, $iconset-version: 1);
 			content: '';
 			vertical-align: middle;
+			margin: -($_o-table-sort-icon-size/2) 0;
 			margin-right: -$_o-table-sort-icon-size;
 		}
 	}

--- a/src/scss/_sort.scss
+++ b/src/scss/_sort.scss
@@ -46,8 +46,8 @@
 	}
 
 	// Show ascending icon in sort button with ascending sort applied or on hover with no sort.
-	th[aria-sort='none']:hover .o-table__sort, // sass-lint:disable-line no-qualifying-elements
-	th:not([aria-sort]):hover .o-table__sort, // sass-lint:disable-line no-qualifying-elements
+	th[aria-sort='none'] .o-table__sort:hover, // sass-lint:disable-line no-qualifying-elements
+	th:not([aria-sort]) .o-table__sort:hover, // sass-lint:disable-line no-qualifying-elements
 	[aria-sort='ascending'] .o-table__sort {
 		&:after {
 			@include oIconsGetIcon('arrow-up', $container-width: 1.25rem,  $container-height: 1.25rem, $iconset-version: 1);

--- a/src/scss/_sort.scss
+++ b/src/scss/_sort.scss
@@ -2,8 +2,9 @@
 /// @access private
 @mixin _oTableSort {
 
-	.o-table--sortable thead th:not([data-o-table-heading-disable-sort]) {
-		padding-right: 0; // No header padding with a child sort icon.
+	.o-table:not([data-o-table-sortable="false"]) thead th:not([data-o-table-heading-disable-sort]) {
+		padding-right: 20px;
+		min-width: 60px;
 	}
 
 	// Sort button.
@@ -21,11 +22,10 @@
 		font: inherit;
 		cursor: pointer;
 		user-select: none;
-		padding-right: 20px;
-		min-width: 60px;
 		text-align: left;
+		min-width: 60px;
 		&:after {
-			@include oIconsGetIcon('arrows-up-down', $container-width: 20,  $container-height: 20, $iconset-version: 1);
+			@include oIconsGetIcon('arrows-up-down', $container-width: 18,  $container-height: 18, $iconset-version: 1);
 			content: '';
 			margin-right: -20px;
 			vertical-align: middle;
@@ -33,21 +33,19 @@
 	}
 
 	// Show descending icon in sort button with DSC sort applied.
-	[aria-sort].o-table-sorting-descending .o-table__sort,
 	[aria-sort='descending'] .o-table__sort {
 		&:after {
-			@include oIconsGetIcon('arrow-down', $container-width: 20,  $container-height: 20, $iconset-version: 1);
+			@include oIconsGetIcon('arrow-down', $container-width: 18,  $container-height: 18, $iconset-version: 1);
 			vertical-align: middle;
 		}
 	}
 
 	// Show ascending icon in sort button with ascending sort applied or on hover with no sort.
-	[aria-sort].o-table-sorting-ascending .o-table__sort,
 	th[aria-sort='none']:hover .o-table__sort, // sass-lint:disable-line no-qualifying-elements
 	th:not([aria-sort]):hover .o-table__sort, // sass-lint:disable-line no-qualifying-elements
 	[aria-sort='ascending'] .o-table__sort {
 		&:after {
-			@include oIconsGetIcon('arrow-up', $container-width: 20,  $container-height: 20, $iconset-version: 1);
+			@include oIconsGetIcon('arrow-up', $container-width: 18,  $container-height: 18, $iconset-version: 1);
 			vertical-align: middle;
 		}
 	}


### PR DESCRIPTION
- Only clone table cells for formatting if they haven't already been formatted.
- Sort is only called once per click (bug).
- Update the order of multiple rows at once with `prepend` rather than `appendChild` (where supported).
- Batches row updates on sort with `requestAnimationFrame`, for more immediate feedback and to break up rendering into multiple frames.
- Updates icon styles to avoid resizing the table when they're added.
- Removes styles which intended to give immediate feedback on click of the sort button, by immediately updating the sort icon. These were broken. When fixed I found it was more confusing to see an icon that indicated the table had been sorted even when it hadn't yet. We could introduce a loading state but my hope it with sort performance improvements we can avoid it.

**Before:**
With Chrome's cpu throttle enabled (x6) it takes several seconds to visually sort a table with 8 columns and 1000 rows:
![before](https://user-images.githubusercontent.com/10405691/52273371-90c5b580-2941-11e9-9b82-4baeea6dc83d.gif)

<img width="1399" alt="screenshot 2019-02-05 at 11 47 40" src="https://user-images.githubusercontent.com/10405691/52272837-ebf6a880-293f-11e9-9469-3da5408840a6.png">

After:
With Chrome's cpu throttle enabled (x6) it's much quicker to visually sort a table with 8 columns and 1000 rows. There's still a noticeable pause, so there's room for further improvement (open to suggestions):
![after](https://user-images.githubusercontent.com/10405691/52273441-c8ccf880-2941-11e9-9ffd-49af07b3112b.gif)
<img width="1399" alt="screenshot 2019-02-05 at 11 46 54" src="https://user-images.githubusercontent.com/10405691/52272846-f022c600-293f-11e9-8eb2-9e85a8d51331.png">
