### PR TITLE
Render expandable table in no more than two batches.

### DIFF
--- a/demos/src/huge.mustache
+++ b/demos/src/huge.mustache
@@ -1,0 +1,13263 @@
+<div class="o-table-container">
+	<div class="o-table-overlay-wrapper n-content-layout__container">
+		<div class="o-table-scroll-wrapper">
+			<table
+				class="o-table o-table--row-stripes o-table--compact o-table--responsive-overflow o-table--responsive-overflow"
+				data-o-component="o-table" data-o-table-responsive="overflow" data-o-table-minimum-row-count="20"
+				data-o-table-expanded="false" aria-expanded="false">
+				<thead>
+					<tr>
+						<th data-column-default-sort="ascending" scope="col" role="columnheader"
+							data-o-table-data-type="number"></th>
+						<th data-column-filter-type="none" data-column-hidden="none" scope="col" role="columnheader"
+							data-o-table-data-type="text">Company</th>
+						<th data-column-filter-type="select-list" data-column-hidden="small-screen" scope="col"
+							role="columnheader" data-o-table-data-type="text">Country</th>
+						<th data-column-filter-type="auto" data-column-hidden="small-screen" scope="col"
+							role="columnheader" data-o-table-data-type="text">Sector</th>
+						<th data-column-hidden="small-screen" scope="col" role="columnheader"
+							data-o-table-data-type="percent">Revenue Growth</th>
+						<th data-column-hidden="large-screen" scope="col" role="columnheader"
+							data-o-table-heading-disable-sort="" data-o-table-data-type="percent">CAGR</th>
+						<th data-column-hidden="none" scope="col" role="columnheader" data-o-table-data-type="number">
+							Revenue</th>
+						<th data-column-hidden="small-screen" scope="col" role="columnheader"
+							data-o-table-data-type="number">Employee Growth</th>
+						<th data-column-default-sort="descending" scope="col" role="columnheader"
+							data-o-table-data-type="number">Employees</th>
+						<th data-column-default-sort="descending" data-column-hidden="small-screen" scope="col"
+							role="columnheader" data-o-table-data-type="date">Founded</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<td class="o-table__cell--numeric">1</td>
+						<td><a href="http://deliveroo.co.uk/" data-trackable="link" target="_blank">Deliveroo*</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/companies/food-beverage" data-trackable="link">Food &amp;
+								Beverage</a></td>
+						<td class="o-table__cell--numeric">107117%</td>
+						<td class="o-table__cell--numeric">923.50%</td>
+						<td class="o-table__cell--numeric">157,406</td>
+						<td class="o-table__cell--numeric">1,046</td>
+						<td class="o-table__cell--numeric">1,049</td>
+						<td>2013</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">2</td>
+						<td><a href="http://thermondo.de/" data-trackable="link" target="_blank">Thermondo</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/energy" data-trackable="link">Energy</a></td>
+						<td class="o-table__cell--numeric">10878%</td>
+						<td class="o-table__cell--numeric">378.80%</td>
+						<td class="o-table__cell--numeric">20,222</td>
+						<td class="o-table__cell--numeric">280</td>
+						<td class="o-table__cell--numeric">300</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">3</td>
+						<td><a href="http://traventia.es/" data-trackable="link" target="_blank">Traventia Viajes*</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/companies/travel-leisure" data-trackable="link">Travel &amp;
+								Leisure</a></td>
+						<td class="o-table__cell--numeric">9377%</td>
+						<td class="o-table__cell--numeric">355.90%</td>
+						<td class="o-table__cell--numeric">10,295</td>
+						<td class="o-table__cell--numeric">19</td>
+						<td class="o-table__cell--numeric">20</td>
+						<td>2013</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">4</td>
+						<td><a href="http://alainsa.com/" data-trackable="link" target="_blank">Alainsa</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/companies/construction" data-trackable="link">Construction</a>
+						</td>
+						<td class="o-table__cell--numeric">9114%</td>
+						<td class="o-table__cell--numeric">351.70%</td>
+						<td class="o-table__cell--numeric">10,286</td>
+						<td class="o-table__cell--numeric">19</td>
+						<td class="o-table__cell--numeric">20</td>
+						<td>1980</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">5</td>
+						<td><a href="http://itravex.es/" data-trackable="link" target="_blank">iTravex</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/companies/travel-leisure" data-trackable="link">Travel &amp;
+								Leisure</a></td>
+						<td class="o-table__cell--numeric">8398%</td>
+						<td class="o-table__cell--numeric">339.60%</td>
+						<td class="o-table__cell--numeric">22,674</td>
+						<td class="o-table__cell--numeric">28</td>
+						<td class="o-table__cell--numeric">37</td>
+						<td>2007</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">6</td>
+						<td><a href="http://carwow.com/" data-trackable="link" target="_blank">Carwow</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/companies/automobiles" data-trackable="link">Automobiles</a>
+						</td>
+						<td class="o-table__cell--numeric">7692%</td>
+						<td class="o-table__cell--numeric">327.10%</td>
+						<td class="o-table__cell--numeric">10,996</td>
+						<td class="o-table__cell--numeric">101</td>
+						<td class="o-table__cell--numeric">104</td>
+						<td>2009</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">7</td>
+						<td><a href="http://formycon.de/" data-trackable="link" target="_blank">Formycon</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/chemicals" data-trackable="link">Chemicals</a></td>
+						<td class="o-table__cell--numeric">6965%</td>
+						<td class="o-table__cell--numeric">313.40%</td>
+						<td class="o-table__cell--numeric">19,500</td>
+						<td class="o-table__cell--numeric">30</td>
+						<td class="o-table__cell--numeric">70</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">8</td>
+						<td><a href="http://localfuel.co.uk/" data-trackable="link" target="_blank">Local Fuel</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/companies/energy" data-trackable="link">Energy</a></td>
+						<td class="o-table__cell--numeric">6774%</td>
+						<td class="o-table__cell--numeric">309.60%</td>
+						<td class="o-table__cell--numeric">73,914</td>
+						<td class="o-table__cell--numeric">6</td>
+						<td class="o-table__cell--numeric">8</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">9</td>
+						<td><a href="http://projectxparis.com/" data-trackable="link" target="_blank">Project X
+								Paris</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/stream/f9f7535d-3b5c-47a7-bd15-3e10dceee597"
+								data-trackable="link">Fashion</a></td>
+						<td class="o-table__cell--numeric">6663%</td>
+						<td class="o-table__cell--numeric">307.40%</td>
+						<td class="o-table__cell--numeric">8,360</td>
+						<td class="o-table__cell--numeric">18</td>
+						<td class="o-table__cell--numeric">20</td>
+						<td>2013</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">10</td>
+						<td><a href="http://global-savings-group.com/" data-trackable="link" target="_blank">Global
+								Savings Group</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Advertising" data-trackable="link">Advertising</a>
+						</td>
+						<td class="o-table__cell--numeric">5449%</td>
+						<td class="o-table__cell--numeric">281.40%</td>
+						<td class="o-table__cell--numeric">19,420</td>
+						<td class="o-table__cell--numeric">204</td>
+						<td class="o-table__cell--numeric">304</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">11</td>
+						<td><a href="http://smarkets.com/" data-trackable="link" target="_blank">Smarkets</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/fintech" data-trackable="link">Fintech</a></td>
+						<td class="o-table__cell--numeric">5390%</td>
+						<td class="o-table__cell--numeric">280.10%</td>
+						<td class="o-table__cell--numeric">31,119</td>
+						<td class="o-table__cell--numeric">62</td>
+						<td class="o-table__cell--numeric">78</td>
+						<td>2008</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">12</td>
+						<td><a href="http://resaneo.com/" data-trackable="link" target="_blank">VLC Travel</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">5046%</td>
+						<td class="o-table__cell--numeric">272%</td>
+						<td class="o-table__cell--numeric">40,173</td>
+						<td class="o-table__cell--numeric">20</td>
+						<td class="o-table__cell--numeric">30</td>
+						<td>2009</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">13</td>
+						<td><a href="http://germanimals.de/" data-trackable="link" target="_blank">Germanimals</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Agricultural_Commodities"
+								data-trackable="link">Agricultural commodities</a></td>
+						<td class="o-table__cell--numeric">4763%</td>
+						<td class="o-table__cell--numeric">265%</td>
+						<td class="o-table__cell--numeric">23,500</td>
+						<td class="o-table__cell--numeric">5</td>
+						<td class="o-table__cell--numeric">7</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">14</td>
+						<td><a href="http://sendinblue.com/" data-trackable="link" target="_blank">SendinBlue</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">4596%</td>
+						<td class="o-table__cell--numeric">260.80%</td>
+						<td class="o-table__cell--numeric">7,517</td>
+						<td class="o-table__cell--numeric">30</td>
+						<td class="o-table__cell--numeric">60</td>
+						<td>2007</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">15</td>
+						<td><a href="http://cheevershoward.co.uk/" data-trackable="link" target="_blank">Cheevers
+								Howard</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/companies/construction" data-trackable="link">Construction</a>
+						</td>
+						<td class="o-table__cell--numeric">4471%</td>
+						<td class="o-table__cell--numeric">257.50%</td>
+						<td class="o-table__cell--numeric">26,127</td>
+						<td class="o-table__cell--numeric">60</td>
+						<td class="o-table__cell--numeric">61</td>
+						<td>2013</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">16</td>
+						<td><a href="http://marfeel.com/" data-trackable="link" target="_blank">Marfeel Solutions</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Advertising" data-trackable="link">Advertising</a>
+						</td>
+						<td class="o-table__cell--numeric">4218%</td>
+						<td class="o-table__cell--numeric">250.80%</td>
+						<td class="o-table__cell--numeric">4,613</td>
+						<td class="o-table__cell--numeric">43</td>
+						<td class="o-table__cell--numeric">52</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">17</td>
+						<td><a href="http://www.petroprix.com/" data-trackable="link" target="_blank">Petroprix
+								Energía*</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/companies/retail" data-trackable="link">Retail</a></td>
+						<td class="o-table__cell--numeric">4033%</td>
+						<td class="o-table__cell--numeric">245.70%</td>
+						<td class="o-table__cell--numeric">72,693</td>
+						<td class="o-table__cell--numeric">40</td>
+						<td class="o-table__cell--numeric">45</td>
+						<td>2013</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">18</td>
+						<td><a href="http://hellofresh.de/" data-trackable="link" target="_blank">HelloFresh</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Ecommerce" data-trackable="link">Ecommerce</a>
+						</td>
+						<td class="o-table__cell--numeric">3989%</td>
+						<td class="o-table__cell--numeric">244.50%</td>
+						<td class="o-table__cell--numeric">596,992</td>
+						<td class="o-table__cell--numeric">n/a</td>
+						<td class="o-table__cell--numeric">1,969</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">19</td>
+						<td><a href="http://strv.com/" data-trackable="link" target="_blank">STRV</a></td>
+						<td><a href="https://www.ft.com/topics/places/Czech_Republic" data-trackable="link">Czech
+								Republic</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">3936%</td>
+						<td class="o-table__cell--numeric">243%</td>
+						<td class="o-table__cell--numeric">5,795</td>
+						<td class="o-table__cell--numeric">n/a</td>
+						<td class="o-table__cell--numeric">150</td>
+						<td>2009</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">20</td>
+						<td><a href="http://bynder.com/" data-trackable="link" target="_blank">Bynder</a></td>
+						<td><a href="https://www.ft.com/topics/places/Netherlands" data-trackable="link">The
+								Netherlands</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">3712%</td>
+						<td class="o-table__cell--numeric">236.50%</td>
+						<td class="o-table__cell--numeric">12,036</td>
+						<td class="o-table__cell--numeric">228</td>
+						<td class="o-table__cell--numeric">248</td>
+						<td>2013</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">21</td>
+						<td><a href="http://bluemotorfinance.co.uk/" data-trackable="link" target="_blank">Blue Motor
+								Finance</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/companies/financial-services" data-trackable="link">Financial
+								Services</a></td>
+						<td class="o-table__cell--numeric">3675%</td>
+						<td class="o-table__cell--numeric">235.50%</td>
+						<td class="o-table__cell--numeric">20,237</td>
+						<td class="o-table__cell--numeric">94</td>
+						<td class="o-table__cell--numeric">103</td>
+						<td>1992</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">22</td>
+						<td><a href="http://stratajet.com/" data-trackable="link" target="_blank">Stratajet</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/companies/travel-leisure" data-trackable="link">Travel &amp;
+								Leisure</a></td>
+						<td class="o-table__cell--numeric">3634%</td>
+						<td class="o-table__cell--numeric">234.20%</td>
+						<td class="o-table__cell--numeric">4,815</td>
+						<td class="o-table__cell--numeric">54</td>
+						<td class="o-table__cell--numeric">60</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">23</td>
+						<td><a href="http://aerfin.com/" data-trackable="link" target="_blank">AerFin</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/companies/aerospace-defence" data-trackable="link">Aerospace
+								&amp; Defence</a></td>
+						<td class="o-table__cell--numeric">3625%</td>
+						<td class="o-table__cell--numeric">234%</td>
+						<td class="o-table__cell--numeric">74,216</td>
+						<td class="o-table__cell--numeric">66</td>
+						<td class="o-table__cell--numeric">79</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">24</td>
+						<td><a href="http://transferwise.com/" data-trackable="link" target="_blank">TransferWise</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/companies/financial-services" data-trackable="link">Financial
+								Services</a></td>
+						<td class="o-table__cell--numeric">3392%</td>
+						<td class="o-table__cell--numeric">226.80%</td>
+						<td class="o-table__cell--numeric">79,663</td>
+						<td class="o-table__cell--numeric">670</td>
+						<td class="o-table__cell--numeric">700</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">25</td>
+						<td><a href="http://actility.com/" data-trackable="link" target="_blank">Actility</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/telecoms" data-trackable="link">Telecoms</a></td>
+						<td class="o-table__cell--numeric">3377%</td>
+						<td class="o-table__cell--numeric">226.40%</td>
+						<td class="o-table__cell--numeric">16,378</td>
+						<td class="o-table__cell--numeric">82</td>
+						<td class="o-table__cell--numeric">100</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">26</td>
+						<td><a href="http://salesmanago.com/" data-trackable="link" target="_blank">Benhauer</a></td>
+						<td><a href="https://www.ft.com/topics/places/Poland" data-trackable="link">Poland</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">3363%</td>
+						<td class="o-table__cell--numeric">225.90%</td>
+						<td class="o-table__cell--numeric">6,067</td>
+						<td class="o-table__cell--numeric">229</td>
+						<td class="o-table__cell--numeric">259</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">27</td>
+						<td><a href="http://subastadeocio.es/" data-trackable="link" target="_blank">Eurocio
+								Freetime</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/companies/travel-leisure" data-trackable="link">Travel &amp;
+								Leisure</a></td>
+						<td class="o-table__cell--numeric">3117%</td>
+						<td class="o-table__cell--numeric">218%</td>
+						<td class="o-table__cell--numeric">7,637</td>
+						<td class="o-table__cell--numeric">16</td>
+						<td class="o-table__cell--numeric">28</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">28</td>
+						<td><a href="http://metacrew.de/" data-trackable="link" target="_blank">Metacrew Group</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Advertising" data-trackable="link">Advertising</a>
+						</td>
+						<td class="o-table__cell--numeric">3108%</td>
+						<td class="o-table__cell--numeric">217.70%</td>
+						<td class="o-table__cell--numeric">10,171</td>
+						<td class="o-table__cell--numeric">46</td>
+						<td class="o-table__cell--numeric">54</td>
+						<td>2008</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">29</td>
+						<td><a href="http://shokes.de/" data-trackable="link" target="_blank">Shokes</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Ecommerce" data-trackable="link">Ecommerce</a>
+						</td>
+						<td class="o-table__cell--numeric">3101%</td>
+						<td class="o-table__cell--numeric">217.50%</td>
+						<td class="o-table__cell--numeric">6,178</td>
+						<td class="o-table__cell--numeric">2</td>
+						<td class="o-table__cell--numeric">6</td>
+						<td>2009</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">30</td>
+						<td><a href="http://tooploox.com/" data-trackable="link" target="_blank">Tooploox</a></td>
+						<td><a href="https://www.ft.com/topics/places/Poland" data-trackable="link">Poland</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">2942%</td>
+						<td class="o-table__cell--numeric">212.20%</td>
+						<td class="o-table__cell--numeric">3,019</td>
+						<td class="o-table__cell--numeric">64</td>
+						<td class="o-table__cell--numeric">72</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">31</td>
+						<td><a href="http://zema-it.de/" data-trackable="link" target="_blank">ZEMA IT</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">2901%</td>
+						<td class="o-table__cell--numeric">210.80%</td>
+						<td class="o-table__cell--numeric">8,825</td>
+						<td class="o-table__cell--numeric">10</td>
+						<td class="o-table__cell--numeric">12</td>
+						<td>2009</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">32</td>
+						<td><a href="http://frameryacoustics.com/" data-trackable="link" target="_blank">Framery</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Finland" data-trackable="link">Finland</a></td>
+						<td><a href="https://www.ft.com/house-home/interiors" data-trackable="link">Interiors</a></td>
+						<td class="o-table__cell--numeric">2873%</td>
+						<td class="o-table__cell--numeric">209.80%</td>
+						<td class="o-table__cell--numeric">17,619</td>
+						<td class="o-table__cell--numeric">62</td>
+						<td class="o-table__cell--numeric">70</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">33</td>
+						<td><a href="http://unidriver.eu/" data-trackable="link" target="_blank">Unidriver</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/companies/transport" data-trackable="link">Transport</a></td>
+						<td class="o-table__cell--numeric">2859%</td>
+						<td class="o-table__cell--numeric">209.30%</td>
+						<td class="o-table__cell--numeric">4,894</td>
+						<td class="o-table__cell--numeric">240</td>
+						<td class="o-table__cell--numeric">252</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">34</td>
+						<td><a href="http://electrocosto.com/" data-trackable="link" target="_blank">Gestaweb 2020*</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Ecommerce" data-trackable="link">Ecommerce</a>
+						</td>
+						<td class="o-table__cell--numeric">2813%</td>
+						<td class="o-table__cell--numeric">207.70%</td>
+						<td class="o-table__cell--numeric">11,650</td>
+						<td class="o-table__cell--numeric">17</td>
+						<td class="o-table__cell--numeric">18</td>
+						<td>2013</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">35</td>
+						<td><a href="http://snti.es/" data-trackable="link" target="_blank">SNTI Nutritional
+								Suplements*</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/companies/food-beverage" data-trackable="link">Food &amp;
+								Beverage</a></td>
+						<td class="o-table__cell--numeric">2698%</td>
+						<td class="o-table__cell--numeric">203.60%</td>
+						<td class="o-table__cell--numeric">2,970</td>
+						<td class="o-table__cell--numeric">0</td>
+						<td class="o-table__cell--numeric">1</td>
+						<td>2013</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">36</td>
+						<td><a href="http://idfinance.com/" data-trackable="link" target="_blank">ID Finance</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/fintech" data-trackable="link">Fintech</a></td>
+						<td class="o-table__cell--numeric">2683%</td>
+						<td class="o-table__cell--numeric">203%</td>
+						<td class="o-table__cell--numeric">57,809</td>
+						<td class="o-table__cell--numeric">211</td>
+						<td class="o-table__cell--numeric">220</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">37</td>
+						<td><a href="http://encoreuntour.com/" data-trackable="link" target="_blank">My Show Must Go
+								On</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/travel-leisure" data-trackable="link">Travel &amp;
+								Leisure</a></td>
+						<td class="o-table__cell--numeric">2538%</td>
+						<td class="o-table__cell--numeric">197.70%</td>
+						<td class="o-table__cell--numeric">2,675</td>
+						<td class="o-table__cell--numeric">n/a</td>
+						<td class="o-table__cell--numeric">3</td>
+						<td>2009</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">38</td>
+						<td><a href="http://moonoff.com/" data-trackable="link" target="_blank">Moonoff</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/companies/industrial-goods" data-trackable="link">Industrial
+								Goods</a></td>
+						<td class="o-table__cell--numeric">2524%</td>
+						<td class="o-table__cell--numeric">197.20%</td>
+						<td class="o-table__cell--numeric">6,737</td>
+						<td class="o-table__cell--numeric">15</td>
+						<td class="o-table__cell--numeric">16</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">39</td>
+						<td><a href="http://yieldlove.de/" data-trackable="link" target="_blank">Yieldlove*</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Advertising" data-trackable="link">Advertising</a>
+						</td>
+						<td class="o-table__cell--numeric">2486%</td>
+						<td class="o-table__cell--numeric">195.70%</td>
+						<td class="o-table__cell--numeric">6,667</td>
+						<td class="o-table__cell--numeric">13</td>
+						<td class="o-table__cell--numeric">17</td>
+						<td>2013</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">40</td>
+						<td><a href="http://everbe.com/" data-trackable="link" target="_blank">everBe</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://ig.ft.com/ft-1000/2018/" data-trackable="link">Management Consulting</a>
+						</td>
+						<td class="o-table__cell--numeric">2481%</td>
+						<td class="o-table__cell--numeric">195.50%</td>
+						<td class="o-table__cell--numeric">5,989</td>
+						<td class="o-table__cell--numeric">40</td>
+						<td class="o-table__cell--numeric">45</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">41</td>
+						<td><a href="http://avenir-renovations.fr/" data-trackable="link" target="_blank">Avenir
+								Renovations*</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/construction" data-trackable="link">Construction</a>
+						</td>
+						<td class="o-table__cell--numeric">2445%</td>
+						<td class="o-table__cell--numeric">194.20%</td>
+						<td class="o-table__cell--numeric">2,800</td>
+						<td class="o-table__cell--numeric">11</td>
+						<td class="o-table__cell--numeric">12</td>
+						<td>2013</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">42</td>
+						<td><a href="http://conserto.pro/" data-trackable="link" target="_blank">Conserto*</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">2362%</td>
+						<td class="o-table__cell--numeric">190.90%</td>
+						<td class="o-table__cell--numeric">13,663</td>
+						<td class="o-table__cell--numeric">230</td>
+						<td class="o-table__cell--numeric">261</td>
+						<td>2013</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">43</td>
+						<td><a href="http://gocardless.co.uk/" data-trackable="link" target="_blank">GoCardless</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/fintech" data-trackable="link">Fintech</a></td>
+						<td class="o-table__cell--numeric">2313%</td>
+						<td class="o-table__cell--numeric">189%</td>
+						<td class="o-table__cell--numeric">7,308</td>
+						<td class="o-table__cell--numeric">100</td>
+						<td class="o-table__cell--numeric">100</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">44</td>
+						<td><a href="http://optal.com/" data-trackable="link" target="_blank">Optal</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/companies/financial-services" data-trackable="link">Financial
+								Services</a></td>
+						<td class="o-table__cell--numeric">2276%</td>
+						<td class="o-table__cell--numeric">187.50%</td>
+						<td class="o-table__cell--numeric">158,052</td>
+						<td class="o-table__cell--numeric">19</td>
+						<td class="o-table__cell--numeric">27</td>
+						<td>2005</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">45</td>
+						<td><a href="http://dcmn.com/" data-trackable="link" target="_blank">DCMN</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Advertising" data-trackable="link">Advertising</a>
+						</td>
+						<td class="o-table__cell--numeric">2265%</td>
+						<td class="o-table__cell--numeric">187.10%</td>
+						<td class="o-table__cell--numeric">41,461</td>
+						<td class="o-table__cell--numeric">82</td>
+						<td class="o-table__cell--numeric">88</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">46</td>
+						<td><a href="http://rtbhouse.com/" data-trackable="link" target="_blank">RTB House</a></td>
+						<td><a href="https://www.ft.com/topics/places/Poland" data-trackable="link">Poland</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">2167%</td>
+						<td class="o-table__cell--numeric">183%</td>
+						<td class="o-table__cell--numeric">18,573</td>
+						<td class="o-table__cell--numeric">116</td>
+						<td class="o-table__cell--numeric">184</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">47</td>
+						<td><a href="http://allseafoodcompany.com/" data-trackable="link" target="_blank">All Seafood
+								Company</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/food-beverage" data-trackable="link">Food &amp;
+								Beverage</a></td>
+						<td class="o-table__cell--numeric">2140%</td>
+						<td class="o-table__cell--numeric">181.90%</td>
+						<td class="o-table__cell--numeric">3,479</td>
+						<td class="o-table__cell--numeric">0</td>
+						<td class="o-table__cell--numeric">2</td>
+						<td>2006</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">48</td>
+						<td><a href="http://catawiki.com/" data-trackable="link" target="_blank">Catawiki</a></td>
+						<td><a href="https://www.ft.com/topics/places/Netherlands" data-trackable="link">The
+								Netherlands</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">2094%</td>
+						<td class="o-table__cell--numeric">179.90%</td>
+						<td class="o-table__cell--numeric">35,100</td>
+						<td class="o-table__cell--numeric">317</td>
+						<td class="o-table__cell--numeric">341</td>
+						<td>2008</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">49</td>
+						<td><a href="http://codilime.com/" data-trackable="link" target="_blank">CodiLime</a></td>
+						<td><a href="https://www.ft.com/topics/places/Poland" data-trackable="link">Poland</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">2076%</td>
+						<td class="o-table__cell--numeric">179.20%</td>
+						<td class="o-table__cell--numeric">8,764</td>
+						<td class="o-table__cell--numeric">180</td>
+						<td class="o-table__cell--numeric">200</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">50</td>
+						<td><a href="http://smadex.com/" data-trackable="link" target="_blank">Smadex</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Sales_&amp;_Marketing" data-trackable="link">Sales
+								&amp; Marketing</a></td>
+						<td class="o-table__cell--numeric">2068%</td>
+						<td class="o-table__cell--numeric">178.80%</td>
+						<td class="o-table__cell--numeric">4,063</td>
+						<td class="o-table__cell--numeric">16</td>
+						<td class="o-table__cell--numeric">29</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">51</td>
+						<td><a href="http://cdprojekt.com/" data-trackable="link" target="_blank">CD PROJEKT</a></td>
+						<td><a href="https://www.ft.com/topics/places/Poland" data-trackable="link">Poland</a></td>
+						<td><a href="https://www.ft.com/stream/f9c6d3fe-5e16-479c-b762-bccdeeb349fe"
+								data-trackable="link">Games industry</a></td>
+						<td class="o-table__cell--numeric">2057%</td>
+						<td class="o-table__cell--numeric">178.40%</td>
+						<td class="o-table__cell--numeric">133,909</td>
+						<td class="o-table__cell--numeric">141</td>
+						<td class="o-table__cell--numeric">214</td>
+						<td>1994</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">52</td>
+						<td><a href="http://engagementfactory.com/" data-trackable="link" target="_blank">Engagement
+								Factory*</a></td>
+						<td><a href="https://www.ft.com/topics/places/Netherlands" data-trackable="link">The
+								Netherlands</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Sales_&amp;_Marketing" data-trackable="link">Sales
+								&amp; Marketing</a></td>
+						<td class="o-table__cell--numeric">2034%</td>
+						<td class="o-table__cell--numeric">177.40%</td>
+						<td class="o-table__cell--numeric">2,331</td>
+						<td class="o-table__cell--numeric">16</td>
+						<td class="o-table__cell--numeric">18</td>
+						<td>2013</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">53</td>
+						<td><a href="http://codewise.com/" data-trackable="link" target="_blank">Codewise</a></td>
+						<td><a href="https://www.ft.com/topics/places/Poland" data-trackable="link">Poland</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Advertising" data-trackable="link">Advertising</a>
+						</td>
+						<td class="o-table__cell--numeric">1923%</td>
+						<td class="o-table__cell--numeric">172.50%</td>
+						<td class="o-table__cell--numeric">43,752</td>
+						<td class="o-table__cell--numeric">83</td>
+						<td class="o-table__cell--numeric">92</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">54</td>
+						<td><a href="http://eskimoz.fr/" data-trackable="link" target="_blank">Eskimoz</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">1900%</td>
+						<td class="o-table__cell--numeric">171.40%</td>
+						<td class="o-table__cell--numeric">3,000</td>
+						<td class="o-table__cell--numeric">26</td>
+						<td class="o-table__cell--numeric">30</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">55</td>
+						<td><a href="http://superawesome.com/" data-trackable="link" target="_blank">SuperAwesome</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">1844%</td>
+						<td class="o-table__cell--numeric">168.90%</td>
+						<td class="o-table__cell--numeric">8,081</td>
+						<td class="o-table__cell--numeric">78</td>
+						<td class="o-table__cell--numeric">90</td>
+						<td>1999</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">56</td>
+						<td><a href="http://rpc-partners.com/" data-trackable="link" target="_blank">The Retail
+								Performance Company</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://ig.ft.com/ft-1000/2018/" data-trackable="link">Management Consulting</a>
+						</td>
+						<td class="o-table__cell--numeric">1841%</td>
+						<td class="o-table__cell--numeric">168.80%</td>
+						<td class="o-table__cell--numeric">33,000</td>
+						<td class="o-table__cell--numeric">209</td>
+						<td class="o-table__cell--numeric">233</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">57</td>
+						<td><a href="http://unielectrica.com/" data-trackable="link" target="_blank">Unieléctrica
+								Energía**</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/companies/energy" data-trackable="link">Energy</a></td>
+						<td class="o-table__cell--numeric">1802%</td>
+						<td class="o-table__cell--numeric">166.90%</td>
+						<td class="o-table__cell--numeric">86,544</td>
+						<td class="o-table__cell--numeric">33</td>
+						<td class="o-table__cell--numeric">35</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">58</td>
+						<td><a href="http://northlander-advisors.com/" data-trackable="link" target="_blank">Northlander
+								Commodity Advisors</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/companies/financial-services" data-trackable="link">Financial
+								Services</a></td>
+						<td class="o-table__cell--numeric">1776%</td>
+						<td class="o-table__cell--numeric">165.70%</td>
+						<td class="o-table__cell--numeric">11,976</td>
+						<td class="o-table__cell--numeric">5</td>
+						<td class="o-table__cell--numeric">7</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">59</td>
+						<td><a href="http://germanflavours.de/" data-trackable="link" target="_blank">GermanFLAVOURS</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/chemicals" data-trackable="link">Chemicals</a></td>
+						<td class="o-table__cell--numeric">1765%</td>
+						<td class="o-table__cell--numeric">165.20%</td>
+						<td class="o-table__cell--numeric">7,931</td>
+						<td class="o-table__cell--numeric">99</td>
+						<td class="o-table__cell--numeric">105</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">60</td>
+						<td><a href="http://cloudtechnologies.pl/" data-trackable="link" target="_blank">Cloud
+								Technologies</a></td>
+						<td><a href="https://www.ft.com/topics/places/Poland" data-trackable="link">Poland</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">1756%</td>
+						<td class="o-table__cell--numeric">164.80%</td>
+						<td class="o-table__cell--numeric">11,105</td>
+						<td class="o-table__cell--numeric">46</td>
+						<td class="o-table__cell--numeric">51</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">61</td>
+						<td><a href="http://virtusdatacentres.com/" data-trackable="link" target="_blank">VIRTUS
+								HoldCo**</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">1729%</td>
+						<td class="o-table__cell--numeric">163.50%</td>
+						<td class="o-table__cell--numeric">28,861</td>
+						<td class="o-table__cell--numeric">11</td>
+						<td class="o-table__cell--numeric">33</td>
+						<td>2008</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">62</td>
+						<td><a href="http://paranet-deutschland.de/" data-trackable="link"
+								target="_blank">PARANET-Deutschland</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/construction" data-trackable="link">Construction</a>
+						</td>
+						<td class="o-table__cell--numeric">1721%</td>
+						<td class="o-table__cell--numeric">163.10%</td>
+						<td class="o-table__cell--numeric">26,161</td>
+						<td class="o-table__cell--numeric">27</td>
+						<td class="o-table__cell--numeric">33</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">63</td>
+						<td><a href="http://kantox.com/" data-trackable="link" target="_blank">Kantox</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/fintech" data-trackable="link">Fintech</a></td>
+						<td class="o-table__cell--numeric">1688%</td>
+						<td class="o-table__cell--numeric">161.50%</td>
+						<td class="o-table__cell--numeric">4,039</td>
+						<td class="o-table__cell--numeric">43</td>
+						<td class="o-table__cell--numeric">75</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">64</td>
+						<td><a href="http://allbranded.de/" data-trackable="link" target="_blank">allbranded</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Advertising" data-trackable="link">Advertising</a>
+						</td>
+						<td class="o-table__cell--numeric">1648%</td>
+						<td class="o-table__cell--numeric">159.50%</td>
+						<td class="o-table__cell--numeric">4,008</td>
+						<td class="o-table__cell--numeric">12</td>
+						<td class="o-table__cell--numeric">15</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">65</td>
+						<td><a href="http://coppolafoodsgroup.com/" data-trackable="link" target="_blank">Coppola
+								Foods</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/companies/food-beverage" data-trackable="link">Food &amp;
+								Beverage</a></td>
+						<td class="o-table__cell--numeric">1632%</td>
+						<td class="o-table__cell--numeric">158.70%</td>
+						<td class="o-table__cell--numeric">2,008</td>
+						<td class="o-table__cell--numeric">0</td>
+						<td class="o-table__cell--numeric">2</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">66</td>
+						<td><a href="http://enitas.de/" data-trackable="link" target="_blank">ENITAS Deutschland*</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">1613%</td>
+						<td class="o-table__cell--numeric">157.80%</td>
+						<td class="o-table__cell--numeric">2,809</td>
+						<td class="o-table__cell--numeric">55</td>
+						<td class="o-table__cell--numeric">60</td>
+						<td>2013</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">67</td>
+						<td><a href="http://seistag.com/" data-trackable="link" target="_blank">Seistag Innovación*</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://ig.ft.com/ft-1000/2018/" data-trackable="link">Management Consulting</a>
+						</td>
+						<td class="o-table__cell--numeric">1610%</td>
+						<td class="o-table__cell--numeric">157.60%</td>
+						<td class="o-table__cell--numeric">3,691</td>
+						<td class="o-table__cell--numeric">9</td>
+						<td class="o-table__cell--numeric">13</td>
+						<td>2013</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">68</td>
+						<td><a href="http://bms2.de/" data-trackable="link" target="_blank">BMS2*</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/construction" data-trackable="link">Construction</a>
+						</td>
+						<td class="o-table__cell--numeric">1609%</td>
+						<td class="o-table__cell--numeric">157.60%</td>
+						<td class="o-table__cell--numeric">3,971</td>
+						<td class="o-table__cell--numeric">8</td>
+						<td class="o-table__cell--numeric">10</td>
+						<td>2013</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">69</td>
+						<td><a href="http://cliqeo.com/" data-trackable="link" target="_blank">CliQéo</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">1602%</td>
+						<td class="o-table__cell--numeric">157.20%</td>
+						<td class="o-table__cell--numeric">4,135</td>
+						<td class="o-table__cell--numeric">42</td>
+						<td class="o-table__cell--numeric">51</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">70</td>
+						<td><a href="http://clearabee.co.uk/" data-trackable="link" target="_blank">Clearabee</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Waste_management_&amp;_recycling"
+								data-trackable="link">Waste management &amp; recycling</a></td>
+						<td class="o-table__cell--numeric">1578%</td>
+						<td class="o-table__cell--numeric">156%</td>
+						<td class="o-table__cell--numeric">7,976</td>
+						<td class="o-table__cell--numeric">119</td>
+						<td class="o-table__cell--numeric">135</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">71</td>
+						<td><a href="http://wealth-dynamix.com/" data-trackable="link" target="_blank">Wealth
+								Dynamics</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/fintech" data-trackable="link">Fintech</a></td>
+						<td class="o-table__cell--numeric">1563%</td>
+						<td class="o-table__cell--numeric">155.30%</td>
+						<td class="o-table__cell--numeric">7,918</td>
+						<td class="o-table__cell--numeric">28</td>
+						<td class="o-table__cell--numeric">32</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">72</td>
+						<td><a href="http://frechefreunde.de/" data-trackable="link" target="_blank">erdbär (Freche
+								Freunde)</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/food-beverage" data-trackable="link">Food &amp;
+								Beverage</a></td>
+						<td class="o-table__cell--numeric">1550%</td>
+						<td class="o-table__cell--numeric">154.60%</td>
+						<td class="o-table__cell--numeric">19,800</td>
+						<td class="o-table__cell--numeric">36</td>
+						<td class="o-table__cell--numeric">44</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">73</td>
+						<td>Sica SAS</td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/industrial-goods" data-trackable="link">Industrial
+								Goods</a></td>
+						<td class="o-table__cell--numeric">1504%</td>
+						<td class="o-table__cell--numeric">152.20%</td>
+						<td class="o-table__cell--numeric">9,016</td>
+						<td class="o-table__cell--numeric">0</td>
+						<td class="o-table__cell--numeric">1</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">74</td>
+						<td><a href="http://screwerk.com/" data-trackable="link" target="_blank">Screwerk*</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/retail" data-trackable="link">Retail</a></td>
+						<td class="o-table__cell--numeric">1482%</td>
+						<td class="o-table__cell--numeric">151%</td>
+						<td class="o-table__cell--numeric">2,038</td>
+						<td class="o-table__cell--numeric">17</td>
+						<td class="o-table__cell--numeric">20</td>
+						<td>2013</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">75</td>
+						<td><a href="http://soltec.com/" data-trackable="link" target="_blank">Soltec</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/companies/energy" data-trackable="link">Energy</a></td>
+						<td class="o-table__cell--numeric">1448%</td>
+						<td class="o-table__cell--numeric">149.20%</td>
+						<td class="o-table__cell--numeric">64,086</td>
+						<td class="o-table__cell--numeric">623</td>
+						<td class="o-table__cell--numeric">646</td>
+						<td>2004</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">76</td>
+						<td><a href="http://ew-energy-world.de/" data-trackable="link" target="_blank">EW&nbsp;Energy
+								World*</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/energy" data-trackable="link">Energy</a></td>
+						<td class="o-table__cell--numeric">1444%</td>
+						<td class="o-table__cell--numeric">149%</td>
+						<td class="o-table__cell--numeric">14,507</td>
+						<td class="o-table__cell--numeric">48</td>
+						<td class="o-table__cell--numeric">54</td>
+						<td>2013</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">77</td>
+						<td><a href="http://grabyo.com/" data-trackable="link" target="_blank">Grabyo*</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">1435%</td>
+						<td class="o-table__cell--numeric">148.50%</td>
+						<td class="o-table__cell--numeric">1,739</td>
+						<td class="o-table__cell--numeric">22</td>
+						<td class="o-table__cell--numeric">30</td>
+						<td>2013</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">78</td>
+						<td><a href="http://anthesisgroup.com/" data-trackable="link" target="_blank">Anthesis
+								Consulting Group*</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://ig.ft.com/ft-1000/2018/" data-trackable="link">Management Consulting</a>
+						</td>
+						<td class="o-table__cell--numeric">1431%</td>
+						<td class="o-table__cell--numeric">148.30%</td>
+						<td class="o-table__cell--numeric">11,249</td>
+						<td class="o-table__cell--numeric">160</td>
+						<td class="o-table__cell--numeric">200</td>
+						<td>2013</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">79</td>
+						<td><a href="http://blackswan.com/" data-trackable="link" target="_blank">Black Swan Data</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">1431%</td>
+						<td class="o-table__cell--numeric">148.30%</td>
+						<td class="o-table__cell--numeric">17,815</td>
+						<td class="o-table__cell--numeric">207</td>
+						<td class="o-table__cell--numeric">215</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">80</td>
+						<td><a href="http://robart.cc/" data-trackable="link" target="_blank">Robart GmbH</a></td>
+						<td><a href="https://www.ft.com/topics/places/Austria" data-trackable="link">Austria</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">1428%</td>
+						<td class="o-table__cell--numeric">148.20%</td>
+						<td class="o-table__cell--numeric">3,135</td>
+						<td class="o-table__cell--numeric">33</td>
+						<td class="o-table__cell--numeric">45</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">81</td>
+						<td><a href="http://novagroupe.eu/" data-trackable="link" target="_blank">Nova Groupe</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/personal-goods" data-trackable="link">Personal &amp;
+								Household Goods</a></td>
+						<td class="o-table__cell--numeric">1424%</td>
+						<td class="o-table__cell--numeric">147.90%</td>
+						<td class="o-table__cell--numeric">1,862</td>
+						<td class="o-table__cell--numeric">4</td>
+						<td class="o-table__cell--numeric">8</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">82</td>
+						<td><a href="http://cerabran.com/" data-trackable="link" target="_blank">PROCERAM</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/construction" data-trackable="link">Construction</a>
+						</td>
+						<td class="o-table__cell--numeric">1369%</td>
+						<td class="o-table__cell--numeric">144.90%</td>
+						<td class="o-table__cell--numeric">2,350</td>
+						<td class="o-table__cell--numeric">12</td>
+						<td class="o-table__cell--numeric">16</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">83</td>
+						<td><a href="http://bunsen.ie/" data-trackable="link" target="_blank">Bolus Restaurants</a></td>
+						<td><a href="https://www.ft.com/topics/places/Ireland" data-trackable="link">Ireland</a></td>
+						<td><a href="https://www.ft.com/restaurants" data-trackable="link">Restaurants</a></td>
+						<td class="o-table__cell--numeric">1349%</td>
+						<td class="o-table__cell--numeric">143.80%</td>
+						<td class="o-table__cell--numeric">5,281</td>
+						<td class="o-table__cell--numeric">47</td>
+						<td class="o-table__cell--numeric">63</td>
+						<td>2013</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">84</td>
+						<td><a href="http://happycompany.fr/" data-trackable="link" target="_blank">Happy Company</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/media" data-trackable="link">Media</a></td>
+						<td class="o-table__cell--numeric">1333%</td>
+						<td class="o-table__cell--numeric">142.90%</td>
+						<td class="o-table__cell--numeric">2,732</td>
+						<td class="o-table__cell--numeric">2</td>
+						<td class="o-table__cell--numeric">3</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">85</td>
+						<td><a href="http://globelocums.co.uk/" data-trackable="link" target="_blank">Globe Locums</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">1298%</td>
+						<td class="o-table__cell--numeric">140.90%</td>
+						<td class="o-table__cell--numeric">36,186</td>
+						<td class="o-table__cell--numeric">23</td>
+						<td class="o-table__cell--numeric">33</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">86</td>
+						<td><a href="http://intouchnetworks.com/" data-trackable="link" target="_blank">In Touch
+								Networks</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Ecommerce" data-trackable="link">Ecommerce</a>
+						</td>
+						<td class="o-table__cell--numeric">1296%</td>
+						<td class="o-table__cell--numeric">140.80%</td>
+						<td class="o-table__cell--numeric">3,938</td>
+						<td class="o-table__cell--numeric">90</td>
+						<td class="o-table__cell--numeric">100</td>
+						<td>2006</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">87</td>
+						<td><a href="http://lapelleweb.it/" data-trackable="link" target="_blank">Lapelle</a></td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/companies/industrial-goods" data-trackable="link">Industrial
+								Goods</a></td>
+						<td class="o-table__cell--numeric">1283%</td>
+						<td class="o-table__cell--numeric">140.10%</td>
+						<td class="o-table__cell--numeric">10,228</td>
+						<td class="o-table__cell--numeric">3</td>
+						<td class="o-table__cell--numeric">5</td>
+						<td>2006</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">88</td>
+						<td><a href="http://pickawood.com/" data-trackable="link" target="_blank">Pickawood</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Ecommerce" data-trackable="link">Ecommerce</a>
+						</td>
+						<td class="o-table__cell--numeric">1262%</td>
+						<td class="o-table__cell--numeric">138.80%</td>
+						<td class="o-table__cell--numeric">3,140</td>
+						<td class="o-table__cell--numeric">10</td>
+						<td class="o-table__cell--numeric">12</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">89</td>
+						<td><a href="http://fourniresto.com/" data-trackable="link" target="_blank">Fourniresto.Com</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/retail" data-trackable="link">Retail</a></td>
+						<td class="o-table__cell--numeric">1245%</td>
+						<td class="o-table__cell--numeric">137.80%</td>
+						<td class="o-table__cell--numeric">3,011</td>
+						<td class="o-table__cell--numeric">4</td>
+						<td class="o-table__cell--numeric">6</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">90</td>
+						<td><a href="http://vizzuality.com/" data-trackable="link" target="_blank">Vizzuality</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">1212%</td>
+						<td class="o-table__cell--numeric">135.90%</td>
+						<td class="o-table__cell--numeric">2,723</td>
+						<td class="o-table__cell--numeric">24</td>
+						<td class="o-table__cell--numeric">29</td>
+						<td>2009</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">91</td>
+						<td><a href="http://localbitcoins.com/" data-trackable="link" target="_blank">Localbitcoins*</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Finland" data-trackable="link">Finland</a></td>
+						<td><a href="https://www.ft.com/fintech" data-trackable="link">Fintech</a></td>
+						<td class="o-table__cell--numeric">1205%</td>
+						<td class="o-table__cell--numeric">135.40%</td>
+						<td class="o-table__cell--numeric">7,082</td>
+						<td class="o-table__cell--numeric">6</td>
+						<td class="o-table__cell--numeric">9</td>
+						<td>2013</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">92</td>
+						<td><a href="http://bademeisterei.com/" data-trackable="link" target="_blank">Bademeisterei
+								Kosmetikmanufaktur*</a></td>
+						<td><a href="https://www.ft.com/topics/places/Austria" data-trackable="link">Austria</a></td>
+						<td><a href="https://www.ft.com/companies/health" data-trackable="link">Health</a></td>
+						<td class="o-table__cell--numeric">1197%</td>
+						<td class="o-table__cell--numeric">134.90%</td>
+						<td class="o-table__cell--numeric">4,577</td>
+						<td class="o-table__cell--numeric">49</td>
+						<td class="o-table__cell--numeric">53</td>
+						<td>2013</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">93</td>
+						<td><a href="http://theanoadvisors.com/" data-trackable="link" target="_blank">Theano
+								Advisors</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://ig.ft.com/ft-1000/2018/" data-trackable="link">Management Consulting</a>
+						</td>
+						<td class="o-table__cell--numeric">1194%</td>
+						<td class="o-table__cell--numeric">134.80%</td>
+						<td class="o-table__cell--numeric">22,909</td>
+						<td class="o-table__cell--numeric">36</td>
+						<td class="o-table__cell--numeric">47</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">94</td>
+						<td><a href="http://neuronation.de/" data-trackable="link" target="_blank">Synaptikon</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/health" data-trackable="link">Health</a></td>
+						<td class="o-table__cell--numeric">1190%</td>
+						<td class="o-table__cell--numeric">134.50%</td>
+						<td class="o-table__cell--numeric">2,331</td>
+						<td class="o-table__cell--numeric">29</td>
+						<td class="o-table__cell--numeric">32</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">95</td>
+						<td><a href="http://radarservices.com/" data-trackable="link" target="_blank">RadarServices
+								Smart IT-Security</a></td>
+						<td><a href="https://www.ft.com/topics/places/Austria" data-trackable="link">Austria</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Cyber_Security" data-trackable="link">Cyber
+								Security</a></td>
+						<td class="o-table__cell--numeric">1169%</td>
+						<td class="o-table__cell--numeric">133.20%</td>
+						<td class="o-table__cell--numeric">3,603</td>
+						<td class="o-table__cell--numeric">25</td>
+						<td class="o-table__cell--numeric">41</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">96</td>
+						<td><a href="http://baobabsuites.com/" data-trackable="link"
+								target="_blank">Rent2ndhometenerife</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/companies/travel-leisure" data-trackable="link">Travel &amp;
+								Leisure</a></td>
+						<td class="o-table__cell--numeric">1166%</td>
+						<td class="o-table__cell--numeric">133.10%</td>
+						<td class="o-table__cell--numeric">8,650</td>
+						<td class="o-table__cell--numeric">80</td>
+						<td class="o-table__cell--numeric">108</td>
+						<td>2009</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">97</td>
+						<td><a href="http://ahorn-wohnmobile.de/" data-trackable="link" target="_blank">AHORN
+								Wohnmobile</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/automobiles" data-trackable="link">Automobiles</a>
+						</td>
+						<td class="o-table__cell--numeric">1155%</td>
+						<td class="o-table__cell--numeric">132.40%</td>
+						<td class="o-table__cell--numeric">28,783</td>
+						<td class="o-table__cell--numeric">31</td>
+						<td class="o-table__cell--numeric">36</td>
+						<td>1996</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">98</td>
+						<td><a href="http://scribbr.com/" data-trackable="link" target="_blank">Scribbr</a></td>
+						<td><a href="https://www.ft.com/topics/places/Netherlands" data-trackable="link">The
+								Netherlands</a></td>
+						<td><a href="https://www.ft.com/stream/d320c9d7-1638-4388-b667-a5d63bd4bbc2"
+								data-trackable="link">Education</a></td>
+						<td class="o-table__cell--numeric">1152%</td>
+						<td class="o-table__cell--numeric">132.20%</td>
+						<td class="o-table__cell--numeric">1,888</td>
+						<td class="o-table__cell--numeric">3</td>
+						<td class="o-table__cell--numeric">7</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">99</td>
+						<td><a href="http://lebepur.de/" data-trackable="link" target="_blank">Lebepur</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/food-beverage" data-trackable="link">Food &amp;
+								Beverage</a></td>
+						<td class="o-table__cell--numeric">1138%</td>
+						<td class="o-table__cell--numeric">131.30%</td>
+						<td class="o-table__cell--numeric">3,188</td>
+						<td class="o-table__cell--numeric">-1</td>
+						<td class="o-table__cell--numeric">2</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">100</td>
+						<td><a href="http://cowana.de/" data-trackable="link" target="_blank">Cowana</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Advertising" data-trackable="link">Advertising</a>
+						</td>
+						<td class="o-table__cell--numeric">1131%</td>
+						<td class="o-table__cell--numeric">130.90%</td>
+						<td class="o-table__cell--numeric">8,000</td>
+						<td class="o-table__cell--numeric">7</td>
+						<td class="o-table__cell--numeric">10</td>
+						<td>2009</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">101</td>
+						<td><a href="http://neuwagen24.de/" data-trackable="link" target="_blank">Neuwagen24.de</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/automobiles" data-trackable="link">Automobiles</a>
+						</td>
+						<td class="o-table__cell--numeric">1126%</td>
+						<td class="o-table__cell--numeric">130.60%</td>
+						<td class="o-table__cell--numeric">4,003</td>
+						<td class="o-table__cell--numeric">8</td>
+						<td class="o-table__cell--numeric">20</td>
+						<td>2007</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">102</td>
+						<td><a href="http://ac-mischke.de/" data-trackable="link" target="_blank">A. C. Mischke</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/automobiles" data-trackable="link">Automobiles</a>
+						</td>
+						<td class="o-table__cell--numeric">1126%</td>
+						<td class="o-table__cell--numeric">130.60%</td>
+						<td class="o-table__cell--numeric">40,176</td>
+						<td class="o-table__cell--numeric">5</td>
+						<td class="o-table__cell--numeric">6</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">103</td>
+						<td><a href="http://supercharge.io/" data-trackable="link" target="_blank">Supercharge</a></td>
+						<td><a href="https://www.ft.com/topics/places/Hungary" data-trackable="link">Hungary</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">1124%</td>
+						<td class="o-table__cell--numeric">130.50%</td>
+						<td class="o-table__cell--numeric">2,185</td>
+						<td class="o-table__cell--numeric">26</td>
+						<td class="o-table__cell--numeric">36</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">104</td>
+						<td><a href="http://goldengates.de/" data-trackable="link" target="_blank">Golden Gates
+								Edelmetalle</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/retail" data-trackable="link">Retail</a></td>
+						<td class="o-table__cell--numeric">1108%</td>
+						<td class="o-table__cell--numeric">129.40%</td>
+						<td class="o-table__cell--numeric">15,954</td>
+						<td class="o-table__cell--numeric">8</td>
+						<td class="o-table__cell--numeric">13</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">105</td>
+						<td><a href="http://warmcook.com/" data-trackable="link" target="_blank">Warmcook</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/personal-goods" data-trackable="link">Personal &amp;
+								Household Goods</a></td>
+						<td class="o-table__cell--numeric">1104%</td>
+						<td class="o-table__cell--numeric">129.20%</td>
+						<td class="o-table__cell--numeric">6,051</td>
+						<td class="o-table__cell--numeric">n/a</td>
+						<td class="o-table__cell--numeric">7</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">106</td>
+						<td><a href="http://wanecque.com/" data-trackable="link" target="_blank">Etablissements
+								Wanecque</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/construction" data-trackable="link">Construction</a>
+						</td>
+						<td class="o-table__cell--numeric">1102%</td>
+						<td class="o-table__cell--numeric">129.10%</td>
+						<td class="o-table__cell--numeric">2,050</td>
+						<td class="o-table__cell--numeric">18</td>
+						<td class="o-table__cell--numeric">19</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">107</td>
+						<td><a href="http://tikiting.com/" data-trackable="link" target="_blank">Tikiting
+								Distribuciones</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/companies/transport" data-trackable="link">Transport</a></td>
+						<td class="o-table__cell--numeric">1063%</td>
+						<td class="o-table__cell--numeric">126.60%</td>
+						<td class="o-table__cell--numeric">11,511</td>
+						<td class="o-table__cell--numeric">32</td>
+						<td class="o-table__cell--numeric">36</td>
+						<td>2008</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">108</td>
+						<td><a href="http://grupoalc.com/" data-trackable="link" target="_blank">ALC grup</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/architecture" data-trackable="link">Architecture</a></td>
+						<td class="o-table__cell--numeric">1049%</td>
+						<td class="o-table__cell--numeric">125.60%</td>
+						<td class="o-table__cell--numeric">3,936</td>
+						<td class="o-table__cell--numeric">55</td>
+						<td class="o-table__cell--numeric">76</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">109</td>
+						<td><a href="http://freepik.com/" data-trackable="link" target="_blank">Freepik</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">1033%</td>
+						<td class="o-table__cell--numeric">124.60%</td>
+						<td class="o-table__cell--numeric">7,730</td>
+						<td class="o-table__cell--numeric">37</td>
+						<td class="o-table__cell--numeric">47</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">110</td>
+						<td><a href="http://storytel.co/" data-trackable="link" target="_blank">Storytel</a></td>
+						<td><a href="https://www.ft.com/topics/places/Sweden" data-trackable="link">Sweden</a></td>
+						<td><a href="https://www.ft.com/companies/media" data-trackable="link">Media</a></td>
+						<td class="o-table__cell--numeric">1007%</td>
+						<td class="o-table__cell--numeric">122.90%</td>
+						<td class="o-table__cell--numeric">78,647</td>
+						<td class="o-table__cell--numeric">148</td>
+						<td class="o-table__cell--numeric">164</td>
+						<td>2005</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">111</td>
+						<td><a href="http://accenta.info/" data-trackable="link" target="_blank">ACCENTA Music &amp;
+								P.O.S.</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/media" data-trackable="link">Media</a></td>
+						<td class="o-table__cell--numeric">1005%</td>
+						<td class="o-table__cell--numeric">122.70%</td>
+						<td class="o-table__cell--numeric">3,475</td>
+						<td class="o-table__cell--numeric">10</td>
+						<td class="o-table__cell--numeric">13</td>
+						<td>2006</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">112</td>
+						<td><a href="http://groupe-quintesens.fr/" data-trackable="link" target="_blank">Groupe
+								Quintesens</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/financial-services" data-trackable="link">Financial
+								Services</a></td>
+						<td class="o-table__cell--numeric">1004%</td>
+						<td class="o-table__cell--numeric">122.70%</td>
+						<td class="o-table__cell--numeric">13,416</td>
+						<td class="o-table__cell--numeric">4</td>
+						<td class="o-table__cell--numeric">9</td>
+						<td>2009</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">113</td>
+						<td><a href="http://animalmaker.es/" data-trackable="link" target="_blank">Animal Maker</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Advertising" data-trackable="link">Advertising</a>
+						</td>
+						<td class="o-table__cell--numeric">981%</td>
+						<td class="o-table__cell--numeric">121.10%</td>
+						<td class="o-table__cell--numeric">8,105</td>
+						<td class="o-table__cell--numeric">17</td>
+						<td class="o-table__cell--numeric">24</td>
+						<td>2005</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">114</td>
+						<td><a href="http://lovecrafts.com/" data-trackable="link" target="_blank">LoveCrafts</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Ecommerce" data-trackable="link">Ecommerce</a>
+						</td>
+						<td class="o-table__cell--numeric">976%</td>
+						<td class="o-table__cell--numeric">120.80%</td>
+						<td class="o-table__cell--numeric">21,282</td>
+						<td class="o-table__cell--numeric">103</td>
+						<td class="o-table__cell--numeric">121</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">115</td>
+						<td><a href="http://ziegler.global/" data-trackable="link" target="_blank">Ziegler Group</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/transport" data-trackable="link">Transport</a></td>
+						<td class="o-table__cell--numeric">974%</td>
+						<td class="o-table__cell--numeric">120.70%</td>
+						<td class="o-table__cell--numeric">20,347</td>
+						<td class="o-table__cell--numeric">94</td>
+						<td class="o-table__cell--numeric">98</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">116</td>
+						<td><a href="http://www.multitrax.it/" data-trackable="link" target="_blank">MTRAX*</a></td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Sales_&amp;_Marketing" data-trackable="link">Sales
+								&amp; Marketing</a></td>
+						<td class="o-table__cell--numeric">964%</td>
+						<td class="o-table__cell--numeric">120%</td>
+						<td class="o-table__cell--numeric">10,536</td>
+						<td class="o-table__cell--numeric">3</td>
+						<td class="o-table__cell--numeric">5</td>
+						<td>2013</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">117</td>
+						<td><a href="http://sdeibar.com/" data-trackable="link" target="_blank">Sociedad Deportiva
+								Eibar</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/companies/travel-leisure" data-trackable="link">Travel &amp;
+								Leisure</a></td>
+						<td class="o-table__cell--numeric">964%</td>
+						<td class="o-table__cell--numeric">119.90%</td>
+						<td class="o-table__cell--numeric">42,999</td>
+						<td class="o-table__cell--numeric">48</td>
+						<td class="o-table__cell--numeric">87</td>
+						<td>1940</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">118</td>
+						<td><a href="http://fraudbuster.mobi/" data-trackable="link" target="_blank">FraudBuster</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Cyber_Security" data-trackable="link">Cyber
+								Security</a></td>
+						<td class="o-table__cell--numeric">961%</td>
+						<td class="o-table__cell--numeric">119.70%</td>
+						<td class="o-table__cell--numeric">7,007</td>
+						<td class="o-table__cell--numeric">26</td>
+						<td class="o-table__cell--numeric">32</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">119</td>
+						<td><a href="http://visioplanhaus.de/" data-trackable="link" target="_blank">Visio Planhaus*</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/construction" data-trackable="link">Construction</a>
+						</td>
+						<td class="o-table__cell--numeric">960%</td>
+						<td class="o-table__cell--numeric">119.70%</td>
+						<td class="o-table__cell--numeric">10,600</td>
+						<td class="o-table__cell--numeric">13</td>
+						<td class="o-table__cell--numeric">15</td>
+						<td>2013</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">120</td>
+						<td><a href="http://exselgroup.com/" data-trackable="link" target="_blank">Exsel IT &amp;
+								Communications</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">959%</td>
+						<td class="o-table__cell--numeric">119.60%</td>
+						<td class="o-table__cell--numeric">3,214</td>
+						<td class="o-table__cell--numeric">33</td>
+						<td class="o-table__cell--numeric">39</td>
+						<td>2008</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">121</td>
+						<td><a href="http://exercon.de/" data-trackable="link" target="_blank">exercon sales</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/energy" data-trackable="link">Energy</a></td>
+						<td class="o-table__cell--numeric">958%</td>
+						<td class="o-table__cell--numeric">119.50%</td>
+						<td class="o-table__cell--numeric">4,219</td>
+						<td class="o-table__cell--numeric">11</td>
+						<td class="o-table__cell--numeric">15</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">122</td>
+						<td><a href="http://attestationlegale.fr/" data-trackable="link" target="_blank">Attestation
+								Légale</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">957%</td>
+						<td class="o-table__cell--numeric">119.50%</td>
+						<td class="o-table__cell--numeric">3,388</td>
+						<td class="o-table__cell--numeric">36</td>
+						<td class="o-table__cell--numeric">53</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">123</td>
+						<td><a href="http://caffeina.com/" data-trackable="link" target="_blank">Caffeina</a></td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Advertising" data-trackable="link">Advertising</a>
+						</td>
+						<td class="o-table__cell--numeric">956%</td>
+						<td class="o-table__cell--numeric">119.40%</td>
+						<td class="o-table__cell--numeric">3,639</td>
+						<td class="o-table__cell--numeric">39</td>
+						<td class="o-table__cell--numeric">48</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">124</td>
+						<td><a href="http://cityshopwest.de/" data-trackable="link" target="_blank">City Shop West
+								Kiosk</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/retail" data-trackable="link">Retail</a></td>
+						<td class="o-table__cell--numeric">950%</td>
+						<td class="o-table__cell--numeric">119%</td>
+						<td class="o-table__cell--numeric">1,995</td>
+						<td class="o-table__cell--numeric">13</td>
+						<td class="o-table__cell--numeric">14</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">125</td>
+						<td><a href="http://joincontract.com/" data-trackable="link" target="_blank">Join Contract</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">948%</td>
+						<td class="o-table__cell--numeric">118.80%</td>
+						<td class="o-table__cell--numeric">8,907</td>
+						<td class="o-table__cell--numeric">8</td>
+						<td class="o-table__cell--numeric">12</td>
+						<td>2008</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">126</td>
+						<td><a href="http://oregoldinvestimentioro.it/" data-trackable="link"
+								target="_blank">Oregold</a></td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Precious_metals" data-trackable="link">Precious
+								metals</a></td>
+						<td class="o-table__cell--numeric">943%</td>
+						<td class="o-table__cell--numeric">118.50%</td>
+						<td class="o-table__cell--numeric">23,094</td>
+						<td class="o-table__cell--numeric">0</td>
+						<td class="o-table__cell--numeric">2</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">127</td>
+						<td><a href="http://kiece.fr/" data-trackable="link" target="_blank">Kiece</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">939%</td>
+						<td class="o-table__cell--numeric">118.20%</td>
+						<td class="o-table__cell--numeric">2,279</td>
+						<td class="o-table__cell--numeric">9</td>
+						<td class="o-table__cell--numeric">14</td>
+						<td>2006</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">128</td>
+						<td><a href="http://minttowercapital.com/" data-trackable="link" target="_blank">Mint Tower</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Netherlands" data-trackable="link">The
+								Netherlands</a></td>
+						<td><a href="https://www.ft.com/companies/financial-services" data-trackable="link">Financial
+								Services</a></td>
+						<td class="o-table__cell--numeric">937%</td>
+						<td class="o-table__cell--numeric">118.10%</td>
+						<td class="o-table__cell--numeric">5,359</td>
+						<td class="o-table__cell--numeric">9</td>
+						<td class="o-table__cell--numeric">15</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">129</td>
+						<td><a href="http://sublimeskinz.com/" data-trackable="link" target="_blank">Sublime Skinz</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Advertising" data-trackable="link">Advertising</a>
+						</td>
+						<td class="o-table__cell--numeric">937%</td>
+						<td class="o-table__cell--numeric">118.10%</td>
+						<td class="o-table__cell--numeric">15,915</td>
+						<td class="o-table__cell--numeric">63</td>
+						<td class="o-table__cell--numeric">70</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">130</td>
+						<td><a href="http://kreditech.com/" data-trackable="link" target="_blank">Kreditech Holding
+								SSL</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/fintech" data-trackable="link">Fintech</a></td>
+						<td class="o-table__cell--numeric">930%</td>
+						<td class="o-table__cell--numeric">117.50%</td>
+						<td class="o-table__cell--numeric">45,300</td>
+						<td class="o-table__cell--numeric">255</td>
+						<td class="o-table__cell--numeric">295</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">131</td>
+						<td><a href="http://afinnaone.com/" data-trackable="link" target="_blank">Afinna One</a></td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/companies/telecoms" data-trackable="link">Telecoms</a></td>
+						<td class="o-table__cell--numeric">910%</td>
+						<td class="o-table__cell--numeric">116.10%</td>
+						<td class="o-table__cell--numeric">45,816</td>
+						<td class="o-table__cell--numeric">2</td>
+						<td class="o-table__cell--numeric">5</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">132</td>
+						<td><a href="http://attrecto.com/" data-trackable="link" target="_blank">Attrecto</a></td>
+						<td><a href="https://www.ft.com/topics/places/Hungary" data-trackable="link">Hungary</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">902%</td>
+						<td class="o-table__cell--numeric">115.60%</td>
+						<td class="o-table__cell--numeric">2,580</td>
+						<td class="o-table__cell--numeric">36</td>
+						<td class="o-table__cell--numeric">47</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">133</td>
+						<td><a href="http://superprof.fr/" data-trackable="link" target="_blank">Superprof</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/stream/d320c9d7-1638-4388-b667-a5d63bd4bbc2"
+								data-trackable="link">Education</a></td>
+						<td class="o-table__cell--numeric">901%</td>
+						<td class="o-table__cell--numeric">115.50%</td>
+						<td class="o-table__cell--numeric">1,534</td>
+						<td class="o-table__cell--numeric">24</td>
+						<td class="o-table__cell--numeric">28</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">134</td>
+						<td><a href="http://redman.fr/" data-trackable="link" target="_blank">Groupe Redman</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/property" data-trackable="link">Property</a></td>
+						<td class="o-table__cell--numeric">896%</td>
+						<td class="o-table__cell--numeric">115.20%</td>
+						<td class="o-table__cell--numeric">41,570</td>
+						<td class="o-table__cell--numeric">28</td>
+						<td class="o-table__cell--numeric">40</td>
+						<td>2007</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">135</td>
+						<td>SFA Transports</td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/transport" data-trackable="link">Transport</a></td>
+						<td class="o-table__cell--numeric">895%</td>
+						<td class="o-table__cell--numeric">115.10%</td>
+						<td class="o-table__cell--numeric">2,007</td>
+						<td class="o-table__cell--numeric">11</td>
+						<td class="o-table__cell--numeric">12</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">136</td>
+						<td><a href="http://hajoona.com/" data-trackable="link" target="_blank">hajoona</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/health" data-trackable="link">Health</a></td>
+						<td class="o-table__cell--numeric">872%</td>
+						<td class="o-table__cell--numeric">113.40%</td>
+						<td class="o-table__cell--numeric">3,438</td>
+						<td class="o-table__cell--numeric">10</td>
+						<td class="o-table__cell--numeric">13</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">137</td>
+						<td><a href="http://mep-werke.de/" data-trackable="link" target="_blank">MEP Werke</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/energy" data-trackable="link">Energy</a></td>
+						<td class="o-table__cell--numeric">867%</td>
+						<td class="o-table__cell--numeric">113.10%</td>
+						<td class="o-table__cell--numeric">17,656</td>
+						<td class="o-table__cell--numeric">39</td>
+						<td class="o-table__cell--numeric">65</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">138</td>
+						<td><a href="http://leyfa-measurement.fr/" data-trackable="link" target="_blank">LEYFA
+								Measurement</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/construction" data-trackable="link">Construction</a>
+						</td>
+						<td class="o-table__cell--numeric">866%</td>
+						<td class="o-table__cell--numeric">112.90%</td>
+						<td class="o-table__cell--numeric">2,493</td>
+						<td class="o-table__cell--numeric">26</td>
+						<td class="o-table__cell--numeric">32</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">139</td>
+						<td><a href="http://devus.de/" data-trackable="link" target="_blank">DEVUS Autopartner</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/automobiles" data-trackable="link">Automobiles</a>
+						</td>
+						<td class="o-table__cell--numeric">859%</td>
+						<td class="o-table__cell--numeric">112.40%</td>
+						<td class="o-table__cell--numeric">36,126</td>
+						<td class="o-table__cell--numeric">19</td>
+						<td class="o-table__cell--numeric">24</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">140</td>
+						<td><a href="http://suselektro.de/" data-trackable="link" target="_blank">SuS Deutschland</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">858%</td>
+						<td class="o-table__cell--numeric">112.40%</td>
+						<td class="o-table__cell--numeric">2,300</td>
+						<td class="o-table__cell--numeric">51</td>
+						<td class="o-table__cell--numeric">55</td>
+						<td>1980</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">141</td>
+						<td><a href="http://cesamcorp.com/" data-trackable="link" target="_blank">Cesam</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/beauty" data-trackable="link">Beauty</a></td>
+						<td class="o-table__cell--numeric">857%</td>
+						<td class="o-table__cell--numeric">112.30%</td>
+						<td class="o-table__cell--numeric">5,792</td>
+						<td class="o-table__cell--numeric">7</td>
+						<td class="o-table__cell--numeric">10</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">142</td>
+						<td><a href="http://kernel-analytics.com/" data-trackable="link" target="_blank">Kernel
+								Analytics*</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">856%</td>
+						<td class="o-table__cell--numeric">112.30%</td>
+						<td class="o-table__cell--numeric">3,513</td>
+						<td class="o-table__cell--numeric">31</td>
+						<td class="o-table__cell--numeric">42</td>
+						<td>2013</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">143</td>
+						<td><a href="http://akademie-sport-gesundheit.de/" data-trackable="link"
+								target="_blank">Akademie für Sport und Gesundheit</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/health" data-trackable="link">Health</a></td>
+						<td class="o-table__cell--numeric">855%</td>
+						<td class="o-table__cell--numeric">112.20%</td>
+						<td class="o-table__cell--numeric">2,193</td>
+						<td class="o-table__cell--numeric">12</td>
+						<td class="o-table__cell--numeric">15</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">144</td>
+						<td><a href="http://rimac-automobili.com/" data-trackable="link" target="_blank">Rimac
+								Automobili</a></td>
+						<td><a href="https://www.ft.com/topics/places/Croatia" data-trackable="link">Croatia</a></td>
+						<td><a href="https://www.ft.com/companies/automobiles" data-trackable="link">Automobiles</a>
+						</td>
+						<td class="o-table__cell--numeric">854%</td>
+						<td class="o-table__cell--numeric">112.10%</td>
+						<td class="o-table__cell--numeric">5,873</td>
+						<td class="o-table__cell--numeric">152</td>
+						<td class="o-table__cell--numeric">164</td>
+						<td>2009</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">145</td>
+						<td><a href="http://dexga.com/" data-trackable="link" target="_blank">Dexga Technologies</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">851%</td>
+						<td class="o-table__cell--numeric">111.80%</td>
+						<td class="o-table__cell--numeric">1,928</td>
+						<td class="o-table__cell--numeric">2</td>
+						<td class="o-table__cell--numeric">8</td>
+						<td>2008</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">146</td>
+						<td><a href="http://lionsmart.com/" data-trackable="link" target="_blank">LION Smart</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/automobiles" data-trackable="link">Automobiles</a>
+						</td>
+						<td class="o-table__cell--numeric">851%</td>
+						<td class="o-table__cell--numeric">111.80%</td>
+						<td class="o-table__cell--numeric">2,386</td>
+						<td class="o-table__cell--numeric">14</td>
+						<td class="o-table__cell--numeric">18</td>
+						<td>2008</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">147</td>
+						<td><a href="http://lottoland.co.uk/" data-trackable="link" target="_blank">Lottoland*</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/stream/f9c6d3fe-5e16-479c-b762-bccdeeb349fe"
+								data-trackable="link">Games industry</a></td>
+						<td class="o-table__cell--numeric">842%</td>
+						<td class="o-table__cell--numeric">111.20%</td>
+						<td class="o-table__cell--numeric">251,600</td>
+						<td class="o-table__cell--numeric">198</td>
+						<td class="o-table__cell--numeric">249</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">148</td>
+						<td><a href="http://emazing.com.es/" data-trackable="link" target="_blank">iSpace
+								Informática</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">838%</td>
+						<td class="o-table__cell--numeric">110.90%</td>
+						<td class="o-table__cell--numeric">11,444</td>
+						<td class="o-table__cell--numeric">3</td>
+						<td class="o-table__cell--numeric">8</td>
+						<td>2009</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">149</td>
+						<td><a href="http://etniacosmetics.com/" data-trackable="link" target="_blank">Etnia Dreams</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/beauty" data-trackable="link">Beauty</a></td>
+						<td class="o-table__cell--numeric">825%</td>
+						<td class="o-table__cell--numeric">109.90%</td>
+						<td class="o-table__cell--numeric">5,528</td>
+						<td class="o-table__cell--numeric">168</td>
+						<td class="o-table__cell--numeric">200</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">150</td>
+						<td><a href="http://artos.ag/" data-trackable="link" target="_blank">artos AG</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/retail" data-trackable="link">Retail</a></td>
+						<td class="o-table__cell--numeric">824%</td>
+						<td class="o-table__cell--numeric">109.90%</td>
+						<td class="o-table__cell--numeric">4,467</td>
+						<td class="o-table__cell--numeric">4</td>
+						<td class="o-table__cell--numeric">7</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">151</td>
+						<td><a href="http://lemonway.com/" data-trackable="link" target="_blank">Lemon Way</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/fintech" data-trackable="link">Fintech</a></td>
+						<td class="o-table__cell--numeric">820%</td>
+						<td class="o-table__cell--numeric">109.60%</td>
+						<td class="o-table__cell--numeric">6,524</td>
+						<td class="o-table__cell--numeric">47</td>
+						<td class="o-table__cell--numeric">56</td>
+						<td>2007</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">152</td>
+						<td><a href="http://avis-verifies.com/" data-trackable="link" target="_blank">Net Reviews</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">819%</td>
+						<td class="o-table__cell--numeric">109.50%</td>
+						<td class="o-table__cell--numeric">2,866</td>
+						<td class="o-table__cell--numeric">n/a</td>
+						<td class="o-table__cell--numeric">23</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">153</td>
+						<td><a href="http://crosscall.com/" data-trackable="link" target="_blank">Crosscall</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">819%</td>
+						<td class="o-table__cell--numeric">109.40%</td>
+						<td class="o-table__cell--numeric">29,790</td>
+						<td class="o-table__cell--numeric">66</td>
+						<td class="o-table__cell--numeric">76</td>
+						<td>2009</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">154</td>
+						<td><a href="http://filoblu.com/" data-trackable="link" target="_blank">FiloBlu</a></td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Ecommerce" data-trackable="link">Ecommerce</a>
+						</td>
+						<td class="o-table__cell--numeric">813%</td>
+						<td class="o-table__cell--numeric">109%</td>
+						<td class="o-table__cell--numeric">13,606</td>
+						<td class="o-table__cell--numeric">73</td>
+						<td class="o-table__cell--numeric">96</td>
+						<td>2009</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">155</td>
+						<td><a href="http://tempus-sachsen.de/" data-trackable="link" target="_blank">TEMPUS
+								Personal</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">811%</td>
+						<td class="o-table__cell--numeric">108.90%</td>
+						<td class="o-table__cell--numeric">6,313</td>
+						<td class="o-table__cell--numeric">6</td>
+						<td class="o-table__cell--numeric">9</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">156</td>
+						<td><a href="http://autodoc.de/" data-trackable="link" target="_blank">Autodoc</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/automobiles" data-trackable="link">Automobiles</a>
+						</td>
+						<td class="o-table__cell--numeric">811%</td>
+						<td class="o-table__cell--numeric">108.80%</td>
+						<td class="o-table__cell--numeric">118,107</td>
+						<td class="o-table__cell--numeric">300</td>
+						<td class="o-table__cell--numeric">320</td>
+						<td>2008</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">157</td>
+						<td><a href="http://eden-port.com/" data-trackable="link" target="_blank">Eden Port*</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/personal-goods" data-trackable="link">Personal &amp;
+								Household Goods</a></td>
+						<td class="o-table__cell--numeric">810%</td>
+						<td class="o-table__cell--numeric">108.80%</td>
+						<td class="o-table__cell--numeric">1,555</td>
+						<td class="o-table__cell--numeric">1</td>
+						<td class="o-table__cell--numeric">3</td>
+						<td>2013</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">158</td>
+						<td><a href="http://3vcargo.de/" data-trackable="link" target="_blank">3V Cargo</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/transport" data-trackable="link">Transport</a></td>
+						<td class="o-table__cell--numeric">807%</td>
+						<td class="o-table__cell--numeric">108.50%</td>
+						<td class="o-table__cell--numeric">6,671</td>
+						<td class="o-table__cell--numeric">27</td>
+						<td class="o-table__cell--numeric">38</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">159</td>
+						<td><a href="http://fioulreduc.com/" data-trackable="link" target="_blank">FioulReduc</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/retail" data-trackable="link">Retail</a></td>
+						<td class="o-table__cell--numeric">803%</td>
+						<td class="o-table__cell--numeric">108.20%</td>
+						<td class="o-table__cell--numeric">13,062</td>
+						<td class="o-table__cell--numeric">7</td>
+						<td class="o-table__cell--numeric">10</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">160</td>
+						<td><a href="http://apotea.se/" data-trackable="link" target="_blank">Apotea</a></td>
+						<td><a href="https://www.ft.com/topics/places/Sweden" data-trackable="link">Sweden</a></td>
+						<td><a href="https://www.ft.com/companies/pharmaceuticals"
+								data-trackable="link">Pharmaceuticals</a></td>
+						<td class="o-table__cell--numeric">799%</td>
+						<td class="o-table__cell--numeric">107.90%</td>
+						<td class="o-table__cell--numeric">102,298</td>
+						<td class="o-table__cell--numeric">254</td>
+						<td class="o-table__cell--numeric">281</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">161</td>
+						<td><a href="http://motork.io/" data-trackable="link" target="_blank">MotorK Italia</a></td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Sales_&amp;_Marketing" data-trackable="link">Sales
+								&amp; Marketing</a></td>
+						<td class="o-table__cell--numeric">796%</td>
+						<td class="o-table__cell--numeric">107.70%</td>
+						<td class="o-table__cell--numeric">10,446</td>
+						<td class="o-table__cell--numeric">109</td>
+						<td class="o-table__cell--numeric">118</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">162</td>
+						<td><a href="http://pianetaoutlet.it/" data-trackable="link" target="_blank">Elle Moda</a></td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Ecommerce" data-trackable="link">Ecommerce</a>
+						</td>
+						<td class="o-table__cell--numeric">794%</td>
+						<td class="o-table__cell--numeric">107.50%</td>
+						<td class="o-table__cell--numeric">2,628</td>
+						<td class="o-table__cell--numeric">3</td>
+						<td class="o-table__cell--numeric">5</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">163</td>
+						<td><a href="http://pisamonas.es/" data-trackable="link" target="_blank">Pisamonas</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/stream/f9f7535d-3b5c-47a7-bd15-3e10dceee597"
+								data-trackable="link">Fashion</a></td>
+						<td class="o-table__cell--numeric">794%</td>
+						<td class="o-table__cell--numeric">107.50%</td>
+						<td class="o-table__cell--numeric">5,826</td>
+						<td class="o-table__cell--numeric">19</td>
+						<td class="o-table__cell--numeric">31</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">164</td>
+						<td><a href="http://funidelia.info/" data-trackable="link" target="_blank">Funiglobal</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Ecommerce" data-trackable="link">Ecommerce</a>
+						</td>
+						<td class="o-table__cell--numeric">792%</td>
+						<td class="o-table__cell--numeric">107.40%</td>
+						<td class="o-table__cell--numeric">10,700</td>
+						<td class="o-table__cell--numeric">30</td>
+						<td class="o-table__cell--numeric">45</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">165</td>
+						<td><a href="http://chevaliertechnologies.com/" data-trackable="link" target="_blank">Chevalier
+								Technologies</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/companies/automobiles" data-trackable="link">Automobiles</a>
+						</td>
+						<td class="o-table__cell--numeric">789%</td>
+						<td class="o-table__cell--numeric">107.20%</td>
+						<td class="o-table__cell--numeric">7,244</td>
+						<td class="o-table__cell--numeric">27</td>
+						<td class="o-table__cell--numeric">35</td>
+						<td>2008</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">166</td>
+						<td><a href="http://cloudcall.com/" data-trackable="link" target="_blank">Cloudcall Group</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">787%</td>
+						<td class="o-table__cell--numeric">107%</td>
+						<td class="o-table__cell--numeric">5,944</td>
+						<td class="o-table__cell--numeric">49</td>
+						<td class="o-table__cell--numeric">89</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">167</td>
+						<td><a href="http://dewarens.fr/" data-trackable="link" target="_blank">WBP</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/retail" data-trackable="link">Retail</a></td>
+						<td class="o-table__cell--numeric">785%</td>
+						<td class="o-table__cell--numeric">106.90%</td>
+						<td class="o-table__cell--numeric">3,317</td>
+						<td class="o-table__cell--numeric">n/a</td>
+						<td class="o-table__cell--numeric">4</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">168</td>
+						<td><a href="http://fonix.com/" data-trackable="link" target="_blank">Fonix</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/fintech" data-trackable="link">Fintech</a></td>
+						<td class="o-table__cell--numeric">785%</td>
+						<td class="o-table__cell--numeric">106.80%</td>
+						<td class="o-table__cell--numeric">55,455</td>
+						<td class="o-table__cell--numeric">5</td>
+						<td class="o-table__cell--numeric">19</td>
+						<td>2006</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">169</td>
+						<td><a href="http://blascar.com/" data-trackable="link" target="_blank">Bláscar</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/companies/construction" data-trackable="link">Construction</a>
+						</td>
+						<td class="o-table__cell--numeric">777%</td>
+						<td class="o-table__cell--numeric">106.20%</td>
+						<td class="o-table__cell--numeric">9,195</td>
+						<td class="o-table__cell--numeric">42</td>
+						<td class="o-table__cell--numeric">80</td>
+						<td>1980</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">170</td>
+						<td><a href="http://travellanda.com/" data-trackable="link" target="_blank">Travellanda</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/companies/travel-leisure" data-trackable="link">Travel &amp;
+								Leisure</a></td>
+						<td class="o-table__cell--numeric">774%</td>
+						<td class="o-table__cell--numeric">106%</td>
+						<td class="o-table__cell--numeric">60,503</td>
+						<td class="o-table__cell--numeric">27</td>
+						<td class="o-table__cell--numeric">40</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">171</td>
+						<td><a href="http://boaconcept.com/" data-trackable="link" target="_blank">Boa Concept</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">766%</td>
+						<td class="o-table__cell--numeric">105.30%</td>
+						<td class="o-table__cell--numeric">6,679</td>
+						<td class="o-table__cell--numeric">n/a</td>
+						<td class="o-table__cell--numeric">14</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">172</td>
+						<td><a href="http://convent-energy.com/" data-trackable="link" target="_blank">convent
+								energy</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">763%</td>
+						<td class="o-table__cell--numeric">105.10%</td>
+						<td class="o-table__cell--numeric">7,930</td>
+						<td class="o-table__cell--numeric">172</td>
+						<td class="o-table__cell--numeric">262</td>
+						<td>2007</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">173</td>
+						<td><a href="http://crestanevada.es/" data-trackable="link" target="_blank">Crestanevada</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/companies/automobiles" data-trackable="link">Automobiles</a>
+						</td>
+						<td class="o-table__cell--numeric">761%</td>
+						<td class="o-table__cell--numeric">105%</td>
+						<td class="o-table__cell--numeric">3,850</td>
+						<td class="o-table__cell--numeric">5</td>
+						<td class="o-table__cell--numeric">8</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">174</td>
+						<td><a href="http://greentechplc.co.uk/" data-trackable="link" target="_blank">GreenTech
+								Distribution</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/companies/telecoms" data-trackable="link">Telecoms</a></td>
+						<td class="o-table__cell--numeric">761%</td>
+						<td class="o-table__cell--numeric">105%</td>
+						<td class="o-table__cell--numeric">192,247</td>
+						<td class="o-table__cell--numeric">13</td>
+						<td class="o-table__cell--numeric">28</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">175</td>
+						<td><a href="http://leslipfrancais.fr/" data-trackable="link" target="_blank">Le Slip
+								Français</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/stream/f9f7535d-3b5c-47a7-bd15-3e10dceee597"
+								data-trackable="link">Fashion</a></td>
+						<td class="o-table__cell--numeric">761%</td>
+						<td class="o-table__cell--numeric">104.90%</td>
+						<td class="o-table__cell--numeric">7,600</td>
+						<td class="o-table__cell--numeric">31</td>
+						<td class="o-table__cell--numeric">34</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">176</td>
+						<td><a href="http://laserwiresolutions.com/" data-trackable="link" target="_blank">LW
+								Solutions</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/companies/industrial-goods" data-trackable="link">Industrial
+								Goods</a></td>
+						<td class="o-table__cell--numeric">748%</td>
+						<td class="o-table__cell--numeric">104%</td>
+						<td class="o-table__cell--numeric">1,901</td>
+						<td class="o-table__cell--numeric">11</td>
+						<td class="o-table__cell--numeric">14</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">177</td>
+						<td><a href="http://consorziodelletecnologie.it/" data-trackable="link"
+								target="_blank">Consorzio delle Tecnologie</a></td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">747%</td>
+						<td class="o-table__cell--numeric">103.80%</td>
+						<td class="o-table__cell--numeric">5,397</td>
+						<td class="o-table__cell--numeric">0</td>
+						<td class="o-table__cell--numeric">1</td>
+						<td>2006</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">178</td>
+						<td><a href="http://efcnorge.no/" data-trackable="link" target="_blank">EFC Norge</a></td>
+						<td><a href="https://www.ft.com/topics/places/Norway" data-trackable="link">Norway</a></td>
+						<td><a href="https://www.ft.com/companies/construction" data-trackable="link">Construction</a>
+						</td>
+						<td class="o-table__cell--numeric">743%</td>
+						<td class="o-table__cell--numeric">103.50%</td>
+						<td class="o-table__cell--numeric">8,117</td>
+						<td class="o-table__cell--numeric">96</td>
+						<td class="o-table__cell--numeric">118</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">179</td>
+						<td><a href="http://verdnatura.es/" data-trackable="link" target="_blank">Verdnatura Levante</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/companies/retail" data-trackable="link">Retail</a></td>
+						<td class="o-table__cell--numeric">741%</td>
+						<td class="o-table__cell--numeric">103.40%</td>
+						<td class="o-table__cell--numeric">27,893</td>
+						<td class="o-table__cell--numeric">112</td>
+						<td class="o-table__cell--numeric">126</td>
+						<td>2003</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">180</td>
+						<td><a href="http://eleanor-wine.com/" data-trackable="link" target="_blank">Eleanor</a></td>
+						<td><a href="https://www.ft.com/topics/places/Netherlands" data-trackable="link">The
+								Netherlands</a></td>
+						<td><a href="https://www.ft.com/companies/food-beverage" data-trackable="link">Food &amp;
+								Beverage</a></td>
+						<td class="o-table__cell--numeric">735%</td>
+						<td class="o-table__cell--numeric">102.90%</td>
+						<td class="o-table__cell--numeric">4,292</td>
+						<td class="o-table__cell--numeric">3</td>
+						<td class="o-table__cell--numeric">5</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">181</td>
+						<td><a href="http://red-badger.com/" data-trackable="link" target="_blank">Red Badger
+								Consulting</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://ig.ft.com/ft-1000/2018/" data-trackable="link">Management Consulting</a>
+						</td>
+						<td class="o-table__cell--numeric">732%</td>
+						<td class="o-table__cell--numeric">102.60%</td>
+						<td class="o-table__cell--numeric">8,857</td>
+						<td class="o-table__cell--numeric">67</td>
+						<td class="o-table__cell--numeric">78</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">182</td>
+						<td><a href="http://eredirossinidomenico.com/" data-trackable="link" target="_blank">Eredi
+								Rossini Domenico</a></td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/companies/construction" data-trackable="link">Construction</a>
+						</td>
+						<td class="o-table__cell--numeric">732%</td>
+						<td class="o-table__cell--numeric">102.60%</td>
+						<td class="o-table__cell--numeric">17,172</td>
+						<td class="o-table__cell--numeric">3</td>
+						<td class="o-table__cell--numeric">4</td>
+						<td>1977</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">183</td>
+						<td><a href="http://izettle.com/" data-trackable="link" target="_blank">iZettle</a></td>
+						<td><a href="https://www.ft.com/topics/places/Sweden" data-trackable="link">Sweden</a></td>
+						<td><a href="https://www.ft.com/fintech" data-trackable="link">Fintech</a></td>
+						<td class="o-table__cell--numeric">730%</td>
+						<td class="o-table__cell--numeric">102.50%</td>
+						<td class="o-table__cell--numeric">67,783</td>
+						<td class="o-table__cell--numeric">222</td>
+						<td class="o-table__cell--numeric">290</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">184</td>
+						<td><a href="http://flyvictor.com/" data-trackable="link" target="_blank">Victor</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/companies/travel-leisure" data-trackable="link">Travel &amp;
+								Leisure</a></td>
+						<td class="o-table__cell--numeric">726%</td>
+						<td class="o-table__cell--numeric">102.10%</td>
+						<td class="o-table__cell--numeric">36,671</td>
+						<td class="o-table__cell--numeric">47</td>
+						<td class="o-table__cell--numeric">55</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">185</td>
+						<td><a href="http://lotto24-ag.de/" data-trackable="link" target="_blank">Lotto24</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/stream/f9c6d3fe-5e16-479c-b762-bccdeeb349fe"
+								data-trackable="link">Games industry</a></td>
+						<td class="o-table__cell--numeric">724%</td>
+						<td class="o-table__cell--numeric">102%</td>
+						<td class="o-table__cell--numeric">22,759</td>
+						<td class="o-table__cell--numeric">53</td>
+						<td class="o-table__cell--numeric">79</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">186</td>
+						<td><a href="http://sanabio.de/" data-trackable="link" target="_blank">SanaBio</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/chemicals" data-trackable="link">Chemicals</a></td>
+						<td class="o-table__cell--numeric">722%</td>
+						<td class="o-table__cell--numeric">101.80%</td>
+						<td class="o-table__cell--numeric">2,465</td>
+						<td class="o-table__cell--numeric">4</td>
+						<td class="o-table__cell--numeric">6</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">187</td>
+						<td><a href="http://plug-in-digital.com/" data-trackable="link" target="_blank">Plug In
+								Digital</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/stream/f9c6d3fe-5e16-479c-b762-bccdeeb349fe"
+								data-trackable="link">Games industry</a></td>
+						<td class="o-table__cell--numeric">721%</td>
+						<td class="o-table__cell--numeric">101.80%</td>
+						<td class="o-table__cell--numeric">3,176</td>
+						<td class="o-table__cell--numeric">5</td>
+						<td class="o-table__cell--numeric">7</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">188</td>
+						<td><a href="http://townandcountryvibro.co.uk/" data-trackable="link" target="_blank">Town and
+								Country Vibro*</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/companies/construction" data-trackable="link">Construction</a>
+						</td>
+						<td class="o-table__cell--numeric">720%</td>
+						<td class="o-table__cell--numeric">101.70%</td>
+						<td class="o-table__cell--numeric">4,804</td>
+						<td class="o-table__cell--numeric">22</td>
+						<td class="o-table__cell--numeric">35</td>
+						<td>2013</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">189</td>
+						<td>SARL Kapulis</td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/retail" data-trackable="link">Retail</a></td>
+						<td class="o-table__cell--numeric">715%</td>
+						<td class="o-table__cell--numeric">101.30%</td>
+						<td class="o-table__cell--numeric">2,336</td>
+						<td class="o-table__cell--numeric">3</td>
+						<td class="o-table__cell--numeric">5</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">190</td>
+						<td><a href="http://augustinbau.com/" data-trackable="link" target="_blank">Augustin Bau</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/construction" data-trackable="link">Construction</a>
+						</td>
+						<td class="o-table__cell--numeric">714%</td>
+						<td class="o-table__cell--numeric">101.20%</td>
+						<td class="o-table__cell--numeric">7,980</td>
+						<td class="o-table__cell--numeric">39</td>
+						<td class="o-table__cell--numeric">50</td>
+						<td>1995</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">191</td>
+						<td><a href="http://eactivos.com/" data-trackable="link" target="_blank">Activos Concursales</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">714%</td>
+						<td class="o-table__cell--numeric">101.10%</td>
+						<td class="o-table__cell--numeric">3,084</td>
+						<td class="o-table__cell--numeric">9</td>
+						<td class="o-table__cell--numeric">14</td>
+						<td>2009</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">192</td>
+						<td><a href="http://zoot.cz/" data-trackable="link" target="_blank">ZOOT Group</a></td>
+						<td><a href="https://www.ft.com/topics/places/Czech_Republic" data-trackable="link">Czech
+								Republic</a></td>
+						<td><a href="https://www.ft.com/companies/retail" data-trackable="link">Retail</a></td>
+						<td class="o-table__cell--numeric">713%</td>
+						<td class="o-table__cell--numeric">101.10%</td>
+						<td class="o-table__cell--numeric">26,267</td>
+						<td class="o-table__cell--numeric">530</td>
+						<td class="o-table__cell--numeric">700</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">193</td>
+						<td><a href="http://trencadis.ro/" data-trackable="link" target="_blank">Trencadis</a></td>
+						<td><a href="https://www.ft.com/topics/places/Romania" data-trackable="link">Romania</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">710%</td>
+						<td class="o-table__cell--numeric">100.90%</td>
+						<td class="o-table__cell--numeric">4,324</td>
+						<td class="o-table__cell--numeric">-3</td>
+						<td class="o-table__cell--numeric">36</td>
+						<td>2007</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">194</td>
+						<td><a href="http://atlante.fr/" data-trackable="link" target="_blank">Atlante</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://ig.ft.com/ft-1000/2018/" data-trackable="link">Management Consulting</a>
+						</td>
+						<td class="o-table__cell--numeric">707%</td>
+						<td class="o-table__cell--numeric">100.60%</td>
+						<td class="o-table__cell--numeric">2,045</td>
+						<td class="o-table__cell--numeric">9</td>
+						<td class="o-table__cell--numeric">13</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">195</td>
+						<td><a href="http://milkthesun.de/" data-trackable="link" target="_blank">Milk the Sun</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/energy" data-trackable="link">Energy</a></td>
+						<td class="o-table__cell--numeric">706%</td>
+						<td class="o-table__cell--numeric">100.50%</td>
+						<td class="o-table__cell--numeric">2,309</td>
+						<td class="o-table__cell--numeric">6</td>
+						<td class="o-table__cell--numeric">16</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">196</td>
+						<td><a href="http://vest-massivhaus.de/" data-trackable="link" target="_blank">Vest
+								Massivhaus</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/construction" data-trackable="link">Construction</a>
+						</td>
+						<td class="o-table__cell--numeric">705%</td>
+						<td class="o-table__cell--numeric">100.40%</td>
+						<td class="o-table__cell--numeric">3,889</td>
+						<td class="o-table__cell--numeric">5</td>
+						<td class="o-table__cell--numeric">8</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">197</td>
+						<td><a href="http://premium-treppenlifte.com/" data-trackable="link" target="_blank">Premium
+								Treppenlifte</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/construction" data-trackable="link">Construction</a>
+						</td>
+						<td class="o-table__cell--numeric">705%</td>
+						<td class="o-table__cell--numeric">100.40%</td>
+						<td class="o-table__cell--numeric">2,608</td>
+						<td class="o-table__cell--numeric">5</td>
+						<td class="o-table__cell--numeric">8</td>
+						<td>2004</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">198</td>
+						<td><a href="http://i-live.de/" data-trackable="link" target="_blank">i Live Holding</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/construction" data-trackable="link">Construction</a>
+						</td>
+						<td class="o-table__cell--numeric">701%</td>
+						<td class="o-table__cell--numeric">100.10%</td>
+						<td class="o-table__cell--numeric">68,900</td>
+						<td class="o-table__cell--numeric">60</td>
+						<td class="o-table__cell--numeric">100</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">199</td>
+						<td><a href="http://greenstorm.eu/" data-trackable="link" target="_blank">Greenstorm
+								mobility</a></td>
+						<td><a href="https://www.ft.com/topics/places/Austria" data-trackable="link">Austria</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Ecommerce" data-trackable="link">Ecommerce</a>
+						</td>
+						<td class="o-table__cell--numeric">700%</td>
+						<td class="o-table__cell--numeric">100%</td>
+						<td class="o-table__cell--numeric">3,600</td>
+						<td class="o-table__cell--numeric">30</td>
+						<td class="o-table__cell--numeric">34</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">200</td>
+						<td><a href="http://geoortodonzia.it/" data-trackable="link" target="_blank">Gruppo Europeo di
+								Ortodonzia*</a></td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/companies/health" data-trackable="link">Health</a></td>
+						<td class="o-table__cell--numeric">699%</td>
+						<td class="o-table__cell--numeric">99.90%</td>
+						<td class="o-table__cell--numeric">1,530</td>
+						<td class="o-table__cell--numeric">8</td>
+						<td class="o-table__cell--numeric">15</td>
+						<td>2013</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">201</td>
+						<td><a href="http://cjdirect.de/" data-trackable="link" target="_blank">C &amp; J Direct</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/retail" data-trackable="link">Retail</a></td>
+						<td class="o-table__cell--numeric">691%</td>
+						<td class="o-table__cell--numeric">99.30%</td>
+						<td class="o-table__cell--numeric">14,442</td>
+						<td class="o-table__cell--numeric">42</td>
+						<td class="o-table__cell--numeric">54</td>
+						<td>2002</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">202</td>
+						<td><a href="http://ennismore.com/" data-trackable="link" target="_blank">Ennismore</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/companies/travel-leisure" data-trackable="link">Travel &amp;
+								Leisure</a></td>
+						<td class="o-table__cell--numeric">689%</td>
+						<td class="o-table__cell--numeric">99.10%</td>
+						<td class="o-table__cell--numeric">17,936</td>
+						<td class="o-table__cell--numeric">63</td>
+						<td class="o-table__cell--numeric">73</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">203</td>
+						<td><a href="http://appsvision.fr/" data-trackable="link" target="_blank">Appsvision</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">686%</td>
+						<td class="o-table__cell--numeric">98.80%</td>
+						<td class="o-table__cell--numeric">5,178</td>
+						<td class="o-table__cell--numeric">n/a</td>
+						<td class="o-table__cell--numeric">40</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">204</td>
+						<td><a href="http://domeniconava.it/" data-trackable="link" target="_blank">D. Nava 1961</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/companies/food-beverage" data-trackable="link">Food &amp;
+								Beverage</a></td>
+						<td class="o-table__cell--numeric">672%</td>
+						<td class="o-table__cell--numeric">97.60%</td>
+						<td class="o-table__cell--numeric">6,164</td>
+						<td class="o-table__cell--numeric">n/a</td>
+						<td class="o-table__cell--numeric">n/a</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">205</td>
+						<td><a href="http://cotramed.com/" data-trackable="link" target="_blank">Cotramed*</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/companies/transport" data-trackable="link">Transport</a></td>
+						<td class="o-table__cell--numeric">662%</td>
+						<td class="o-table__cell--numeric">96.70%</td>
+						<td class="o-table__cell--numeric">1,888</td>
+						<td class="o-table__cell--numeric">21</td>
+						<td class="o-table__cell--numeric">23</td>
+						<td>2013</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">206</td>
+						<td><a href="http://aula-salud.com/" data-trackable="link" target="_blank">Aula Salud</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/stream/d320c9d7-1638-4388-b667-a5d63bd4bbc2"
+								data-trackable="link">Education</a></td>
+						<td class="o-table__cell--numeric">660%</td>
+						<td class="o-table__cell--numeric">96.60%</td>
+						<td class="o-table__cell--numeric">5,976</td>
+						<td class="o-table__cell--numeric">15</td>
+						<td class="o-table__cell--numeric">26</td>
+						<td>2008</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">207</td>
+						<td><a href="http://nahimic.com/" data-trackable="link" target="_blank">A-Volute</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">660%</td>
+						<td class="o-table__cell--numeric">96.60%</td>
+						<td class="o-table__cell--numeric">2,813</td>
+						<td class="o-table__cell--numeric">17</td>
+						<td class="o-table__cell--numeric">32</td>
+						<td>2004</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">208</td>
+						<td><a href="http://lexer.es/" data-trackable="link" target="_blank">Lexer Abogados</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Law" data-trackable="link">Law</a></td>
+						<td class="o-table__cell--numeric">658%</td>
+						<td class="o-table__cell--numeric">96.40%</td>
+						<td class="o-table__cell--numeric">16,135</td>
+						<td class="o-table__cell--numeric">74</td>
+						<td class="o-table__cell--numeric">137</td>
+						<td>2001</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">209</td>
+						<td><a href="http://m2energie.com/" data-trackable="link" target="_blank">M2energie</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/energy" data-trackable="link">Energy</a></td>
+						<td class="o-table__cell--numeric">658%</td>
+						<td class="o-table__cell--numeric">96.40%</td>
+						<td class="o-table__cell--numeric">2,500</td>
+						<td class="o-table__cell--numeric">15</td>
+						<td class="o-table__cell--numeric">25</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">210</td>
+						<td><a href="http://aer-trading.com/" data-trackable="link" target="_blank">AER Trading*</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/food-beverage" data-trackable="link">Food &amp;
+								Beverage</a></td>
+						<td class="o-table__cell--numeric">655%</td>
+						<td class="o-table__cell--numeric">96.20%</td>
+						<td class="o-table__cell--numeric">2,074</td>
+						<td class="o-table__cell--numeric">0</td>
+						<td class="o-table__cell--numeric">1</td>
+						<td>2013</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">211</td>
+						<td><a href="http://housetohouse.eu/" data-trackable="link" target="_blank">House To House</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Sales_&amp;_Marketing" data-trackable="link">Sales
+								&amp; Marketing</a></td>
+						<td class="o-table__cell--numeric">655%</td>
+						<td class="o-table__cell--numeric">96.20%</td>
+						<td class="o-table__cell--numeric">6,950</td>
+						<td class="o-table__cell--numeric">13</td>
+						<td class="o-table__cell--numeric">18</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">212</td>
+						<td><a href="http://trakglobalgroup.com/" data-trackable="link" target="_blank">Trak Global
+								Group</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">652%</td>
+						<td class="o-table__cell--numeric">95.90%</td>
+						<td class="o-table__cell--numeric">26,323</td>
+						<td class="o-table__cell--numeric">191</td>
+						<td class="o-table__cell--numeric">223</td>
+						<td>2009</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">213</td>
+						<td><a href="http://whatsbeef.de/" data-trackable="link" target="_blank">What's Beef Assets*</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/restaurants" data-trackable="link">Restaurants</a></td>
+						<td class="o-table__cell--numeric">650%</td>
+						<td class="o-table__cell--numeric">95.70%</td>
+						<td class="o-table__cell--numeric">4,500</td>
+						<td class="o-table__cell--numeric">95</td>
+						<td class="o-table__cell--numeric">110</td>
+						<td>2013</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">214</td>
+						<td><a href="http://tekdom.es/" data-trackable="link" target="_blank">Tekdōm</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/companies/construction" data-trackable="link">Construction</a>
+						</td>
+						<td class="o-table__cell--numeric">647%</td>
+						<td class="o-table__cell--numeric">95.50%</td>
+						<td class="o-table__cell--numeric">2,000</td>
+						<td class="o-table__cell--numeric">10</td>
+						<td class="o-table__cell--numeric">14</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">215</td>
+						<td><a href="http://ludilabel.fr/" data-trackable="link" target="_blank">Ludilabel</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/retail" data-trackable="link">Retail</a></td>
+						<td class="o-table__cell--numeric">646%</td>
+						<td class="o-table__cell--numeric">95.40%</td>
+						<td class="o-table__cell--numeric">1,770</td>
+						<td class="o-table__cell--numeric">10</td>
+						<td class="o-table__cell--numeric">14</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">216</td>
+						<td><a href="http://davricourt.com/" data-trackable="link" target="_blank">Davricourt</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://ig.ft.com/ft-1000/2018/" data-trackable="link">Management Consulting</a>
+						</td>
+						<td class="o-table__cell--numeric">643%</td>
+						<td class="o-table__cell--numeric">95.10%</td>
+						<td class="o-table__cell--numeric">16,900</td>
+						<td class="o-table__cell--numeric">165</td>
+						<td class="o-table__cell--numeric">200</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">217</td>
+						<td><a href="http://showtruck-marketing.com/" data-trackable="link"
+								target="_blank">ShowTruckMarketing</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Advertising" data-trackable="link">Advertising</a>
+						</td>
+						<td class="o-table__cell--numeric">641%</td>
+						<td class="o-table__cell--numeric">95%</td>
+						<td class="o-table__cell--numeric">4,476</td>
+						<td class="o-table__cell--numeric">9</td>
+						<td class="o-table__cell--numeric">12</td>
+						<td>2009</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">218</td>
+						<td><a href="http://skservicios.es/" data-trackable="link" target="_blank">SK Servicios</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/architecture" data-trackable="link">Architecture</a></td>
+						<td class="o-table__cell--numeric">636%</td>
+						<td class="o-table__cell--numeric">94.50%</td>
+						<td class="o-table__cell--numeric">1,537</td>
+						<td class="o-table__cell--numeric">7</td>
+						<td class="o-table__cell--numeric">10</td>
+						<td>2005</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">219</td>
+						<td><a href="http://joinbusinessmc.com/" data-trackable="link" target="_blank">Join Business
+								MC*</a></td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://ig.ft.com/ft-1000/2018/" data-trackable="link">Management Consulting</a>
+						</td>
+						<td class="o-table__cell--numeric">625%</td>
+						<td class="o-table__cell--numeric">93.50%</td>
+						<td class="o-table__cell--numeric">2,432</td>
+						<td class="o-table__cell--numeric">18</td>
+						<td class="o-table__cell--numeric">20</td>
+						<td>2013</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">220</td>
+						<td><a href="http://neondiagnostics.co.uk/" data-trackable="link" target="_blank">Neon
+								Diagnostics</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/companies/health" data-trackable="link">Health</a></td>
+						<td class="o-table__cell--numeric">618%</td>
+						<td class="o-table__cell--numeric">92.90%</td>
+						<td class="o-table__cell--numeric">5,023</td>
+						<td class="o-table__cell--numeric">7</td>
+						<td class="o-table__cell--numeric">12</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">221</td>
+						<td><a href="http://testbirds.de/" data-trackable="link" target="_blank">Testbirds</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">617%</td>
+						<td class="o-table__cell--numeric">92.80%</td>
+						<td class="o-table__cell--numeric">4,050</td>
+						<td class="o-table__cell--numeric">60</td>
+						<td class="o-table__cell--numeric">85</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">222</td>
+						<td><a href="http://pammobility.com/" data-trackable="link" target="_blank">Pam Mobility</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/companies/health" data-trackable="link">Health</a></td>
+						<td class="o-table__cell--numeric">616%</td>
+						<td class="o-table__cell--numeric">92.70%</td>
+						<td class="o-table__cell--numeric">1,598</td>
+						<td class="o-table__cell--numeric">3</td>
+						<td class="o-table__cell--numeric">6</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">223</td>
+						<td><a href="http://joiisushi.com/" data-trackable="link" target="_blank">Joii Sushi*</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/companies/food-beverage" data-trackable="link">Food &amp;
+								Beverage</a></td>
+						<td class="o-table__cell--numeric">615%</td>
+						<td class="o-table__cell--numeric">92.70%</td>
+						<td class="o-table__cell--numeric">19,448</td>
+						<td class="o-table__cell--numeric">14</td>
+						<td class="o-table__cell--numeric">19</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">224</td>
+						<td><a href="http://griffinmarkets.com/" data-trackable="link" target="_blank">Griffin Markets
+								Group</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/companies/financial-services" data-trackable="link">Financial
+								Services</a></td>
+						<td class="o-table__cell--numeric">614%</td>
+						<td class="o-table__cell--numeric">92.60%</td>
+						<td class="o-table__cell--numeric">12,126</td>
+						<td class="o-table__cell--numeric">-1</td>
+						<td class="o-table__cell--numeric">26</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">225</td>
+						<td><a href="http://dogu.io/" data-trackable="link" target="_blank">Dogu AS</a></td>
+						<td><a href="https://www.ft.com/topics/places/Norway" data-trackable="link">Norway</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">608%</td>
+						<td class="o-table__cell--numeric">92%</td>
+						<td class="o-table__cell--numeric">1,748</td>
+						<td class="o-table__cell--numeric">4</td>
+						<td class="o-table__cell--numeric">15</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">226</td>
+						<td><a href="http://tiendeo.com/" data-trackable="link" target="_blank">Tiendeo Web
+								Marketing</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Sales_&amp;_Marketing" data-trackable="link">Sales
+								&amp; Marketing</a></td>
+						<td class="o-table__cell--numeric">607%</td>
+						<td class="o-table__cell--numeric">91.90%</td>
+						<td class="o-table__cell--numeric">4,766</td>
+						<td class="o-table__cell--numeric">57</td>
+						<td class="o-table__cell--numeric">75</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">227</td>
+						<td><a href="http://giaconsulting.it/" data-trackable="link" target="_blank">G.I.A.
+								Consulting*</a></td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">607%</td>
+						<td class="o-table__cell--numeric">91.90%</td>
+						<td class="o-table__cell--numeric">2,854</td>
+						<td class="o-table__cell--numeric">-6</td>
+						<td class="o-table__cell--numeric">10</td>
+						<td>2013</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">228</td>
+						<td><a href="http://greendonkey.de/" data-trackable="link" target="_blank">Greendonkey</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Ecommerce" data-trackable="link">Ecommerce</a>
+						</td>
+						<td class="o-table__cell--numeric">606%</td>
+						<td class="o-table__cell--numeric">91.90%</td>
+						<td class="o-table__cell--numeric">2,345</td>
+						<td class="o-table__cell--numeric">5</td>
+						<td class="o-table__cell--numeric">9</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">229</td>
+						<td>CH Montferrer*</td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/companies/retail" data-trackable="link">Retail</a></td>
+						<td class="o-table__cell--numeric">605%</td>
+						<td class="o-table__cell--numeric">91.70%</td>
+						<td class="o-table__cell--numeric">8,880</td>
+						<td class="o-table__cell--numeric">43</td>
+						<td class="o-table__cell--numeric">52</td>
+						<td>2013</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">230</td>
+						<td><a href="http://azuri-technologies.com/" data-trackable="link" target="_blank">Azuri
+								Technologies</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">603%</td>
+						<td class="o-table__cell--numeric">91.50%</td>
+						<td class="o-table__cell--numeric">2,280</td>
+						<td class="o-table__cell--numeric">5</td>
+						<td class="o-table__cell--numeric">20</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">231</td>
+						<td><a href="http://myelefant.com/" data-trackable="link" target="_blank">myElefant</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Sales_&amp;_Marketing" data-trackable="link">Sales
+								&amp; Marketing</a></td>
+						<td class="o-table__cell--numeric">601%</td>
+						<td class="o-table__cell--numeric">91.40%</td>
+						<td class="o-table__cell--numeric">4,535</td>
+						<td class="o-table__cell--numeric">14</td>
+						<td class="o-table__cell--numeric">21</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">232</td>
+						<td><a href="http://profixsystemleasing.de/" data-trackable="link"
+								target="_blank">ProfixSystemleasing</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/automobiles" data-trackable="link">Automobiles</a>
+						</td>
+						<td class="o-table__cell--numeric">598%</td>
+						<td class="o-table__cell--numeric">91.20%</td>
+						<td class="o-table__cell--numeric">4,419</td>
+						<td class="o-table__cell--numeric">3</td>
+						<td class="o-table__cell--numeric">5</td>
+						<td>2008</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">233</td>
+						<td><a href="http://obelisksupport.com/" data-trackable="link" target="_blank">Obelisk Legal
+								Support Solutions</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Law" data-trackable="link">Law</a></td>
+						<td class="o-table__cell--numeric">596%</td>
+						<td class="o-table__cell--numeric">90.90%</td>
+						<td class="o-table__cell--numeric">2,046</td>
+						<td class="o-table__cell--numeric">6</td>
+						<td class="o-table__cell--numeric">7</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">234</td>
+						<td><a href="http://flatironsteak.co.uk/" data-trackable="link" target="_blank">Flat Iron
+								Steak</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/restaurants" data-trackable="link">Restaurants</a></td>
+						<td class="o-table__cell--numeric">595%</td>
+						<td class="o-table__cell--numeric">90.90%</td>
+						<td class="o-table__cell--numeric">9,828</td>
+						<td class="o-table__cell--numeric">115</td>
+						<td class="o-table__cell--numeric">157</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">235</td>
+						<td><a href="http://lepetitvapoteur.com/" data-trackable="link" target="_blank">Le Petit
+								Vapoteur</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/retail" data-trackable="link">Retail</a></td>
+						<td class="o-table__cell--numeric">594%</td>
+						<td class="o-table__cell--numeric">90.70%</td>
+						<td class="o-table__cell--numeric">24,274</td>
+						<td class="o-table__cell--numeric">35</td>
+						<td class="o-table__cell--numeric">45</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">236</td>
+						<td><a href="http://tixalia.com/" data-trackable="link" target="_blank">Tixalia Worldwide</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/companies/travel-leisure" data-trackable="link">Travel &amp;
+								Leisure</a></td>
+						<td class="o-table__cell--numeric">590%</td>
+						<td class="o-table__cell--numeric">90.30%</td>
+						<td class="o-table__cell--numeric">4,195</td>
+						<td class="o-table__cell--numeric">5</td>
+						<td class="o-table__cell--numeric">8</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">237</td>
+						<td><a href="http://aprotecnic.com/" data-trackable="link" target="_blank">Aprotecnic</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/architecture" data-trackable="link">Architecture</a></td>
+						<td class="o-table__cell--numeric">586%</td>
+						<td class="o-table__cell--numeric">90%</td>
+						<td class="o-table__cell--numeric">4,973</td>
+						<td class="o-table__cell--numeric">72</td>
+						<td class="o-table__cell--numeric">84</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">238</td>
+						<td><a href="http://alameda.com.es/" data-trackable="link" target="_blank">Alameda</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/restaurants" data-trackable="link">Restaurants</a></td>
+						<td class="o-table__cell--numeric">584%</td>
+						<td class="o-table__cell--numeric">89.80%</td>
+						<td class="o-table__cell--numeric">2,961</td>
+						<td class="o-table__cell--numeric">38</td>
+						<td class="o-table__cell--numeric">45</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">239</td>
+						<td><a href="http://holztec.de/" data-trackable="link" target="_blank">H &amp; D HolzTec</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/construction" data-trackable="link">Construction</a>
+						</td>
+						<td class="o-table__cell--numeric">576%</td>
+						<td class="o-table__cell--numeric">89.10%</td>
+						<td class="o-table__cell--numeric">3,095</td>
+						<td class="o-table__cell--numeric">1</td>
+						<td class="o-table__cell--numeric">2</td>
+						<td>2000</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">240</td>
+						<td><a href="http://estructurasarque.com/" data-trackable="link" target="_blank">Estructuras
+								Arqué</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/companies/construction" data-trackable="link">Construction</a>
+						</td>
+						<td class="o-table__cell--numeric">575%</td>
+						<td class="o-table__cell--numeric">89%</td>
+						<td class="o-table__cell--numeric">7,045</td>
+						<td class="o-table__cell--numeric">29</td>
+						<td class="o-table__cell--numeric">37</td>
+						<td>2001</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">241</td>
+						<td><a href="http://ozaroo.com/" data-trackable="link" target="_blank">Ozaroo</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Ecommerce" data-trackable="link">Ecommerce</a>
+						</td>
+						<td class="o-table__cell--numeric">574%</td>
+						<td class="o-table__cell--numeric">88.90%</td>
+						<td class="o-table__cell--numeric">10,926</td>
+						<td class="o-table__cell--numeric">4</td>
+						<td class="o-table__cell--numeric">8</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">242</td>
+						<td><a href="http://creotech.pl/" data-trackable="link" target="_blank">Creotech Instruments
+								S.A.</a></td>
+						<td><a href="https://www.ft.com/topics/places/Poland" data-trackable="link">Poland</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">574%</td>
+						<td class="o-table__cell--numeric">88.90%</td>
+						<td class="o-table__cell--numeric">1,965</td>
+						<td class="o-table__cell--numeric">29</td>
+						<td class="o-table__cell--numeric">32</td>
+						<td>2008</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">243</td>
+						<td><a href="http://assurances-sfam.fr/" data-trackable="link" target="_blank">SFAM</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/insurance" data-trackable="link">Insurance</a></td>
+						<td class="o-table__cell--numeric">570%</td>
+						<td class="o-table__cell--numeric">88.50%</td>
+						<td class="o-table__cell--numeric">134,000</td>
+						<td class="o-table__cell--numeric">564</td>
+						<td class="o-table__cell--numeric">600</td>
+						<td>1999</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">244</td>
+						<td><a href="http://mrwonderful.es/" data-trackable="link" target="_blank">Mr. Wonderful
+								Comunication</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Ecommerce" data-trackable="link">Ecommerce</a>
+						</td>
+						<td class="o-table__cell--numeric">569%</td>
+						<td class="o-table__cell--numeric">88.50%</td>
+						<td class="o-table__cell--numeric">30,341</td>
+						<td class="o-table__cell--numeric">56</td>
+						<td class="o-table__cell--numeric">72</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">245</td>
+						<td><a href="http://trustly.com/" data-trackable="link" target="_blank">Trustly</a></td>
+						<td><a href="https://www.ft.com/topics/places/Sweden" data-trackable="link">Sweden</a></td>
+						<td><a href="https://www.ft.com/fintech" data-trackable="link">Fintech</a></td>
+						<td class="o-table__cell--numeric">569%</td>
+						<td class="o-table__cell--numeric">88.50%</td>
+						<td class="o-table__cell--numeric">32,310</td>
+						<td class="o-table__cell--numeric">122</td>
+						<td class="o-table__cell--numeric">150</td>
+						<td>2008</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">246</td>
+						<td><a href="http://e-r-s.eu/" data-trackable="link" target="_blank">e-r-s materials</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/retail" data-trackable="link">Retail</a></td>
+						<td class="o-table__cell--numeric">563%</td>
+						<td class="o-table__cell--numeric">87.90%</td>
+						<td class="o-table__cell--numeric">7,943</td>
+						<td class="o-table__cell--numeric">2</td>
+						<td class="o-table__cell--numeric">5</td>
+						<td>2008</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">247</td>
+						<td><a href="http://tenderhut.com/" data-trackable="link" target="_blank">TenderHut SA</a></td>
+						<td><a href="https://www.ft.com/topics/places/Poland" data-trackable="link">Poland</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">560%</td>
+						<td class="o-table__cell--numeric">87.50%</td>
+						<td class="o-table__cell--numeric">2,048</td>
+						<td class="o-table__cell--numeric">24</td>
+						<td class="o-table__cell--numeric">26</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">248</td>
+						<td><a href="http://innovamaxx.de/" data-trackable="link" target="_blank">InnovaMaxx
+								(Sportstech)</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/retail" data-trackable="link">Retail</a></td>
+						<td class="o-table__cell--numeric">559%</td>
+						<td class="o-table__cell--numeric">87.40%</td>
+						<td class="o-table__cell--numeric">8,870</td>
+						<td class="o-table__cell--numeric">25</td>
+						<td class="o-table__cell--numeric">33</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">249</td>
+						<td><a href="http://richtigstrom.de/" data-trackable="link" target="_blank">richtigstrom</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/energy" data-trackable="link">Energy</a></td>
+						<td class="o-table__cell--numeric">557%</td>
+						<td class="o-table__cell--numeric">87.30%</td>
+						<td class="o-table__cell--numeric">18,381</td>
+						<td class="o-table__cell--numeric">2</td>
+						<td class="o-table__cell--numeric">10</td>
+						<td>2006</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">250</td>
+						<td><a href="http://procemo.com/" data-trackable="link" target="_blank">Procemo</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">557%</td>
+						<td class="o-table__cell--numeric">87.30%</td>
+						<td class="o-table__cell--numeric">2,300</td>
+						<td class="o-table__cell--numeric">30</td>
+						<td class="o-table__cell--numeric">35</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">251</td>
+						<td><a href="http://bookingbug.co.uk/" data-trackable="link" target="_blank">BookingBug</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">554%</td>
+						<td class="o-table__cell--numeric">87.10%</td>
+						<td class="o-table__cell--numeric">5,394</td>
+						<td class="o-table__cell--numeric">54</td>
+						<td class="o-table__cell--numeric">63</td>
+						<td>2008</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">252</td>
+						<td><a href="http://lazerlamps.com/" data-trackable="link" target="_blank">Lazer Lamps</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/companies/automobiles" data-trackable="link">Automobiles</a>
+						</td>
+						<td class="o-table__cell--numeric">554%</td>
+						<td class="o-table__cell--numeric">87%</td>
+						<td class="o-table__cell--numeric">2,913</td>
+						<td class="o-table__cell--numeric">15</td>
+						<td class="o-table__cell--numeric">18</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">253</td>
+						<td><a href="http://blendplants.com/" data-trackable="link" target="_blank">FBG</a></td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/companies/industrial-goods" data-trackable="link">Industrial
+								Goods</a></td>
+						<td class="o-table__cell--numeric">554%</td>
+						<td class="o-table__cell--numeric">87%</td>
+						<td class="o-table__cell--numeric">3,000</td>
+						<td class="o-table__cell--numeric">12</td>
+						<td class="o-table__cell--numeric">15</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">254</td>
+						<td><a href="http://acondistec.de/" data-trackable="link" target="_blank">Acondistec</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/retail" data-trackable="link">Retail</a></td>
+						<td class="o-table__cell--numeric">553%</td>
+						<td class="o-table__cell--numeric">86.90%</td>
+						<td class="o-table__cell--numeric">9,834</td>
+						<td class="o-table__cell--numeric">5</td>
+						<td class="o-table__cell--numeric">13</td>
+						<td>2004</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">255</td>
+						<td><a href="http://xpose360.de/" data-trackable="link" target="_blank">Xpose360</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Advertising" data-trackable="link">Advertising</a>
+						</td>
+						<td class="o-table__cell--numeric">552%</td>
+						<td class="o-table__cell--numeric">86.80%</td>
+						<td class="o-table__cell--numeric">2,217</td>
+						<td class="o-table__cell--numeric">20</td>
+						<td class="o-table__cell--numeric">30</td>
+						<td>2009</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">256</td>
+						<td><a href="http://jobzone-deutschland.de/" data-trackable="link" target="_blank">Jobzone
+								Deutschland</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">551%</td>
+						<td class="o-table__cell--numeric">86.80%</td>
+						<td class="o-table__cell--numeric">3,669</td>
+						<td class="o-table__cell--numeric">78</td>
+						<td class="o-table__cell--numeric">91</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">257</td>
+						<td><a href="http://finanzcheck.de/" data-trackable="link" target="_blank">FFG FINANZCHECK
+								Finanzportale</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/financial-services" data-trackable="link">Financial
+								Services</a></td>
+						<td class="o-table__cell--numeric">550%</td>
+						<td class="o-table__cell--numeric">86.60%</td>
+						<td class="o-table__cell--numeric">26,000</td>
+						<td class="o-table__cell--numeric">127</td>
+						<td class="o-table__cell--numeric">165</td>
+						<td>2009</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">258</td>
+						<td><a href="http://shopfullygroup.com/" data-trackable="link" target="_blank">DoveConviene</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Advertising" data-trackable="link">Advertising</a>
+						</td>
+						<td class="o-table__cell--numeric">549%</td>
+						<td class="o-table__cell--numeric">86.60%</td>
+						<td class="o-table__cell--numeric">11,570</td>
+						<td class="o-table__cell--numeric">94</td>
+						<td class="o-table__cell--numeric">134</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">259</td>
+						<td><a href="http://baselabs.de/" data-trackable="link" target="_blank">BASELABS</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/automobiles" data-trackable="link">Automobiles</a>
+						</td>
+						<td class="o-table__cell--numeric">547%</td>
+						<td class="o-table__cell--numeric">86.40%</td>
+						<td class="o-table__cell--numeric">2,392</td>
+						<td class="o-table__cell--numeric">15</td>
+						<td class="o-table__cell--numeric">27</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">260</td>
+						<td><a href="http://rendimientoverde.com/" data-trackable="link" target="_blank">Rendimiento
+								Verde</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">547%</td>
+						<td class="o-table__cell--numeric">86.30%</td>
+						<td class="o-table__cell--numeric">3,485</td>
+						<td class="o-table__cell--numeric">8</td>
+						<td class="o-table__cell--numeric">12</td>
+						<td>2006</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">261</td>
+						<td><a href="http://adyoulike.com/" data-trackable="link" target="_blank">Adyoulike</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Advertising" data-trackable="link">Advertising</a>
+						</td>
+						<td class="o-table__cell--numeric">545%</td>
+						<td class="o-table__cell--numeric">86.10%</td>
+						<td class="o-table__cell--numeric">13,843</td>
+						<td class="o-table__cell--numeric">45</td>
+						<td class="o-table__cell--numeric">80</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">262</td>
+						<td><a href="http://oemdefenceservices.com/" data-trackable="link" target="_blank">OEM Defence
+								Services</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/aerospace-defence" data-trackable="link">Aerospace
+								&amp; Defence</a></td>
+						<td class="o-table__cell--numeric">543%</td>
+						<td class="o-table__cell--numeric">86%</td>
+						<td class="o-table__cell--numeric">31,518</td>
+						<td class="o-table__cell--numeric">3</td>
+						<td class="o-table__cell--numeric">8</td>
+						<td>2008</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">263</td>
+						<td><a href="http://littlegiants.de/" data-trackable="link" target="_blank">Kleine Riesen
+								Nord</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/stream/d320c9d7-1638-4388-b667-a5d63bd4bbc2"
+								data-trackable="link">Education</a></td>
+						<td class="o-table__cell--numeric">542%</td>
+						<td class="o-table__cell--numeric">85.90%</td>
+						<td class="o-table__cell--numeric">4,574</td>
+						<td class="o-table__cell--numeric">68</td>
+						<td class="o-table__cell--numeric">90</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">264</td>
+						<td><a href="http://easybooking.at/" data-trackable="link" target="_blank">zadego</a></td>
+						<td><a href="https://www.ft.com/topics/places/Austria" data-trackable="link">Austria</a></td>
+						<td><a href="https://www.ft.com/companies/travel-leisure" data-trackable="link">Travel &amp;
+								Leisure</a></td>
+						<td class="o-table__cell--numeric">538%</td>
+						<td class="o-table__cell--numeric">85.40%</td>
+						<td class="o-table__cell--numeric">2,693</td>
+						<td class="o-table__cell--numeric">45</td>
+						<td class="o-table__cell--numeric">57</td>
+						<td>2008</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">265</td>
+						<td><a href="http://betterglobe.com/" data-trackable="link" target="_blank">Better Globe</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Norway" data-trackable="link">Norway</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Agricultural_Commodities"
+								data-trackable="link">Agricultural commodities</a></td>
+						<td class="o-table__cell--numeric">537%</td>
+						<td class="o-table__cell--numeric">85.40%</td>
+						<td class="o-table__cell--numeric">3,600</td>
+						<td class="o-table__cell--numeric">0</td>
+						<td class="o-table__cell--numeric">2</td>
+						<td>2006</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">266</td>
+						<td><a href="http://reanova.fr/" data-trackable="link" target="_blank">Reanova</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/construction" data-trackable="link">Construction</a>
+						</td>
+						<td class="o-table__cell--numeric">537%</td>
+						<td class="o-table__cell--numeric">85.40%</td>
+						<td class="o-table__cell--numeric">1,629</td>
+						<td class="o-table__cell--numeric">15</td>
+						<td class="o-table__cell--numeric">17</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">267</td>
+						<td><a href="http://taksee.com/" data-trackable="link" target="_blank">Taksee</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/companies/transport" data-trackable="link">Transport</a></td>
+						<td class="o-table__cell--numeric">536%</td>
+						<td class="o-table__cell--numeric">85.30%</td>
+						<td class="o-table__cell--numeric">4,388</td>
+						<td class="o-table__cell--numeric">4</td>
+						<td class="o-table__cell--numeric">9</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">268</td>
+						<td><a href="http://blueglass.co.uk/" data-trackable="link" target="_blank">BlueGlass
+								Interactive UK</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Sales_&amp;_Marketing" data-trackable="link">Sales
+								&amp; Marketing</a></td>
+						<td class="o-table__cell--numeric">535%</td>
+						<td class="o-table__cell--numeric">85.20%</td>
+						<td class="o-table__cell--numeric">1,885</td>
+						<td class="o-table__cell--numeric">8</td>
+						<td class="o-table__cell--numeric">14</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">269</td>
+						<td><a href="http://50factory.com/" data-trackable="link" target="_blank">50 Factory</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/automobiles" data-trackable="link">Automobiles</a>
+						</td>
+						<td class="o-table__cell--numeric">533%</td>
+						<td class="o-table__cell--numeric">85%</td>
+						<td class="o-table__cell--numeric">1,900</td>
+						<td class="o-table__cell--numeric">10</td>
+						<td class="o-table__cell--numeric">13</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">270</td>
+						<td><a href="http://incubethic.fr/" data-trackable="link" target="_blank">Incubethic</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/energy" data-trackable="link">Energy</a></td>
+						<td class="o-table__cell--numeric">531%</td>
+						<td class="o-table__cell--numeric">84.80%</td>
+						<td class="o-table__cell--numeric">2,734</td>
+						<td class="o-table__cell--numeric">9</td>
+						<td class="o-table__cell--numeric">15</td>
+						<td>2009</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">271</td>
+						<td><a href="http://sire-search.com/" data-trackable="link" target="_blank">SIRE Life
+								Sciences</a></td>
+						<td><a href="https://www.ft.com/topics/places/Netherlands" data-trackable="link">The
+								Netherlands</a></td>
+						<td><a href="https://ig.ft.com/ft-1000/2018/" data-trackable="link">Management Consulting</a>
+						</td>
+						<td class="o-table__cell--numeric">531%</td>
+						<td class="o-table__cell--numeric">84.80%</td>
+						<td class="o-table__cell--numeric">8,200</td>
+						<td class="o-table__cell--numeric">45</td>
+						<td class="o-table__cell--numeric">60</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">272</td>
+						<td><a href="http://vastaamo.fi/" data-trackable="link" target="_blank">Psykoterapiakeskus
+								Vastaamo</a></td>
+						<td><a href="https://www.ft.com/topics/places/Finland" data-trackable="link">Finland</a></td>
+						<td><a href="https://www.ft.com/companies/health" data-trackable="link">Health</a></td>
+						<td class="o-table__cell--numeric">529%</td>
+						<td class="o-table__cell--numeric">84.60%</td>
+						<td class="o-table__cell--numeric">5,575</td>
+						<td class="o-table__cell--numeric">124</td>
+						<td class="o-table__cell--numeric">160</td>
+						<td>2008</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">273</td>
+						<td><a href="http://optifol.de/" data-trackable="link" target="_blank">OptiFol</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/industrial-goods" data-trackable="link">Industrial
+								Goods</a></td>
+						<td class="o-table__cell--numeric">529%</td>
+						<td class="o-table__cell--numeric">84.60%</td>
+						<td class="o-table__cell--numeric">6,332</td>
+						<td class="o-table__cell--numeric">4</td>
+						<td class="o-table__cell--numeric">7</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">274</td>
+						<td><a href="http://deporvillage.com/" data-trackable="link" target="_blank">Deporvillage</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Ecommerce" data-trackable="link">Ecommerce</a>
+						</td>
+						<td class="o-table__cell--numeric">529%</td>
+						<td class="o-table__cell--numeric">84.60%</td>
+						<td class="o-table__cell--numeric">22,000</td>
+						<td class="o-table__cell--numeric">36</td>
+						<td class="o-table__cell--numeric">45</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">275</td>
+						<td><a href="http://capitalontap.com/" data-trackable="link" target="_blank">New Wave
+								Capital</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/fintech" data-trackable="link">Fintech</a></td>
+						<td class="o-table__cell--numeric">528%</td>
+						<td class="o-table__cell--numeric">84.50%</td>
+						<td class="o-table__cell--numeric">10,795</td>
+						<td class="o-table__cell--numeric">43</td>
+						<td class="o-table__cell--numeric">71</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">276</td>
+						<td><a href="http://disko.fr/" data-trackable="link" target="_blank">Disko</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/media" data-trackable="link">Media</a></td>
+						<td class="o-table__cell--numeric">525%</td>
+						<td class="o-table__cell--numeric">84.20%</td>
+						<td class="o-table__cell--numeric">10,000</td>
+						<td class="o-table__cell--numeric">66</td>
+						<td class="o-table__cell--numeric">93</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">277</td>
+						<td><a href="http://ingenova.pro/" data-trackable="link" target="_blank">Ingenova Norte</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/companies/construction" data-trackable="link">Construction</a>
+						</td>
+						<td class="o-table__cell--numeric">522%</td>
+						<td class="o-table__cell--numeric">83.90%</td>
+						<td class="o-table__cell--numeric">6,609</td>
+						<td class="o-table__cell--numeric">28</td>
+						<td class="o-table__cell--numeric">34</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">278</td>
+						<td><a href="http://zopa.com/" data-trackable="link" target="_blank">Zopa</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/fintech" data-trackable="link">Fintech</a></td>
+						<td class="o-table__cell--numeric">518%</td>
+						<td class="o-table__cell--numeric">83.50%</td>
+						<td class="o-table__cell--numeric">40,673</td>
+						<td class="o-table__cell--numeric">148</td>
+						<td class="o-table__cell--numeric">188</td>
+						<td>2004</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">279</td>
+						<td><a href="http://wabel.com/" data-trackable="link" target="_blank">Wabel</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/retail" data-trackable="link">Retail</a></td>
+						<td class="o-table__cell--numeric">518%</td>
+						<td class="o-table__cell--numeric">83.50%</td>
+						<td class="o-table__cell--numeric">3,206</td>
+						<td class="o-table__cell--numeric">n/a</td>
+						<td class="o-table__cell--numeric">30</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">280</td>
+						<td><a href="http://bmf-beton.de/" data-trackable="link" target="_blank">BMF
+								Bauwerkerhaltung</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/construction" data-trackable="link">Construction</a>
+						</td>
+						<td class="o-table__cell--numeric">515%</td>
+						<td class="o-table__cell--numeric">83.20%</td>
+						<td class="o-table__cell--numeric">6,077</td>
+						<td class="o-table__cell--numeric">-2</td>
+						<td class="o-table__cell--numeric">15</td>
+						<td>2008</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">281</td>
+						<td><a href="http://goodgout.fr/" data-trackable="link" target="_blank">BBB (Good Goût)</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Agricultural_Commodities"
+								data-trackable="link">Agricultural commodities</a></td>
+						<td class="o-table__cell--numeric">515%</td>
+						<td class="o-table__cell--numeric">83.20%</td>
+						<td class="o-table__cell--numeric">9,320</td>
+						<td class="o-table__cell--numeric">14</td>
+						<td class="o-table__cell--numeric">24</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">282</td>
+						<td><a href="http://superscommesse.it/" data-trackable="link" target="_blank">ASAP Italia</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/companies/media" data-trackable="link">Media</a></td>
+						<td class="o-table__cell--numeric">514%</td>
+						<td class="o-table__cell--numeric">83.10%</td>
+						<td class="o-table__cell--numeric">1,739</td>
+						<td class="o-table__cell--numeric">21</td>
+						<td class="o-table__cell--numeric">31</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">283</td>
+						<td><a href="http://ecogreenenergy.fr/" data-trackable="link" target="_blank">Ecogreenenergy</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Waste_management_&amp;_recycling"
+								data-trackable="link">Waste management &amp; recycling</a></td>
+						<td class="o-table__cell--numeric">513%</td>
+						<td class="o-table__cell--numeric">83%</td>
+						<td class="o-table__cell--numeric">2,786</td>
+						<td class="o-table__cell--numeric">8</td>
+						<td class="o-table__cell--numeric">17</td>
+						<td>2008</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">284</td>
+						<td><a href="http://89grad.ch/" data-trackable="link" target="_blank">89grad</a></td>
+						<td><a href="https://www.ft.com/topics/places/Switzerland" data-trackable="link">Switzerland</a>
+						</td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">513%</td>
+						<td class="o-table__cell--numeric">83%</td>
+						<td class="o-table__cell--numeric">3,104</td>
+						<td class="o-table__cell--numeric">16</td>
+						<td class="o-table__cell--numeric">22</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">285</td>
+						<td><a href="http://sellsy.fr/" data-trackable="link" target="_blank">Easybill (Sellsy)</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">512%</td>
+						<td class="o-table__cell--numeric">83%</td>
+						<td class="o-table__cell--numeric">2,498</td>
+						<td class="o-table__cell--numeric">29</td>
+						<td class="o-table__cell--numeric">39</td>
+						<td>2009</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">286</td>
+						<td><a href="http://catsas.com/" data-trackable="link" target="_blank">Clean Air
+								Technologies</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">512%</td>
+						<td class="o-table__cell--numeric">82.90%</td>
+						<td class="o-table__cell--numeric">2,290</td>
+						<td class="o-table__cell--numeric">5</td>
+						<td class="o-table__cell--numeric">7</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">287</td>
+						<td><a href="http://movetia.com/" data-trackable="link" target="_blank">Movetia Digital</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/fintech" data-trackable="link">Fintech</a></td>
+						<td class="o-table__cell--numeric">510%</td>
+						<td class="o-table__cell--numeric">82.70%</td>
+						<td class="o-table__cell--numeric">2,779</td>
+						<td class="o-table__cell--numeric">37</td>
+						<td class="o-table__cell--numeric">47</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">288</td>
+						<td><a href="http://hexad.de/" data-trackable="link" target="_blank">Hexad</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">510%</td>
+						<td class="o-table__cell--numeric">82.70%</td>
+						<td class="o-table__cell--numeric">18,277</td>
+						<td class="o-table__cell--numeric">17</td>
+						<td class="o-table__cell--numeric">45</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">289</td>
+						<td><a href="http://egobodegas.com/" data-trackable="link" target="_blank">Ego Bodegas</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/companies/food-beverage" data-trackable="link">Food &amp;
+								Beverage</a></td>
+						<td class="o-table__cell--numeric">506%</td>
+						<td class="o-table__cell--numeric">82.30%</td>
+						<td class="o-table__cell--numeric">3,063</td>
+						<td class="o-table__cell--numeric">6</td>
+						<td class="o-table__cell--numeric">9</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">290</td>
+						<td><a href="http://planiv-projektbau.de/" data-trackable="link" target="_blank">Planiv
+								Projektbau</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/construction" data-trackable="link">Construction</a>
+						</td>
+						<td class="o-table__cell--numeric">505%</td>
+						<td class="o-table__cell--numeric">82.20%</td>
+						<td class="o-table__cell--numeric">3,775</td>
+						<td class="o-table__cell--numeric">3</td>
+						<td class="o-table__cell--numeric">6</td>
+						<td>1999</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">291</td>
+						<td><a href="http://younited-credit.com/" data-trackable="link" target="_blank">Younited
+								Credit</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/fintech" data-trackable="link">Fintech</a></td>
+						<td class="o-table__cell--numeric">502%</td>
+						<td class="o-table__cell--numeric">81.90%</td>
+						<td class="o-table__cell--numeric">9,274</td>
+						<td class="o-table__cell--numeric">n/a</td>
+						<td class="o-table__cell--numeric">190</td>
+						<td>2009</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">292</td>
+						<td><a href="http://rockwheel.com/" data-trackable="link" target="_blank">Rokla*</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/industrial-goods" data-trackable="link">Industrial
+								Goods</a></td>
+						<td class="o-table__cell--numeric">500%</td>
+						<td class="o-table__cell--numeric">81.70%</td>
+						<td class="o-table__cell--numeric">4,200</td>
+						<td class="o-table__cell--numeric">13</td>
+						<td class="o-table__cell--numeric">18</td>
+						<td>2013</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">293</td>
+						<td><a href="http://enpire.pl/" data-trackable="link" target="_blank">Enpire</a></td>
+						<td><a href="https://www.ft.com/topics/places/Poland" data-trackable="link">Poland</a></td>
+						<td><a href="https://www.ft.com/companies/transport" data-trackable="link">Transport</a></td>
+						<td class="o-table__cell--numeric">499%</td>
+						<td class="o-table__cell--numeric">81.70%</td>
+						<td class="o-table__cell--numeric">4,844</td>
+						<td class="o-table__cell--numeric">47</td>
+						<td class="o-table__cell--numeric">55</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">294</td>
+						<td><a href="http://jfr-sas.fr/" data-trackable="link" target="_blank">JFR</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/construction" data-trackable="link">Construction</a>
+						</td>
+						<td class="o-table__cell--numeric">498%</td>
+						<td class="o-table__cell--numeric">81.50%</td>
+						<td class="o-table__cell--numeric">6,035</td>
+						<td class="o-table__cell--numeric">26</td>
+						<td class="o-table__cell--numeric">33</td>
+						<td>2006</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">295</td>
+						<td><a href="http://druckertanke-berlin.de/" data-trackable="link" target="_blank">Eurotone</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Ecommerce" data-trackable="link">Ecommerce</a>
+						</td>
+						<td class="o-table__cell--numeric">498%</td>
+						<td class="o-table__cell--numeric">81.50%</td>
+						<td class="o-table__cell--numeric">2,554</td>
+						<td class="o-table__cell--numeric">11</td>
+						<td class="o-table__cell--numeric">17</td>
+						<td>2005</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">296</td>
+						<td><a href="http://iprotect.de/" data-trackable="link" target="_blank">Iprotect</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Ecommerce" data-trackable="link">Ecommerce</a>
+						</td>
+						<td class="o-table__cell--numeric">496%</td>
+						<td class="o-table__cell--numeric">81.30%</td>
+						<td class="o-table__cell--numeric">18,251</td>
+						<td class="o-table__cell--numeric">25</td>
+						<td class="o-table__cell--numeric">45</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">297</td>
+						<td><a href="http://hartung-ludwig.de/" data-trackable="link" target="_blank">Hartung &amp;
+								Ludwig</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/construction" data-trackable="link">Construction</a>
+						</td>
+						<td class="o-table__cell--numeric">496%</td>
+						<td class="o-table__cell--numeric">81.30%</td>
+						<td class="o-table__cell--numeric">2,990</td>
+						<td class="o-table__cell--numeric">14</td>
+						<td class="o-table__cell--numeric">27</td>
+						<td>2009</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">298</td>
+						<td><a href="http://propercorn.com/" data-trackable="link" target="_blank">Catapult Enterprises
+								(Propercorn)</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/companies/food-beverage" data-trackable="link">Food &amp;
+								Beverage</a></td>
+						<td class="o-table__cell--numeric">495%</td>
+						<td class="o-table__cell--numeric">81.30%</td>
+						<td class="o-table__cell--numeric">12,316</td>
+						<td class="o-table__cell--numeric">27</td>
+						<td class="o-table__cell--numeric">39</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">299</td>
+						<td><a href="http://lovli.it/" data-trackable="link" target="_blank">Lovli</a></td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Sales_&amp;_Marketing" data-trackable="link">Sales
+								&amp; Marketing</a></td>
+						<td class="o-table__cell--numeric">494%</td>
+						<td class="o-table__cell--numeric">81.10%</td>
+						<td class="o-table__cell--numeric">1,686</td>
+						<td class="o-table__cell--numeric">10</td>
+						<td class="o-table__cell--numeric">11</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">300</td>
+						<td><a href="http://ethica-group.com/" data-trackable="link" target="_blank">Ethica Corporate
+								Finance</a></td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/companies/financial-services" data-trackable="link">Financial
+								Services</a></td>
+						<td class="o-table__cell--numeric">493%</td>
+						<td class="o-table__cell--numeric">81%</td>
+						<td class="o-table__cell--numeric">5,630</td>
+						<td class="o-table__cell--numeric">3</td>
+						<td class="o-table__cell--numeric">10</td>
+						<td>2009</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">301</td>
+						<td><a href="http://termaenergia.it/" data-trackable="link" target="_blank">Terma Energia</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/companies/industrial-goods" data-trackable="link">Industrial
+								Goods</a></td>
+						<td class="o-table__cell--numeric">493%</td>
+						<td class="o-table__cell--numeric">81%</td>
+						<td class="o-table__cell--numeric">1,897</td>
+						<td class="o-table__cell--numeric">7</td>
+						<td class="o-table__cell--numeric">17</td>
+						<td>2006</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">302</td>
+						<td><a href="http://inaudito.de/" data-trackable="link" target="_blank">IN AUDITO</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Advertising" data-trackable="link">Advertising</a>
+						</td>
+						<td class="o-table__cell--numeric">492%</td>
+						<td class="o-table__cell--numeric">80.90%</td>
+						<td class="o-table__cell--numeric">6,364</td>
+						<td class="o-table__cell--numeric">14</td>
+						<td class="o-table__cell--numeric">19</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">303</td>
+						<td>Comcertrans*</td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Agricultural_Commodities"
+								data-trackable="link">Agricultural commodities</a></td>
+						<td class="o-table__cell--numeric">491%</td>
+						<td class="o-table__cell--numeric">80.80%</td>
+						<td class="o-table__cell--numeric">4,622</td>
+						<td class="o-table__cell--numeric">4</td>
+						<td class="o-table__cell--numeric">5</td>
+						<td>2013</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">304</td>
+						<td><a href="http://supperfood.nl/" data-trackable="link" target="_blank">SupperFood</a></td>
+						<td><a href="https://www.ft.com/topics/places/Netherlands" data-trackable="link">The
+								Netherlands</a></td>
+						<td><a href="https://www.ft.com/companies/food-beverage" data-trackable="link">Food &amp;
+								Beverage</a></td>
+						<td class="o-table__cell--numeric">491%</td>
+						<td class="o-table__cell--numeric">80.80%</td>
+						<td class="o-table__cell--numeric">5,938</td>
+						<td class="o-table__cell--numeric">5</td>
+						<td class="o-table__cell--numeric">8</td>
+						<td>2008</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">305</td>
+						<td><a href="http://easybution.de/" data-trackable="link" target="_blank">easysparen</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/retail" data-trackable="link">Retail</a></td>
+						<td class="o-table__cell--numeric">490%</td>
+						<td class="o-table__cell--numeric">80.70%</td>
+						<td class="o-table__cell--numeric">25,463</td>
+						<td class="o-table__cell--numeric">4</td>
+						<td class="o-table__cell--numeric">11</td>
+						<td>2009</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">306</td>
+						<td><a href="http://stueve-strassenbau.de/" data-trackable="link" target="_blank">Stüve
+								Straßenbau</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/construction" data-trackable="link">Construction</a>
+						</td>
+						<td class="o-table__cell--numeric">488%</td>
+						<td class="o-table__cell--numeric">80.40%</td>
+						<td class="o-table__cell--numeric">2,350</td>
+						<td class="o-table__cell--numeric">16</td>
+						<td class="o-table__cell--numeric">18</td>
+						<td>1995</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">307</td>
+						<td><a href="http://districlos.com/" data-trackable="link" target="_blank">Districlos
+								Holding</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/retail" data-trackable="link">Retail</a></td>
+						<td class="o-table__cell--numeric">487%</td>
+						<td class="o-table__cell--numeric">80.40%</td>
+						<td class="o-table__cell--numeric">5,563</td>
+						<td class="o-table__cell--numeric">26</td>
+						<td class="o-table__cell--numeric">30</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">308</td>
+						<td><a href="http://universaliberland.com/" data-trackable="link" target="_blank">Universal
+								Iberland</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/companies/food-beverage" data-trackable="link">Food &amp;
+								Beverage</a></td>
+						<td class="o-table__cell--numeric">487%</td>
+						<td class="o-table__cell--numeric">80.40%</td>
+						<td class="o-table__cell--numeric">16,373</td>
+						<td class="o-table__cell--numeric">2</td>
+						<td class="o-table__cell--numeric">3</td>
+						<td>2004</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">309</td>
+						<td><a href="http://giglio.com/" data-trackable="link" target="_blank">Giglio.com</a></td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Ecommerce" data-trackable="link">Ecommerce</a>
+						</td>
+						<td class="o-table__cell--numeric">486%</td>
+						<td class="o-table__cell--numeric">80.30%</td>
+						<td class="o-table__cell--numeric">5,944</td>
+						<td class="o-table__cell--numeric">6</td>
+						<td class="o-table__cell--numeric">15</td>
+						<td>2007</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">310</td>
+						<td><a href="http://tis.biz/" data-trackable="link" target="_blank">Treasury Intelligence
+								Solutions</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">486%</td>
+						<td class="o-table__cell--numeric">80.30%</td>
+						<td class="o-table__cell--numeric">4,167</td>
+						<td class="o-table__cell--numeric">16</td>
+						<td class="o-table__cell--numeric">63</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">311</td>
+						<td><a href="http://thodacon.de/" data-trackable="link" target="_blank">Thodacon
+								Werkzeugmaschinenschutz</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/industrial-goods" data-trackable="link">Industrial
+								Goods</a></td>
+						<td class="o-table__cell--numeric">486%</td>
+						<td class="o-table__cell--numeric">80.30%</td>
+						<td class="o-table__cell--numeric">3,088</td>
+						<td class="o-table__cell--numeric">7</td>
+						<td class="o-table__cell--numeric">9</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">312</td>
+						<td><a href="http://alps-residence.com/" data-trackable="link" target="_blank">Alps Residence
+								Holidayservice</a></td>
+						<td><a href="https://www.ft.com/topics/places/Austria" data-trackable="link">Austria</a></td>
+						<td><a href="https://www.ft.com/companies/travel-leisure" data-trackable="link">Travel &amp;
+								Leisure</a></td>
+						<td class="o-table__cell--numeric">485%</td>
+						<td class="o-table__cell--numeric">80.20%</td>
+						<td class="o-table__cell--numeric">4,934</td>
+						<td class="o-table__cell--numeric">31</td>
+						<td class="o-table__cell--numeric">40</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">313</td>
+						<td><a href="http://neusta-consulting.de/" data-trackable="link" target="_blank">neusta
+								consulting</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">483%</td>
+						<td class="o-table__cell--numeric">80%</td>
+						<td class="o-table__cell--numeric">52,953</td>
+						<td class="o-table__cell--numeric">18</td>
+						<td class="o-table__cell--numeric">36</td>
+						<td>2007</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">314</td>
+						<td><a href="http://experaconseils.fr/" data-trackable="link" target="_blank">Expera Conseils
+								Holding</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://ig.ft.com/ft-1000/2018/" data-trackable="link">Management Consulting</a>
+						</td>
+						<td class="o-table__cell--numeric">482%</td>
+						<td class="o-table__cell--numeric">79.90%</td>
+						<td class="o-table__cell--numeric">1,733</td>
+						<td class="o-table__cell--numeric">10</td>
+						<td class="o-table__cell--numeric">14</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">315</td>
+						<td><a href="http://stadtkiosk-frilling.de/" data-trackable="link" target="_blank">Stadtkiosk
+								Julius Frilling*</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/retail" data-trackable="link">Retail</a></td>
+						<td class="o-table__cell--numeric">481%</td>
+						<td class="o-table__cell--numeric">79.80%</td>
+						<td class="o-table__cell--numeric">2,935</td>
+						<td class="o-table__cell--numeric">37</td>
+						<td class="o-table__cell--numeric">43</td>
+						<td>2013</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">316</td>
+						<td><a href="http://thinclient24.eu/" data-trackable="link" target="_blank">ThinClient24</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/retail" data-trackable="link">Retail</a></td>
+						<td class="o-table__cell--numeric">481%</td>
+						<td class="o-table__cell--numeric">79.80%</td>
+						<td class="o-table__cell--numeric">5,538</td>
+						<td class="o-table__cell--numeric">6</td>
+						<td class="o-table__cell--numeric">11</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">317</td>
+						<td><a href="http://abaenglish.com/" data-trackable="link" target="_blank">English Worldwide</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/stream/d320c9d7-1638-4388-b667-a5d63bd4bbc2"
+								data-trackable="link">Education</a></td>
+						<td class="o-table__cell--numeric">479%</td>
+						<td class="o-table__cell--numeric">79.60%</td>
+						<td class="o-table__cell--numeric">9,838</td>
+						<td class="o-table__cell--numeric">48</td>
+						<td class="o-table__cell--numeric">71</td>
+						<td>2007</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">318</td>
+						<td><a href="http://vizolution.co.uk/" data-trackable="link" target="_blank">Vizolution</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">475%</td>
+						<td class="o-table__cell--numeric">79.10%</td>
+						<td class="o-table__cell--numeric">4,527</td>
+						<td class="o-table__cell--numeric">80</td>
+						<td class="o-table__cell--numeric">93</td>
+						<td>2008</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">319</td>
+						<td><a href="http://ebury.com/" data-trackable="link" target="_blank">Ebury</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/companies/financial-services" data-trackable="link">Financial
+								Services</a></td>
+						<td class="o-table__cell--numeric">472%</td>
+						<td class="o-table__cell--numeric">78.80%</td>
+						<td class="o-table__cell--numeric">43,090</td>
+						<td class="o-table__cell--numeric">256</td>
+						<td class="o-table__cell--numeric">387</td>
+						<td>2009</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">320</td>
+						<td><a href="http://idirecto.es/" data-trackable="link" target="_blank">I-Directo Mayorista</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/companies/retail" data-trackable="link">Retail</a></td>
+						<td class="o-table__cell--numeric">469%</td>
+						<td class="o-table__cell--numeric">78.60%</td>
+						<td class="o-table__cell--numeric">9,759</td>
+						<td class="o-table__cell--numeric">5</td>
+						<td class="o-table__cell--numeric">10</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">321</td>
+						<td><a href="http://fekra-group.com/" data-trackable="link" target="_blank">Fekra Consulting</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://ig.ft.com/ft-1000/2018/" data-trackable="link">Management Consulting</a>
+						</td>
+						<td class="o-table__cell--numeric">469%</td>
+						<td class="o-table__cell--numeric">78.50%</td>
+						<td class="o-table__cell--numeric">3,014</td>
+						<td class="o-table__cell--numeric">32</td>
+						<td class="o-table__cell--numeric">38</td>
+						<td>2008</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">322</td>
+						<td><a href="http://sarigato.com/" data-trackable="link" target="_blank">Sarigato sp. z.
+								o.o.</a></td>
+						<td><a href="https://www.ft.com/topics/places/Poland" data-trackable="link">Poland</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Advertising" data-trackable="link">Advertising</a>
+						</td>
+						<td class="o-table__cell--numeric">469%</td>
+						<td class="o-table__cell--numeric">78.50%</td>
+						<td class="o-table__cell--numeric">2,290</td>
+						<td class="o-table__cell--numeric">33</td>
+						<td class="o-table__cell--numeric">42</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">323</td>
+						<td><a href="http://http/www.lesbigboss.fr" data-trackable="link" target="_blank">Digilinx</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">468%</td>
+						<td class="o-table__cell--numeric">78.40%</td>
+						<td class="o-table__cell--numeric">2,937</td>
+						<td class="o-table__cell--numeric">5</td>
+						<td class="o-table__cell--numeric">6</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">324</td>
+						<td><a href="http://riccardo-zigarette.de/" data-trackable="link" target="_blank">Riccardo
+								Retail*</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/retail" data-trackable="link">Retail</a></td>
+						<td class="o-table__cell--numeric">468%</td>
+						<td class="o-table__cell--numeric">78.40%</td>
+						<td class="o-table__cell--numeric">12,314</td>
+						<td class="o-table__cell--numeric">32</td>
+						<td class="o-table__cell--numeric">47</td>
+						<td>2013</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">325</td>
+						<td><a href="http://hanzo.es/" data-trackable="link" target="_blank">Hanzo Studio</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">466%</td>
+						<td class="o-table__cell--numeric">78.20%</td>
+						<td class="o-table__cell--numeric">4,469</td>
+						<td class="o-table__cell--numeric">9</td>
+						<td class="o-table__cell--numeric">19</td>
+						<td>2009</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">326</td>
+						<td><a href="http://jomodo.de/" data-trackable="link" target="_blank">FJ Trading*</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Ecommerce" data-trackable="link">Ecommerce</a>
+						</td>
+						<td class="o-table__cell--numeric">463%</td>
+						<td class="o-table__cell--numeric">77.80%</td>
+						<td class="o-table__cell--numeric">9,000</td>
+						<td class="o-table__cell--numeric">7</td>
+						<td class="o-table__cell--numeric">8</td>
+						<td>2013</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">327</td>
+						<td><a href="http://http/www.viennaestate.com/" data-trackable="link"
+								target="_blank">ViennaEstate Immobilien AG</a></td>
+						<td><a href="https://www.ft.com/topics/places/Austria" data-trackable="link">Austria</a></td>
+						<td><a href="https://www.ft.com/companies/property" data-trackable="link">Property</a></td>
+						<td class="o-table__cell--numeric">462%</td>
+						<td class="o-table__cell--numeric">77.80%</td>
+						<td class="o-table__cell--numeric">2,046</td>
+						<td class="o-table__cell--numeric">3</td>
+						<td class="o-table__cell--numeric">9</td>
+						<td>2008</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">328</td>
+						<td><a href="http://experium-nax.com/" data-trackable="link" target="_blank">Experium Nax
+								Group</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Management_Consulting"
+								data-trackable="link">Management Consulting</a></td>
+						<td class="o-table__cell--numeric">460%</td>
+						<td class="o-table__cell--numeric">77.60%</td>
+						<td class="o-table__cell--numeric">2,893</td>
+						<td class="o-table__cell--numeric">12</td>
+						<td class="o-table__cell--numeric">16</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">329</td>
+						<td><a href="http://nettbureau.no/" data-trackable="link" target="_blank">Nettbureau AS</a></td>
+						<td><a href="https://www.ft.com/topics/places/Norway" data-trackable="link">Norway</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Ecommerce" data-trackable="link">Ecommerce</a>
+						</td>
+						<td class="o-table__cell--numeric">459%</td>
+						<td class="o-table__cell--numeric">77.50%</td>
+						<td class="o-table__cell--numeric">2,573</td>
+						<td class="o-table__cell--numeric">5</td>
+						<td class="o-table__cell--numeric">8</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">330</td>
+						<td><a href="http://matooma.com/" data-trackable="link" target="_blank">Matooma</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/telecoms" data-trackable="link">Telecoms</a></td>
+						<td class="o-table__cell--numeric">458%</td>
+						<td class="o-table__cell--numeric">77.40%</td>
+						<td class="o-table__cell--numeric">5,389</td>
+						<td class="o-table__cell--numeric">21</td>
+						<td class="o-table__cell--numeric">29</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">331</td>
+						<td><a href="http://grupa-tense.pl/" data-trackable="link" target="_blank">Grupa TENSE</a></td>
+						<td><a href="https://www.ft.com/topics/places/Poland" data-trackable="link">Poland</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Advertising" data-trackable="link">Advertising</a>
+						</td>
+						<td class="o-table__cell--numeric">457%</td>
+						<td class="o-table__cell--numeric">77.30%</td>
+						<td class="o-table__cell--numeric">1,731</td>
+						<td class="o-table__cell--numeric">32</td>
+						<td class="o-table__cell--numeric">60</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">332</td>
+						<td><a href="http://dronevolt.com/" data-trackable="link" target="_blank">Drone Volt</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/aerospace-defence" data-trackable="link">Aerospace
+								&amp; Defence</a></td>
+						<td class="o-table__cell--numeric">456%</td>
+						<td class="o-table__cell--numeric">77.20%</td>
+						<td class="o-table__cell--numeric">6,820</td>
+						<td class="o-table__cell--numeric">33</td>
+						<td class="o-table__cell--numeric">36</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">333</td>
+						<td><a href="http://sns.at/" data-trackable="link" target="_blank">SNS - Saturn Networking
+								Solutions</a></td>
+						<td><a href="https://www.ft.com/topics/places/Austria" data-trackable="link">Austria</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">456%</td>
+						<td class="o-table__cell--numeric">77.20%</td>
+						<td class="o-table__cell--numeric">4,658</td>
+						<td class="o-table__cell--numeric">2</td>
+						<td class="o-table__cell--numeric">5</td>
+						<td>1997</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">334</td>
+						<td><a href="http://e-novia.it/" data-trackable="link" target="_blank">e-Novia</a></td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">456%</td>
+						<td class="o-table__cell--numeric">77.10%</td>
+						<td class="o-table__cell--numeric">2,680</td>
+						<td class="o-table__cell--numeric">34</td>
+						<td class="o-table__cell--numeric">39</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">335</td>
+						<td><a href="http://accentro.ag/" data-trackable="link" target="_blank">Accentro Real Estate</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/property" data-trackable="link">Property</a></td>
+						<td class="o-table__cell--numeric">455%</td>
+						<td class="o-table__cell--numeric">77%</td>
+						<td class="o-table__cell--numeric">156,232</td>
+						<td class="o-table__cell--numeric">-7</td>
+						<td class="o-table__cell--numeric">33</td>
+						<td>1993</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">336</td>
+						<td><a href="http://lead-energy.com/" data-trackable="link" target="_blank">LEAD energy</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/retail" data-trackable="link">Retail</a></td>
+						<td class="o-table__cell--numeric">454%</td>
+						<td class="o-table__cell--numeric">77%</td>
+						<td class="o-table__cell--numeric">4,800</td>
+						<td class="o-table__cell--numeric">13</td>
+						<td class="o-table__cell--numeric">24</td>
+						<td>2003</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">337</td>
+						<td><a href="http://teamwille.com/" data-trackable="link" target="_blank">TEAMWILLE</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Management_Consulting"
+								data-trackable="link">Management Consulting</a></td>
+						<td class="o-table__cell--numeric">452%</td>
+						<td class="o-table__cell--numeric">76.70%</td>
+						<td class="o-table__cell--numeric">5,492</td>
+						<td class="o-table__cell--numeric">28</td>
+						<td class="o-table__cell--numeric">45</td>
+						<td>2004</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">338</td>
+						<td><a href="http://mucaj.de/" data-trackable="link" target="_blank">Mucaj Tiefbau</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/construction" data-trackable="link">Construction</a>
+						</td>
+						<td class="o-table__cell--numeric">451%</td>
+						<td class="o-table__cell--numeric">76.60%</td>
+						<td class="o-table__cell--numeric">2,416</td>
+						<td class="o-table__cell--numeric">18</td>
+						<td class="o-table__cell--numeric">26</td>
+						<td>1979</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">339</td>
+						<td><a href="http://instantor.com/" data-trackable="link" target="_blank">Instantor</a></td>
+						<td><a href="https://www.ft.com/topics/places/Sweden" data-trackable="link">Sweden</a></td>
+						<td><a href="https://www.ft.com/fintech" data-trackable="link">Fintech</a></td>
+						<td class="o-table__cell--numeric">451%</td>
+						<td class="o-table__cell--numeric">76.60%</td>
+						<td class="o-table__cell--numeric">1,671</td>
+						<td class="o-table__cell--numeric">18</td>
+						<td class="o-table__cell--numeric">30</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">340</td>
+						<td><a href="http://o2feel.com/" data-trackable="link" target="_blank">O2Feel Bikes</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/personal-goods" data-trackable="link">Personal &amp;
+								Household Goods</a></td>
+						<td class="o-table__cell--numeric">450%</td>
+						<td class="o-table__cell--numeric">76.50%</td>
+						<td class="o-table__cell--numeric">6,312</td>
+						<td class="o-table__cell--numeric">12</td>
+						<td class="o-table__cell--numeric">16</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">341</td>
+						<td><a href="http://quillcontent.com/" data-trackable="link" target="_blank">Quill Content</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Sales_&amp;_Marketing" data-trackable="link">Sales
+								&amp; Marketing</a></td>
+						<td class="o-table__cell--numeric">447%</td>
+						<td class="o-table__cell--numeric">76.20%</td>
+						<td class="o-table__cell--numeric">3,371</td>
+						<td class="o-table__cell--numeric">15</td>
+						<td class="o-table__cell--numeric">29</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">342</td>
+						<td>Termotecnica Cavatton*</td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/companies/construction" data-trackable="link">Construction</a>
+						</td>
+						<td class="o-table__cell--numeric">447%</td>
+						<td class="o-table__cell--numeric">76.20%</td>
+						<td class="o-table__cell--numeric">3,855</td>
+						<td class="o-table__cell--numeric">16</td>
+						<td class="o-table__cell--numeric">22</td>
+						<td>2013</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">343</td>
+						<td><a href="http://forsis.fr/" data-trackable="link" target="_blank">Forsis</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/financial-services" data-trackable="link">Financial
+								Services</a></td>
+						<td class="o-table__cell--numeric">447%</td>
+						<td class="o-table__cell--numeric">76.20%</td>
+						<td class="o-table__cell--numeric">3,836</td>
+						<td class="o-table__cell--numeric">6</td>
+						<td class="o-table__cell--numeric">10</td>
+						<td>2009</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">344</td>
+						<td><a href="http://memodo.de/" data-trackable="link" target="_blank">Memodo*</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/energy" data-trackable="link">Energy</a></td>
+						<td class="o-table__cell--numeric">445%</td>
+						<td class="o-table__cell--numeric">76%</td>
+						<td class="o-table__cell--numeric">20,459</td>
+						<td class="o-table__cell--numeric">15</td>
+						<td class="o-table__cell--numeric">20</td>
+						<td>2013</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">345</td>
+						<td><a href="http://touchnote.com/" data-trackable="link" target="_blank">TouchNote</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Ecommerce" data-trackable="link">Ecommerce</a>
+						</td>
+						<td class="o-table__cell--numeric">445%</td>
+						<td class="o-table__cell--numeric">75.90%</td>
+						<td class="o-table__cell--numeric">6,210</td>
+						<td class="o-table__cell--numeric">9</td>
+						<td class="o-table__cell--numeric">16</td>
+						<td>2007</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">346</td>
+						<td><a href="http://smartadserver.com/" data-trackable="link" target="_blank">Smartadserver</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Advertising" data-trackable="link">Advertising</a>
+						</td>
+						<td class="o-table__cell--numeric">444%</td>
+						<td class="o-table__cell--numeric">75.90%</td>
+						<td class="o-table__cell--numeric">65,350</td>
+						<td class="o-table__cell--numeric">114</td>
+						<td class="o-table__cell--numeric">172</td>
+						<td>2005</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">347</td>
+						<td><a href="http://deltacapita.com/" data-trackable="link" target="_blank">Delta Capita</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Management_Consulting"
+								data-trackable="link">Management Consulting</a></td>
+						<td class="o-table__cell--numeric">442%</td>
+						<td class="o-table__cell--numeric">75.70%</td>
+						<td class="o-table__cell--numeric">5,734</td>
+						<td class="o-table__cell--numeric">48</td>
+						<td class="o-table__cell--numeric">60</td>
+						<td>2009</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">348</td>
+						<td><a href="http://deinoasl.com/" data-trackable="link" target="_blank">Deinoa</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/companies/construction" data-trackable="link">Construction</a>
+						</td>
+						<td class="o-table__cell--numeric">442%</td>
+						<td class="o-table__cell--numeric">75.70%</td>
+						<td class="o-table__cell--numeric">2,738</td>
+						<td class="o-table__cell--numeric">49</td>
+						<td class="o-table__cell--numeric">64</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">349</td>
+						<td><a href="http://neomouv.com/" data-trackable="link" target="_blank">Neomouv</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/personal-goods" data-trackable="link">Personal &amp;
+								Household Goods</a></td>
+						<td class="o-table__cell--numeric">440%</td>
+						<td class="o-table__cell--numeric">75.50%</td>
+						<td class="o-table__cell--numeric">7,651</td>
+						<td class="o-table__cell--numeric">7</td>
+						<td class="o-table__cell--numeric">12</td>
+						<td>2009</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">350</td>
+						<td><a href="http://kinderpflegedienst.com/" data-trackable="link"
+								target="_blank">Kinderpflegedienst.com Karlsruhe</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/health" data-trackable="link">Health</a></td>
+						<td class="o-table__cell--numeric">440%</td>
+						<td class="o-table__cell--numeric">75.40%</td>
+						<td class="o-table__cell--numeric">4,201</td>
+						<td class="o-table__cell--numeric">166</td>
+						<td class="o-table__cell--numeric">198</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">351</td>
+						<td><a href="http://vitedelair.com/" data-trackable="link" target="_blank">Vitedelair</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/media" data-trackable="link">Media</a></td>
+						<td class="o-table__cell--numeric">439%</td>
+						<td class="o-table__cell--numeric">75.30%</td>
+						<td class="o-table__cell--numeric">1,879</td>
+						<td class="o-table__cell--numeric">8</td>
+						<td class="o-table__cell--numeric">9</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">352</td>
+						<td><a href="http://emmeteksrl.it/" data-trackable="link" target="_blank">Emmetek*</a></td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/companies/industrial-goods" data-trackable="link">Industrial
+								Goods</a></td>
+						<td class="o-table__cell--numeric">439%</td>
+						<td class="o-table__cell--numeric">75.30%</td>
+						<td class="o-table__cell--numeric">2,576</td>
+						<td class="o-table__cell--numeric">5</td>
+						<td class="o-table__cell--numeric">14</td>
+						<td>2013</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">353</td>
+						<td><a href="http://coyoapp.com/" data-trackable="link" target="_blank">COYO</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">436%</td>
+						<td class="o-table__cell--numeric">75%</td>
+						<td class="o-table__cell--numeric">4,225</td>
+						<td class="o-table__cell--numeric">33</td>
+						<td class="o-table__cell--numeric">42</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">354</td>
+						<td><a href="http://herring-spareparts.com/" data-trackable="link" target="_blank">Herring
+								GmbH</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/automobiles" data-trackable="link">Automobiles</a>
+						</td>
+						<td class="o-table__cell--numeric">434%</td>
+						<td class="o-table__cell--numeric">74.80%</td>
+						<td class="o-table__cell--numeric">8,254</td>
+						<td class="o-table__cell--numeric">4</td>
+						<td class="o-table__cell--numeric">7</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">355</td>
+						<td><a href="http://fmb-e.de/" data-trackable="link" target="_blank">FMB Engineering*</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/telecoms" data-trackable="link">Telecoms</a></td>
+						<td class="o-table__cell--numeric">433%</td>
+						<td class="o-table__cell--numeric">74.70%</td>
+						<td class="o-table__cell--numeric">4,062</td>
+						<td class="o-table__cell--numeric">14</td>
+						<td class="o-table__cell--numeric">36</td>
+						<td>2013</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">356</td>
+						<td><a href="http://youngdigitals.com/" data-trackable="link" target="_blank">Young Digitals</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Advertising" data-trackable="link">Advertising</a>
+						</td>
+						<td class="o-table__cell--numeric">431%</td>
+						<td class="o-table__cell--numeric">74.50%</td>
+						<td class="o-table__cell--numeric">2,851</td>
+						<td class="o-table__cell--numeric">41</td>
+						<td class="o-table__cell--numeric">50</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">357</td>
+						<td><a href="http://mamagetzner.com/" data-trackable="link" target="_blank">Emmayli</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/retail" data-trackable="link">Retail</a></td>
+						<td class="o-table__cell--numeric">430%</td>
+						<td class="o-table__cell--numeric">74.40%</td>
+						<td class="o-table__cell--numeric">8,519</td>
+						<td class="o-table__cell--numeric">8</td>
+						<td class="o-table__cell--numeric">12</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">358</td>
+						<td><a href="http://erowz.com/" data-trackable="link" target="_blank">eRowz</a></td>
+						<td><a href="https://www.ft.com/topics/places/Belgium" data-trackable="link">Belgium</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Advertising" data-trackable="link">Advertising</a>
+						</td>
+						<td class="o-table__cell--numeric">430%</td>
+						<td class="o-table__cell--numeric">74.30%</td>
+						<td class="o-table__cell--numeric">2,635</td>
+						<td class="o-table__cell--numeric">15</td>
+						<td class="o-table__cell--numeric">17</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">359</td>
+						<td><a href="http://boycor.com/" data-trackable="link" target="_blank">Boycor</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Management_Consulting"
+								data-trackable="link">Management Consulting</a></td>
+						<td class="o-table__cell--numeric">429%</td>
+						<td class="o-table__cell--numeric">74.30%</td>
+						<td class="o-table__cell--numeric">3,482</td>
+						<td class="o-table__cell--numeric">99</td>
+						<td class="o-table__cell--numeric">134</td>
+						<td>2005</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">360</td>
+						<td><a href="http://lesfilmsduworso.com/" data-trackable="link" target="_blank">Les Films Du
+								Worso</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/media" data-trackable="link">Media</a></td>
+						<td class="o-table__cell--numeric">429%</td>
+						<td class="o-table__cell--numeric">74.20%</td>
+						<td class="o-table__cell--numeric">10,867</td>
+						<td class="o-table__cell--numeric">0</td>
+						<td class="o-table__cell--numeric">7</td>
+						<td>2003</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">361</td>
+						<td><a href="http://mediantechnologies.com/" data-trackable="link" target="_blank">Median
+								Technologies</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">428%</td>
+						<td class="o-table__cell--numeric">74.20%</td>
+						<td class="o-table__cell--numeric">6,353</td>
+						<td class="o-table__cell--numeric">46</td>
+						<td class="o-table__cell--numeric">93</td>
+						<td>2002</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">362</td>
+						<td><a href="http://stxnext.com/" data-trackable="link" target="_blank">STX Next Sp. Zo.o</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Poland" data-trackable="link">Poland</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">428%</td>
+						<td class="o-table__cell--numeric">74.10%</td>
+						<td class="o-table__cell--numeric">8,233</td>
+						<td class="o-table__cell--numeric">154</td>
+						<td class="o-table__cell--numeric">246</td>
+						<td>2005</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">363</td>
+						<td><a href="http://theleadagency.com/" data-trackable="link" target="_blank">The Lead
+								Agency</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Sales_&amp;_Marketing" data-trackable="link">Sales
+								&amp; Marketing</a></td>
+						<td class="o-table__cell--numeric">426%</td>
+						<td class="o-table__cell--numeric">74%</td>
+						<td class="o-table__cell--numeric">5,300</td>
+						<td class="o-table__cell--numeric">65</td>
+						<td class="o-table__cell--numeric">90</td>
+						<td>2002</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">364</td>
+						<td><a href="http://enloc.de/" data-trackable="link" target="_blank">Enloc</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/energy" data-trackable="link">Energy</a></td>
+						<td class="o-table__cell--numeric">425%</td>
+						<td class="o-table__cell--numeric">73.80%</td>
+						<td class="o-table__cell--numeric">6,300</td>
+						<td class="o-table__cell--numeric">7</td>
+						<td class="o-table__cell--numeric">12</td>
+						<td>2009</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">365</td>
+						<td><a href="http://lginvest.it/" data-trackable="link" target="_blank">LG Invest</a></td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/companies/telecoms" data-trackable="link">Telecoms</a></td>
+						<td class="o-table__cell--numeric">424%</td>
+						<td class="o-table__cell--numeric">73.70%</td>
+						<td class="o-table__cell--numeric">1,921</td>
+						<td class="o-table__cell--numeric">45</td>
+						<td class="o-table__cell--numeric">50</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">366</td>
+						<td><a href="http://intenta.de/" data-trackable="link" target="_blank">Intenta</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">423%</td>
+						<td class="o-table__cell--numeric">73.60%</td>
+						<td class="o-table__cell--numeric">11,767</td>
+						<td class="o-table__cell--numeric">113</td>
+						<td class="o-table__cell--numeric">160</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">367</td>
+						<td><a href="http://kbs-group.de/" data-trackable="link" target="_blank">KBS Group</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">423%</td>
+						<td class="o-table__cell--numeric">73.60%</td>
+						<td class="o-table__cell--numeric">11,500</td>
+						<td class="o-table__cell--numeric">300</td>
+						<td class="o-table__cell--numeric">400</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">368</td>
+						<td><a href="http://epigroupe.com/" data-trackable="link" target="_blank">EPI Group</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">422%</td>
+						<td class="o-table__cell--numeric">73.50%</td>
+						<td class="o-table__cell--numeric">5,274</td>
+						<td class="o-table__cell--numeric">7</td>
+						<td class="o-table__cell--numeric">12</td>
+						<td>2002</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">369</td>
+						<td><a href="http://logisan.it/" data-trackable="link" target="_blank">Logisan</a></td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/companies/health" data-trackable="link">Health</a></td>
+						<td class="o-table__cell--numeric">422%</td>
+						<td class="o-table__cell--numeric">73.50%</td>
+						<td class="o-table__cell--numeric">19,000</td>
+						<td class="o-table__cell--numeric">5</td>
+						<td class="o-table__cell--numeric">11</td>
+						<td>2004</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">370</td>
+						<td><a href="http://yogurtfactory.fr/" data-trackable="link" target="_blank">Yogurt Factory</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Agricultural_Commodities"
+								data-trackable="link">Agricultural commodities</a></td>
+						<td class="o-table__cell--numeric">421%</td>
+						<td class="o-table__cell--numeric">73.40%</td>
+						<td class="o-table__cell--numeric">2,183</td>
+						<td class="o-table__cell--numeric">33</td>
+						<td class="o-table__cell--numeric">35</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">371</td>
+						<td><a href="http://metsys.fr/" data-trackable="link" target="_blank">Metsys</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">420%</td>
+						<td class="o-table__cell--numeric">73.30%</td>
+						<td class="o-table__cell--numeric">10,901</td>
+						<td class="o-table__cell--numeric">60</td>
+						<td class="o-table__cell--numeric">80</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">372</td>
+						<td><a href="http://hypertecs.it/" data-trackable="link" target="_blank">Hypertec Solution</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/companies/industrial-goods" data-trackable="link">Industrial
+								Goods</a></td>
+						<td class="o-table__cell--numeric">420%</td>
+						<td class="o-table__cell--numeric">73.20%</td>
+						<td class="o-table__cell--numeric">4,865</td>
+						<td class="o-table__cell--numeric">38</td>
+						<td class="o-table__cell--numeric">87</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">373</td>
+						<td><a href="http://clabrun.it/" data-trackable="link" target="_blank">Clabrun</a></td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/companies/retail" data-trackable="link">Retail</a></td>
+						<td class="o-table__cell--numeric">419%</td>
+						<td class="o-table__cell--numeric">73.10%</td>
+						<td class="o-table__cell--numeric">3,975</td>
+						<td class="o-table__cell--numeric">15</td>
+						<td class="o-table__cell--numeric">23</td>
+						<td>2000</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">374</td>
+						<td><a href="http://mediainteractiva.com/" data-trackable="link" target="_blank">Media
+								Interactiva Software</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">419%</td>
+						<td class="o-table__cell--numeric">73.10%</td>
+						<td class="o-table__cell--numeric">2,634</td>
+						<td class="o-table__cell--numeric">28</td>
+						<td class="o-table__cell--numeric">39</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">375</td>
+						<td><a href="http://roctechnologies.com/" data-trackable="link" target="_blank">Roc
+								Technologies</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">418%</td>
+						<td class="o-table__cell--numeric">73%</td>
+						<td class="o-table__cell--numeric">29,168</td>
+						<td class="o-table__cell--numeric">26</td>
+						<td class="o-table__cell--numeric">54</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">376</td>
+						<td><a href="http://powerplanetonline.com/" data-trackable="link" target="_blank">Leask
+								(Powerplanetonline)</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Ecommerce" data-trackable="link">Ecommerce</a>
+						</td>
+						<td class="o-table__cell--numeric">418%</td>
+						<td class="o-table__cell--numeric">73%</td>
+						<td class="o-table__cell--numeric">11,636</td>
+						<td class="o-table__cell--numeric">15</td>
+						<td class="o-table__cell--numeric">31</td>
+						<td>2004</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">377</td>
+						<td><a href="http://palettenversand.com/" data-trackable="link" target="_blank">Raven
+								Logistic</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/transport" data-trackable="link">Transport</a></td>
+						<td class="o-table__cell--numeric">417%</td>
+						<td class="o-table__cell--numeric">72.90%</td>
+						<td class="o-table__cell--numeric">3,653</td>
+						<td class="o-table__cell--numeric">19</td>
+						<td class="o-table__cell--numeric">34</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">378</td>
+						<td><a href="http://monterail.com/" data-trackable="link" target="_blank">Monterail</a></td>
+						<td><a href="https://www.ft.com/topics/places/Poland" data-trackable="link">Poland</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">413%</td>
+						<td class="o-table__cell--numeric">72.50%</td>
+						<td class="o-table__cell--numeric">1,911</td>
+						<td class="o-table__cell--numeric">27</td>
+						<td class="o-table__cell--numeric">36</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">379</td>
+						<td><a href="http://happinyfood.de/" data-trackable="link" target="_blank">Happiny Food</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/food-beverage" data-trackable="link">Food &amp;
+								Beverage</a></td>
+						<td class="o-table__cell--numeric">412%</td>
+						<td class="o-table__cell--numeric">72.30%</td>
+						<td class="o-table__cell--numeric">3,716</td>
+						<td class="o-table__cell--numeric">4</td>
+						<td class="o-table__cell--numeric">6</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">380</td>
+						<td><a href="http://sphere-immo.com/" data-trackable="link" target="_blank">Sphere Immo</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/property" data-trackable="link">Property</a></td>
+						<td class="o-table__cell--numeric">412%</td>
+						<td class="o-table__cell--numeric">72.30%</td>
+						<td class="o-table__cell--numeric">3,285</td>
+						<td class="o-table__cell--numeric">2</td>
+						<td class="o-table__cell--numeric">5</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">381</td>
+						<td><a href="http://touchassociates.com/" data-trackable="link" target="_blank">Touch
+								Associates</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Sales_&amp;_Marketing" data-trackable="link">Sales
+								&amp; Marketing</a></td>
+						<td class="o-table__cell--numeric">410%</td>
+						<td class="o-table__cell--numeric">72.20%</td>
+						<td class="o-table__cell--numeric">33,943</td>
+						<td class="o-table__cell--numeric">43</td>
+						<td class="o-table__cell--numeric">69</td>
+						<td>2009</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">382</td>
+						<td><a href="http://flexstructures.com/" data-trackable="link"
+								target="_blank">fleXstructures</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">408%</td>
+						<td class="o-table__cell--numeric">71.90%</td>
+						<td class="o-table__cell--numeric">2,007</td>
+						<td class="o-table__cell--numeric">12</td>
+						<td class="o-table__cell--numeric">15</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">383</td>
+						<td><a href="http://green-giraffe.eu/" data-trackable="link" target="_blank">Green Giraffe</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Netherlands" data-trackable="link">The
+								Netherlands</a></td>
+						<td><a href="https://www.ft.com/companies/financial-services" data-trackable="link">Financial
+								Services</a></td>
+						<td class="o-table__cell--numeric">408%</td>
+						<td class="o-table__cell--numeric">71.90%</td>
+						<td class="o-table__cell--numeric">13,200</td>
+						<td class="o-table__cell--numeric">35</td>
+						<td class="o-table__cell--numeric">55</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">384</td>
+						<td><a href="http://manifone.com/" data-trackable="link" target="_blank">Manifone</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/telecoms" data-trackable="link">Telecoms</a></td>
+						<td class="o-table__cell--numeric">408%</td>
+						<td class="o-table__cell--numeric">71.90%</td>
+						<td class="o-table__cell--numeric">3,690</td>
+						<td class="o-table__cell--numeric">6</td>
+						<td class="o-table__cell--numeric">11</td>
+						<td>2006</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">385</td>
+						<td><a href="http://geotogether.com/" data-trackable="link" target="_blank">Green Energy Options
+								(Geo)</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">406%</td>
+						<td class="o-table__cell--numeric">71.70%</td>
+						<td class="o-table__cell--numeric">26,849</td>
+						<td class="o-table__cell--numeric">27</td>
+						<td class="o-table__cell--numeric">56</td>
+						<td>2006</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">386</td>
+						<td><a href="http://tropicskincare.com/" data-trackable="link" target="_blank">Tropic
+								Skincare</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/beauty" data-trackable="link">Beauty</a></td>
+						<td class="o-table__cell--numeric">405%</td>
+						<td class="o-table__cell--numeric">71.60%</td>
+						<td class="o-table__cell--numeric">15,052</td>
+						<td class="o-table__cell--numeric">70</td>
+						<td class="o-table__cell--numeric">80</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">387</td>
+						<td><a href="http://enragroup.co.uk/" data-trackable="link" target="_blank">Enra Group</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/companies/financial-services" data-trackable="link">Financial
+								Services</a></td>
+						<td class="o-table__cell--numeric">404%</td>
+						<td class="o-table__cell--numeric">71.50%</td>
+						<td class="o-table__cell--numeric">47,777</td>
+						<td class="o-table__cell--numeric">59</td>
+						<td class="o-table__cell--numeric">79</td>
+						<td>2002</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">388</td>
+						<td><a href="http://hisert.de/" data-trackable="link" target="_blank">HISERT</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/retail" data-trackable="link">Retail</a></td>
+						<td class="o-table__cell--numeric">404%</td>
+						<td class="o-table__cell--numeric">71.40%</td>
+						<td class="o-table__cell--numeric">17,214</td>
+						<td class="o-table__cell--numeric">0</td>
+						<td class="o-table__cell--numeric">5</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">389</td>
+						<td><a href="http://bulkpowders.co.uk/" data-trackable="link" target="_blank">Bulk Powders</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Ecommerce" data-trackable="link">Ecommerce</a>
+						</td>
+						<td class="o-table__cell--numeric">403%</td>
+						<td class="o-table__cell--numeric">71.40%</td>
+						<td class="o-table__cell--numeric">28,344</td>
+						<td class="o-table__cell--numeric">65</td>
+						<td class="o-table__cell--numeric">95</td>
+						<td>2006</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">390</td>
+						<td><a href="http://innovasoftspa.it/" data-trackable="link" target="_blank">Innovasoft</a></td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">403%</td>
+						<td class="o-table__cell--numeric">71.30%</td>
+						<td class="o-table__cell--numeric">1,892</td>
+						<td class="o-table__cell--numeric">11</td>
+						<td class="o-table__cell--numeric">22</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">391</td>
+						<td><a href="http://riversleasing.com/" data-trackable="link" target="_blank">Rivers Finance
+								Group</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/companies/financial-services" data-trackable="link">Financial
+								Services</a></td>
+						<td class="o-table__cell--numeric">402%</td>
+						<td class="o-table__cell--numeric">71.20%</td>
+						<td class="o-table__cell--numeric">2,365</td>
+						<td class="o-table__cell--numeric">5</td>
+						<td class="o-table__cell--numeric">8</td>
+						<td>2002</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">392</td>
+						<td><a href="http://podiumengineering.com/" data-trackable="link" target="_blank">Podium
+								Engineering</a></td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/companies/automobiles" data-trackable="link">Automobiles</a>
+						</td>
+						<td class="o-table__cell--numeric">400%</td>
+						<td class="o-table__cell--numeric">71%</td>
+						<td class="o-table__cell--numeric">1,644</td>
+						<td class="o-table__cell--numeric">10</td>
+						<td class="o-table__cell--numeric">11</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">393</td>
+						<td><a href="http://inovefa.com/" data-trackable="link" target="_blank">Inovefa</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/property" data-trackable="link">Property</a></td>
+						<td class="o-table__cell--numeric">400%</td>
+						<td class="o-table__cell--numeric">71%</td>
+						<td class="o-table__cell--numeric">2,450</td>
+						<td class="o-table__cell--numeric">23</td>
+						<td class="o-table__cell--numeric">30</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">394</td>
+						<td><a href="http://acpdus.com/" data-trackable="link" target="_blank">Air Cargo Professionals
+								(ACP)</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/transport" data-trackable="link">Transport</a></td>
+						<td class="o-table__cell--numeric">399%</td>
+						<td class="o-table__cell--numeric">70.90%</td>
+						<td class="o-table__cell--numeric">7,667</td>
+						<td class="o-table__cell--numeric">5</td>
+						<td class="o-table__cell--numeric">8</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">395</td>
+						<td><a href="http://getbest.at/" data-trackable="link" target="_blank">getBEST
+								Personalservice*</a></td>
+						<td><a href="https://www.ft.com/topics/places/Austria" data-trackable="link">Austria</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">399%</td>
+						<td class="o-table__cell--numeric">70.90%</td>
+						<td class="o-table__cell--numeric">3,362</td>
+						<td class="o-table__cell--numeric">80</td>
+						<td class="o-table__cell--numeric">100</td>
+						<td>2013</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">396</td>
+						<td><a href="http://charlidiscount.com/" data-trackable="link"
+								target="_blank">CharliDiscount.com</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/retail" data-trackable="link">Retail</a></td>
+						<td class="o-table__cell--numeric">398%</td>
+						<td class="o-table__cell--numeric">70.80%</td>
+						<td class="o-table__cell--numeric">1,774</td>
+						<td class="o-table__cell--numeric">-1</td>
+						<td class="o-table__cell--numeric">1</td>
+						<td>2009</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">397</td>
+						<td><a href="http://sofidys.com/" data-trackable="link" target="_blank">Sofidys</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">398%</td>
+						<td class="o-table__cell--numeric">70.70%</td>
+						<td class="o-table__cell--numeric">16,380</td>
+						<td class="o-table__cell--numeric">0</td>
+						<td class="o-table__cell--numeric">2</td>
+						<td>2008</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">398</td>
+						<td><a href="http://tecnip.com/" data-trackable="link" target="_blank">Tecnip*</a></td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/companies/industrial-goods" data-trackable="link">Industrial
+								Goods</a></td>
+						<td class="o-table__cell--numeric">397%</td>
+						<td class="o-table__cell--numeric">70.70%</td>
+						<td class="o-table__cell--numeric">11,438</td>
+						<td class="o-table__cell--numeric">19</td>
+						<td class="o-table__cell--numeric">27</td>
+						<td>2013</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">399</td>
+						<td><a href="http://alternatyva.it/" data-trackable="link" target="_blank">Alternatyva</a></td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/companies/telecoms" data-trackable="link">Telecoms</a></td>
+						<td class="o-table__cell--numeric">396%</td>
+						<td class="o-table__cell--numeric">70.60%</td>
+						<td class="o-table__cell--numeric">4,997</td>
+						<td class="o-table__cell--numeric">10</td>
+						<td class="o-table__cell--numeric">20</td>
+						<td>2006</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">400</td>
+						<td><a href="http://ghilardiselezioni.com/" data-trackable="link" target="_blank">Ghilardi
+								Selezioni</a></td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/companies/food-beverage" data-trackable="link">Food &amp;
+								Beverage</a></td>
+						<td class="o-table__cell--numeric">393%</td>
+						<td class="o-table__cell--numeric">70.20%</td>
+						<td class="o-table__cell--numeric">1,564</td>
+						<td class="o-table__cell--numeric">3</td>
+						<td class="o-table__cell--numeric">4</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">401</td>
+						<td><a href="http://ellipsedentale.fr/" data-trackable="link" target="_blank">Ellipse
+								Dentale*</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/health" data-trackable="link">Health</a></td>
+						<td class="o-table__cell--numeric">393%</td>
+						<td class="o-table__cell--numeric">70.20%</td>
+						<td class="o-table__cell--numeric">1,674</td>
+						<td class="o-table__cell--numeric">5</td>
+						<td class="o-table__cell--numeric">7</td>
+						<td>2013</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">402</td>
+						<td><a href="http://dreischtrom.de/" data-trackable="link" target="_blank">Dreischtrom</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/energy" data-trackable="link">Energy</a></td>
+						<td class="o-table__cell--numeric">393%</td>
+						<td class="o-table__cell--numeric">70.10%</td>
+						<td class="o-table__cell--numeric">4,288</td>
+						<td class="o-table__cell--numeric">4</td>
+						<td class="o-table__cell--numeric">7</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">403</td>
+						<td><a href="http://bulpros.com/" data-trackable="link" target="_blank">Bulpros Consulting</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Bulgaria" data-trackable="link">Bulgaria</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">391%</td>
+						<td class="o-table__cell--numeric">70%</td>
+						<td class="o-table__cell--numeric">16,734</td>
+						<td class="o-table__cell--numeric">868</td>
+						<td class="o-table__cell--numeric">1,083</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">404</td>
+						<td><a href="http://iqfinance.co.uk/" data-trackable="link" target="_blank">IQ Finance</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/companies/financial-services" data-trackable="link">Financial
+								Services</a></td>
+						<td class="o-table__cell--numeric">391%</td>
+						<td class="o-table__cell--numeric">70%</td>
+						<td class="o-table__cell--numeric">3,925</td>
+						<td class="o-table__cell--numeric">0</td>
+						<td class="o-table__cell--numeric">2</td>
+						<td>2002</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">405</td>
+						<td><a href="http://wota-online.de/" data-trackable="link" target="_blank">GBV Taucha mbH</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/property" data-trackable="link">Property</a></td>
+						<td class="o-table__cell--numeric">391%</td>
+						<td class="o-table__cell--numeric">70%</td>
+						<td class="o-table__cell--numeric">2,277</td>
+						<td class="o-table__cell--numeric">0</td>
+						<td class="o-table__cell--numeric">2</td>
+						<td>1991</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">406</td>
+						<td><a href="http://buyingpeers.com/" data-trackable="link" target="_blank">Buyingpeers</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Management_Consulting"
+								data-trackable="link">Management Consulting</a></td>
+						<td class="o-table__cell--numeric">391%</td>
+						<td class="o-table__cell--numeric">69.90%</td>
+						<td class="o-table__cell--numeric">7,153</td>
+						<td class="o-table__cell--numeric">56</td>
+						<td class="o-table__cell--numeric">75</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">407</td>
+						<td><a href="http://networldsports.co.uk/" data-trackable="link" target="_blank">Net World
+								Sports</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/companies/retail" data-trackable="link">Retail</a></td>
+						<td class="o-table__cell--numeric">391%</td>
+						<td class="o-table__cell--numeric">69.90%</td>
+						<td class="o-table__cell--numeric">15,226</td>
+						<td class="o-table__cell--numeric">49</td>
+						<td class="o-table__cell--numeric">62</td>
+						<td>2009</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">408</td>
+						<td><a href="http://ccsabogados.com/" data-trackable="link" target="_blank">Caamaño, Concheiro
+								&amp; Seoan</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Law" data-trackable="link">Law</a></td>
+						<td class="o-table__cell--numeric">390%</td>
+						<td class="o-table__cell--numeric">69.90%</td>
+						<td class="o-table__cell--numeric">4,953</td>
+						<td class="o-table__cell--numeric">55</td>
+						<td class="o-table__cell--numeric">68</td>
+						<td>2002</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">409</td>
+						<td><a href="http://7starsms.eu/" data-trackable="link" target="_blank">Seven Stars Marina &amp;
+								Shipyard</a></td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/companies/travel-leisure" data-trackable="link">Travel &amp;
+								Leisure</a></td>
+						<td class="o-table__cell--numeric">387%</td>
+						<td class="o-table__cell--numeric">69.50%</td>
+						<td class="o-table__cell--numeric">7,848</td>
+						<td class="o-table__cell--numeric">10</td>
+						<td class="o-table__cell--numeric">17</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">410</td>
+						<td><a href="http://mifarma.es/" data-trackable="link" target="_blank">Mifarma</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/companies/pharmaceuticals"
+								data-trackable="link">Pharmaceuticals</a></td>
+						<td class="o-table__cell--numeric">386%</td>
+						<td class="o-table__cell--numeric">69.40%</td>
+						<td class="o-table__cell--numeric">14,208</td>
+						<td class="o-table__cell--numeric">18</td>
+						<td class="o-table__cell--numeric">33</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">411</td>
+						<td><a href="http://whatchado.com/" data-trackable="link" target="_blank">whatchado</a></td>
+						<td><a href="https://www.ft.com/topics/places/Austria" data-trackable="link">Austria</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">386%</td>
+						<td class="o-table__cell--numeric">69.40%</td>
+						<td class="o-table__cell--numeric">2,179</td>
+						<td class="o-table__cell--numeric">33</td>
+						<td class="o-table__cell--numeric">48</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">412</td>
+						<td><a href="http://familjehemmenkrut.se/" data-trackable="link" target="_blank">KRUT Sociala
+								Tjänster</a></td>
+						<td><a href="https://www.ft.com/topics/places/Sweden" data-trackable="link">Sweden</a></td>
+						<td><a href="https://www.ft.com/companies/health" data-trackable="link">Health</a></td>
+						<td class="o-table__cell--numeric">384%</td>
+						<td class="o-table__cell--numeric">69.20%</td>
+						<td class="o-table__cell--numeric">6,338</td>
+						<td class="o-table__cell--numeric">78</td>
+						<td class="o-table__cell--numeric">95</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">413</td>
+						<td><a href="http://lioncourthomes.com/" data-trackable="link" target="_blank">Lioncourt
+								Homes</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/companies/property" data-trackable="link">Property</a></td>
+						<td class="o-table__cell--numeric">384%</td>
+						<td class="o-table__cell--numeric">69.20%</td>
+						<td class="o-table__cell--numeric">66,832</td>
+						<td class="o-table__cell--numeric">47</td>
+						<td class="o-table__cell--numeric">71</td>
+						<td>2006</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">414</td>
+						<td><a href="http://pymar.com/" data-trackable="link" target="_blank">Pequeños y Medianos
+								Astilleros</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/companies/construction" data-trackable="link">Construction</a>
+						</td>
+						<td class="o-table__cell--numeric">384%</td>
+						<td class="o-table__cell--numeric">69.20%</td>
+						<td class="o-table__cell--numeric">5,670</td>
+						<td class="o-table__cell--numeric">-1</td>
+						<td class="o-table__cell--numeric">21</td>
+						<td>1985</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">415</td>
+						<td><a href="http://diekreartisten.com/" data-trackable="link" target="_blank">die
+								kreArtisten</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">382%</td>
+						<td class="o-table__cell--numeric">68.90%</td>
+						<td class="o-table__cell--numeric">2,137</td>
+						<td class="o-table__cell--numeric">19</td>
+						<td class="o-table__cell--numeric">26</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">416</td>
+						<td><a href="http://avocadostore.de/" data-trackable="link" target="_blank">Avocadostore</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Ecommerce" data-trackable="link">Ecommerce</a>
+						</td>
+						<td class="o-table__cell--numeric">382%</td>
+						<td class="o-table__cell--numeric">68.90%</td>
+						<td class="o-table__cell--numeric">9,008</td>
+						<td class="o-table__cell--numeric">10</td>
+						<td class="o-table__cell--numeric">16</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">417</td>
+						<td><a href="http://zanatta.de/" data-trackable="link" target="_blank">ZANATTA media group</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Advertising" data-trackable="link">Advertising</a>
+						</td>
+						<td class="o-table__cell--numeric">381%</td>
+						<td class="o-table__cell--numeric">68.80%</td>
+						<td class="o-table__cell--numeric">1,957</td>
+						<td class="o-table__cell--numeric">2</td>
+						<td class="o-table__cell--numeric">4</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">418</td>
+						<td><a href="http://my1styears.com/" data-trackable="link" target="_blank">My 1st Years</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/companies/retail" data-trackable="link">Retail</a></td>
+						<td class="o-table__cell--numeric">381%</td>
+						<td class="o-table__cell--numeric">68.80%</td>
+						<td class="o-table__cell--numeric">7,652</td>
+						<td class="o-table__cell--numeric">53</td>
+						<td class="o-table__cell--numeric">63</td>
+						<td>2009</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">419</td>
+						<td><a href="http://reputationvip.com/" data-trackable="link" target="_blank">Reputation VIP</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">381%</td>
+						<td class="o-table__cell--numeric">68.80%</td>
+						<td class="o-table__cell--numeric">1,523</td>
+						<td class="o-table__cell--numeric">14</td>
+						<td class="o-table__cell--numeric">22</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">420</td>
+						<td><a href="http://naturedog.fr/" data-trackable="link" target="_blank">Nature Dog</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/retail" data-trackable="link">Retail</a></td>
+						<td class="o-table__cell--numeric">380%</td>
+						<td class="o-table__cell--numeric">68.70%</td>
+						<td class="o-table__cell--numeric">2,824</td>
+						<td class="o-table__cell--numeric">6</td>
+						<td class="o-table__cell--numeric">8</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">421</td>
+						<td><a href="http://mcginleygroup.co.uk/" data-trackable="link" target="_blank">McGinley Human
+								Resources</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">379%</td>
+						<td class="o-table__cell--numeric">68.60%</td>
+						<td class="o-table__cell--numeric">140,232</td>
+						<td class="o-table__cell--numeric">45</td>
+						<td class="o-table__cell--numeric">75</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">422</td>
+						<td><a href="http://utopialab.it/" data-trackable="link" target="_blank">Utopia Lab</a></td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">376%</td>
+						<td class="o-table__cell--numeric">68.20%</td>
+						<td class="o-table__cell--numeric">1,645</td>
+						<td class="o-table__cell--numeric">8</td>
+						<td class="o-table__cell--numeric">9</td>
+						<td>2008</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">423</td>
+						<td><a href="http://ratesetter.com/" data-trackable="link" target="_blank">Ratesetter</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/fintech" data-trackable="link">Fintech</a></td>
+						<td class="o-table__cell--numeric">374%</td>
+						<td class="o-table__cell--numeric">68%</td>
+						<td class="o-table__cell--numeric">28,176</td>
+						<td class="o-table__cell--numeric">186</td>
+						<td class="o-table__cell--numeric">222</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">424</td>
+						<td><a href="http://lithoz.com/" data-trackable="link" target="_blank">Lithoz</a></td>
+						<td><a href="https://www.ft.com/topics/places/Austria" data-trackable="link">Austria</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">374%</td>
+						<td class="o-table__cell--numeric">68%</td>
+						<td class="o-table__cell--numeric">2,312</td>
+						<td class="o-table__cell--numeric">19</td>
+						<td class="o-table__cell--numeric">30</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">425</td>
+						<td><a href="http://bernina-france.fr/" data-trackable="link" target="_blank">Bernina France</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/personal-goods" data-trackable="link">Personal &amp;
+								Household Goods</a></td>
+						<td class="o-table__cell--numeric">374%</td>
+						<td class="o-table__cell--numeric">67.90%</td>
+						<td class="o-table__cell--numeric">2,086</td>
+						<td class="o-table__cell--numeric">n/a</td>
+						<td class="o-table__cell--numeric">n/a</td>
+						<td>1991</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">426</td>
+						<td><a href="http://balyo.com/" data-trackable="link" target="_blank">Balyo</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">373%</td>
+						<td class="o-table__cell--numeric">67.90%</td>
+						<td class="o-table__cell--numeric">5,373</td>
+						<td class="o-table__cell--numeric">35</td>
+						<td class="o-table__cell--numeric">72</td>
+						<td>2005</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">427</td>
+						<td><a href="http://humanus-personalservice.de/" data-trackable="link" target="_blank">Humanus
+								Personalservice*</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">373%</td>
+						<td class="o-table__cell--numeric">67.80%</td>
+						<td class="o-table__cell--numeric">5,046</td>
+						<td class="o-table__cell--numeric">90</td>
+						<td class="o-table__cell--numeric">140</td>
+						<td>2013</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">428</td>
+						<td><a href="http://theofficegroup.co.uk/" data-trackable="link" target="_blank">The Office
+								Group</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/companies/property" data-trackable="link">Property</a></td>
+						<td class="o-table__cell--numeric">373%</td>
+						<td class="o-table__cell--numeric">67.80%</td>
+						<td class="o-table__cell--numeric">85,611</td>
+						<td class="o-table__cell--numeric">131</td>
+						<td class="o-table__cell--numeric">202</td>
+						<td>2003</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">429</td>
+						<td><a href="http://sweetpunk.com/" data-trackable="link" target="_blank">Sweet Punk</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/media" data-trackable="link">Media</a></td>
+						<td class="o-table__cell--numeric">372%</td>
+						<td class="o-table__cell--numeric">67.80%</td>
+						<td class="o-table__cell--numeric">2,071</td>
+						<td class="o-table__cell--numeric">15</td>
+						<td class="o-table__cell--numeric">19</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">430</td>
+						<td><a href="http://lexception.com/" data-trackable="link" target="_blank">L'Exception</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/retail" data-trackable="link">Retail</a></td>
+						<td class="o-table__cell--numeric">372%</td>
+						<td class="o-table__cell--numeric">67.80%</td>
+						<td class="o-table__cell--numeric">3,961</td>
+						<td class="o-table__cell--numeric">17</td>
+						<td class="o-table__cell--numeric">21</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">431</td>
+						<td><a href="http://dag1.nl/" data-trackable="link" target="_blank">Dag1</a></td>
+						<td><a href="https://www.ft.com/topics/places/Netherlands" data-trackable="link">The
+								Netherlands</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">371%</td>
+						<td class="o-table__cell--numeric">67.70%</td>
+						<td class="o-table__cell--numeric">3,300</td>
+						<td class="o-table__cell--numeric">13</td>
+						<td class="o-table__cell--numeric">17</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">432</td>
+						<td><a href="http://expert-security.de/" data-trackable="link"
+								target="_blank">EXPERT-Security</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Ecommerce" data-trackable="link">Ecommerce</a>
+						</td>
+						<td class="o-table__cell--numeric">370%</td>
+						<td class="o-table__cell--numeric">67.50%</td>
+						<td class="o-table__cell--numeric">10,011</td>
+						<td class="o-table__cell--numeric">14</td>
+						<td class="o-table__cell--numeric">30</td>
+						<td>2007</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">433</td>
+						<td><a href="http://sostariffe.it/" data-trackable="link" target="_blank">Sos Tariffe</a></td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/companies/financial-services" data-trackable="link">Financial
+								Services</a></td>
+						<td class="o-table__cell--numeric">369%</td>
+						<td class="o-table__cell--numeric">67.40%</td>
+						<td class="o-table__cell--numeric">5,177</td>
+						<td class="o-table__cell--numeric">12</td>
+						<td class="o-table__cell--numeric">14</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">434</td>
+						<td><a href="http://bygglet.com/" data-trackable="link" target="_blank">Bygglet</a></td>
+						<td><a href="https://www.ft.com/topics/places/Sweden" data-trackable="link">Sweden</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">368%</td>
+						<td class="o-table__cell--numeric">67.30%</td>
+						<td class="o-table__cell--numeric">2,138</td>
+						<td class="o-table__cell--numeric">12</td>
+						<td class="o-table__cell--numeric">18</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">435</td>
+						<td><a href="http://paymentsense.co.uk/" data-trackable="link" target="_blank">Paymentsense</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/fintech" data-trackable="link">Fintech</a></td>
+						<td class="o-table__cell--numeric">367%</td>
+						<td class="o-table__cell--numeric">67.20%</td>
+						<td class="o-table__cell--numeric">73,583</td>
+						<td class="o-table__cell--numeric">69</td>
+						<td class="o-table__cell--numeric">203</td>
+						<td>2008</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">436</td>
+						<td><a href="http://12build.com/" data-trackable="link" target="_blank">12Build</a></td>
+						<td><a href="https://www.ft.com/topics/places/Netherlands" data-trackable="link">The
+								Netherlands</a></td>
+						<td><a href="https://www.ft.com/companies/construction" data-trackable="link">Construction</a>
+						</td>
+						<td class="o-table__cell--numeric">367%</td>
+						<td class="o-table__cell--numeric">67.10%</td>
+						<td class="o-table__cell--numeric">2,615</td>
+						<td class="o-table__cell--numeric">21</td>
+						<td class="o-table__cell--numeric">27</td>
+						<td>2007</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">437</td>
+						<td><a href="http://alkamelsystems.com/" data-trackable="link" target="_blank">Al Kamel
+								Systems</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">365%</td>
+						<td class="o-table__cell--numeric">66.90%</td>
+						<td class="o-table__cell--numeric">5,489</td>
+						<td class="o-table__cell--numeric">8</td>
+						<td class="o-table__cell--numeric">13</td>
+						<td>2006</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">438</td>
+						<td><a href="http://logisseo.com/" data-trackable="link" target="_blank">Logisseo</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/transport" data-trackable="link">Transport</a></td>
+						<td class="o-table__cell--numeric">364%</td>
+						<td class="o-table__cell--numeric">66.80%</td>
+						<td class="o-table__cell--numeric">1,631</td>
+						<td class="o-table__cell--numeric">9</td>
+						<td class="o-table__cell--numeric">16</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">439</td>
+						<td><a href="http://luca-tic.com/" data-trackable="link" target="_blank">Luca Tic</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">363%</td>
+						<td class="o-table__cell--numeric">66.70%</td>
+						<td class="o-table__cell--numeric">5,334</td>
+						<td class="o-table__cell--numeric">145</td>
+						<td class="o-table__cell--numeric">180</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">440</td>
+						<td><a href="http://aiuken.com/" data-trackable="link" target="_blank">Aiuken solutions</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Cyber_Security" data-trackable="link">Cyber
+								Security</a></td>
+						<td class="o-table__cell--numeric">363%</td>
+						<td class="o-table__cell--numeric">66.70%</td>
+						<td class="o-table__cell--numeric">3,097</td>
+						<td class="o-table__cell--numeric">21</td>
+						<td class="o-table__cell--numeric">25</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">441</td>
+						<td><a href="http://rafagrautransport.com/" data-trackable="link" target="_blank">Rafa Grau
+								Transports</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/companies/transport" data-trackable="link">Transport</a></td>
+						<td class="o-table__cell--numeric">360%</td>
+						<td class="o-table__cell--numeric">66.30%</td>
+						<td class="o-table__cell--numeric">6,900</td>
+						<td class="o-table__cell--numeric">30</td>
+						<td class="o-table__cell--numeric">39</td>
+						<td>2005</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">442</td>
+						<td><a href="http://supermercadostusuper.com/" data-trackable="link" target="_blank">Tu Súper
+								Purchase</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/companies/retail" data-trackable="link">Retail</a></td>
+						<td class="o-table__cell--numeric">360%</td>
+						<td class="o-table__cell--numeric">66.30%</td>
+						<td class="o-table__cell--numeric">4,457</td>
+						<td class="o-table__cell--numeric">42</td>
+						<td class="o-table__cell--numeric">49</td>
+						<td>2006</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">443</td>
+						<td><a href="http://tokiota.com/" data-trackable="link" target="_blank">Tokiota</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">360%</td>
+						<td class="o-table__cell--numeric">66.30%</td>
+						<td class="o-table__cell--numeric">4,757</td>
+						<td class="o-table__cell--numeric">58</td>
+						<td class="o-table__cell--numeric">64</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">444</td>
+						<td><a href="http://metalvenice.it/" data-trackable="link" target="_blank">MetalVenice</a></td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/companies/automobiles" data-trackable="link">Automobiles</a>
+						</td>
+						<td class="o-table__cell--numeric">359%</td>
+						<td class="o-table__cell--numeric">66.20%</td>
+						<td class="o-table__cell--numeric">2,947</td>
+						<td class="o-table__cell--numeric">29</td>
+						<td class="o-table__cell--numeric">57</td>
+						<td>1999</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">445</td>
+						<td><a href="http://theodo.fr/" data-trackable="link" target="_blank">Theodo</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">359%</td>
+						<td class="o-table__cell--numeric">66.10%</td>
+						<td class="o-table__cell--numeric">13,822</td>
+						<td class="o-table__cell--numeric">74</td>
+						<td class="o-table__cell--numeric">99</td>
+						<td>2007</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">446</td>
+						<td><a href="http://stillfront.com/" data-trackable="link" target="_blank">Stillfront Group</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Sweden" data-trackable="link">Sweden</a></td>
+						<td><a href="https://www.ft.com/stream/f9c6d3fe-5e16-479c-b762-bccdeeb349fe"
+								data-trackable="link">Games industry</a></td>
+						<td class="o-table__cell--numeric">358%</td>
+						<td class="o-table__cell--numeric">66.10%</td>
+						<td class="o-table__cell--numeric">10,026</td>
+						<td class="o-table__cell--numeric">72</td>
+						<td class="o-table__cell--numeric">96</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">447</td>
+						<td><a href="http://oliver.agency/" data-trackable="link" target="_blank">Inside Ideas Group</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Advertising" data-trackable="link">Advertising</a>
+						</td>
+						<td class="o-table__cell--numeric">357%</td>
+						<td class="o-table__cell--numeric">66%</td>
+						<td class="o-table__cell--numeric">91,718</td>
+						<td class="o-table__cell--numeric">353</td>
+						<td class="o-table__cell--numeric">438</td>
+						<td>2003</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">448</td>
+						<td><a href="http://bannerflow.com/" data-trackable="link" target="_blank">Bannerflow</a></td>
+						<td><a href="https://www.ft.com/topics/places/Sweden" data-trackable="link">Sweden</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Advertising" data-trackable="link">Advertising</a>
+						</td>
+						<td class="o-table__cell--numeric">357%</td>
+						<td class="o-table__cell--numeric">66%</td>
+						<td class="o-table__cell--numeric">4,469</td>
+						<td class="o-table__cell--numeric">32</td>
+						<td class="o-table__cell--numeric">42</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">449</td>
+						<td><a href="http://satistt.fr/" data-trackable="link" target="_blank">Satis TT</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">356%</td>
+						<td class="o-table__cell--numeric">65.90%</td>
+						<td class="o-table__cell--numeric">8,652</td>
+						<td class="o-table__cell--numeric">286</td>
+						<td class="o-table__cell--numeric">323</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">450</td>
+						<td><a href="http://ilumax.es/" data-trackable="link" target="_blank">Ilumax Led Solutions</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/companies/retail" data-trackable="link">Retail</a></td>
+						<td class="o-table__cell--numeric">356%</td>
+						<td class="o-table__cell--numeric">65.80%</td>
+						<td class="o-table__cell--numeric">2,693</td>
+						<td class="o-table__cell--numeric">13</td>
+						<td class="o-table__cell--numeric">16</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">451</td>
+						<td><a href="http://gastronovi.de/" data-trackable="link" target="_blank">gastronovi</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/restaurants" data-trackable="link">Restaurants</a></td>
+						<td class="o-table__cell--numeric">356%</td>
+						<td class="o-table__cell--numeric">65.80%</td>
+						<td class="o-table__cell--numeric">1,960</td>
+						<td class="o-table__cell--numeric">26</td>
+						<td class="o-table__cell--numeric">30</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">452</td>
+						<td><a href="http://al-logistics.eu/" data-trackable="link" target="_blank">A &amp; L Logistics
+								&amp; Trade</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/transport" data-trackable="link">Transport</a></td>
+						<td class="o-table__cell--numeric">356%</td>
+						<td class="o-table__cell--numeric">65.80%</td>
+						<td class="o-table__cell--numeric">3,439</td>
+						<td class="o-table__cell--numeric">25</td>
+						<td class="o-table__cell--numeric">33</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">453</td>
+						<td><a href="http://bagjump.com/" data-trackable="link" target="_blank">Bagjump Action
+								Sports</a></td>
+						<td><a href="https://www.ft.com/topics/places/Austria" data-trackable="link">Austria</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">355%</td>
+						<td class="o-table__cell--numeric">65.70%</td>
+						<td class="o-table__cell--numeric">5,010</td>
+						<td class="o-table__cell--numeric">4</td>
+						<td class="o-table__cell--numeric">9</td>
+						<td>2009</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">454</td>
+						<td><a href="http://kasadenn.fr/" data-trackable="link" target="_blank">Kasadenn</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/transport" data-trackable="link">Transport</a></td>
+						<td class="o-table__cell--numeric">355%</td>
+						<td class="o-table__cell--numeric">65.70%</td>
+						<td class="o-table__cell--numeric">2,568</td>
+						<td class="o-table__cell--numeric">27</td>
+						<td class="o-table__cell--numeric">37</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">455</td>
+						<td><a href="http://woolwarehouse.co.uk/" data-trackable="link" target="_blank">Wool Warehouse
+								Direct</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Ecommerce" data-trackable="link">Ecommerce</a>
+						</td>
+						<td class="o-table__cell--numeric">354%</td>
+						<td class="o-table__cell--numeric">65.60%</td>
+						<td class="o-table__cell--numeric">8,785</td>
+						<td class="o-table__cell--numeric">36</td>
+						<td class="o-table__cell--numeric">41</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">456</td>
+						<td><a href="http://aalgaardbygg.no/" data-trackable="link" target="_blank">Aalgaard Bygg</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Norway" data-trackable="link">Norway</a></td>
+						<td><a href="https://www.ft.com/companies/property" data-trackable="link">Property</a></td>
+						<td class="o-table__cell--numeric">353%</td>
+						<td class="o-table__cell--numeric">65.50%</td>
+						<td class="o-table__cell--numeric">6,673</td>
+						<td class="o-table__cell--numeric">n/a</td>
+						<td class="o-table__cell--numeric">12</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">457</td>
+						<td><a href="http://techpump.com/" data-trackable="link" target="_blank">Techpump</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">353%</td>
+						<td class="o-table__cell--numeric">65.40%</td>
+						<td class="o-table__cell--numeric">11,762</td>
+						<td class="o-table__cell--numeric">17</td>
+						<td class="o-table__cell--numeric">29</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">458</td>
+						<td><a href="http://northvaleconstruction.co.uk/" data-trackable="link"
+								target="_blank">Northvale Construction</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/companies/construction" data-trackable="link">Construction</a>
+						</td>
+						<td class="o-table__cell--numeric">353%</td>
+						<td class="o-table__cell--numeric">65.40%</td>
+						<td class="o-table__cell--numeric">15,782</td>
+						<td class="o-table__cell--numeric">15</td>
+						<td class="o-table__cell--numeric">30</td>
+						<td>2008</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">459</td>
+						<td><a href="http://civitatis.com/" data-trackable="link" target="_blank">Civitatis Tours</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/companies/travel-leisure" data-trackable="link">Travel &amp;
+								Leisure</a></td>
+						<td class="o-table__cell--numeric">352%</td>
+						<td class="o-table__cell--numeric">65.30%</td>
+						<td class="o-table__cell--numeric">17,935</td>
+						<td class="o-table__cell--numeric">22</td>
+						<td class="o-table__cell--numeric">24</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">460</td>
+						<td><a href="http://zef-buergerbeteiligung.de/" data-trackable="link"
+								target="_blank">ZukunftsEnergie Fichtelgebirge</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/energy" data-trackable="link">Energy</a></td>
+						<td class="o-table__cell--numeric">351%</td>
+						<td class="o-table__cell--numeric">65.30%</td>
+						<td class="o-table__cell--numeric">2,649</td>
+						<td class="o-table__cell--numeric">0</td>
+						<td class="o-table__cell--numeric">1</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">461</td>
+						<td><a href="http://opuspsg.com/" data-trackable="link" target="_blank">Opus Professional
+								Services Group</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">351%</td>
+						<td class="o-table__cell--numeric">65.20%</td>
+						<td class="o-table__cell--numeric">76,134</td>
+						<td class="o-table__cell--numeric">106</td>
+						<td class="o-table__cell--numeric">139</td>
+						<td>2008</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">462</td>
+						<td><a href="http://winergia.com/" data-trackable="link" target="_blank">Winergia</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/energy" data-trackable="link">Energy</a></td>
+						<td class="o-table__cell--numeric">347%</td>
+						<td class="o-table__cell--numeric">64.70%</td>
+						<td class="o-table__cell--numeric">2,217</td>
+						<td class="o-table__cell--numeric">16</td>
+						<td class="o-table__cell--numeric">27</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">463</td>
+						<td><a href="http://apissys.com/" data-trackable="link" target="_blank">ApisSys</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">346%</td>
+						<td class="o-table__cell--numeric">64.60%</td>
+						<td class="o-table__cell--numeric">4,243</td>
+						<td class="o-table__cell--numeric">5</td>
+						<td class="o-table__cell--numeric">12</td>
+						<td>2009</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">464</td>
+						<td><a href="http://freaks4u.de/" data-trackable="link" target="_blank">Freaks 4U Gaming</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Advertising" data-trackable="link">Advertising</a>
+						</td>
+						<td class="o-table__cell--numeric">346%</td>
+						<td class="o-table__cell--numeric">64.60%</td>
+						<td class="o-table__cell--numeric">7,070</td>
+						<td class="o-table__cell--numeric">60</td>
+						<td class="o-table__cell--numeric">90</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">465</td>
+						<td><a href="http://cristaux-couleurs.com/" data-trackable="link" target="_blank">Cristaux &amp;
+								Couleurs</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/retail" data-trackable="link">Retail</a></td>
+						<td class="o-table__cell--numeric">345%</td>
+						<td class="o-table__cell--numeric">64.50%</td>
+						<td class="o-table__cell--numeric">3,781</td>
+						<td class="o-table__cell--numeric">26</td>
+						<td class="o-table__cell--numeric">30</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">466</td>
+						<td><a href="http://netguru.co/" data-trackable="link" target="_blank">Netguru</a></td>
+						<td><a href="https://www.ft.com/topics/places/Poland" data-trackable="link">Poland</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">345%</td>
+						<td class="o-table__cell--numeric">64.50%</td>
+						<td class="o-table__cell--numeric">6,460</td>
+						<td class="o-table__cell--numeric">155</td>
+						<td class="o-table__cell--numeric">206</td>
+						<td>2008</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">467</td>
+						<td><a href="http://amiltone.com/" data-trackable="link" target="_blank">Amiltone</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">345%</td>
+						<td class="o-table__cell--numeric">64.40%</td>
+						<td class="o-table__cell--numeric">7,621</td>
+						<td class="o-table__cell--numeric">99</td>
+						<td class="o-table__cell--numeric">135</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">468</td>
+						<td><a href="http://devisubox.com/" data-trackable="link" target="_blank">Devisubox</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">343%</td>
+						<td class="o-table__cell--numeric">64.20%</td>
+						<td class="o-table__cell--numeric">3,607</td>
+						<td class="o-table__cell--numeric">21</td>
+						<td class="o-table__cell--numeric">38</td>
+						<td>2006</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">469</td>
+						<td><a href="http://weezevent.com/" data-trackable="link" target="_blank">Weezevent</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/travel-leisure" data-trackable="link">Travel &amp;
+								Leisure</a></td>
+						<td class="o-table__cell--numeric">340%</td>
+						<td class="o-table__cell--numeric">63.90%</td>
+						<td class="o-table__cell--numeric">88,000</td>
+						<td class="o-table__cell--numeric">17</td>
+						<td class="o-table__cell--numeric">37</td>
+						<td>2008</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">470</td>
+						<td><a href="http://viborapadel.com/" data-trackable="link" target="_blank">Vibor-A Padel</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/companies/retail" data-trackable="link">Retail</a></td>
+						<td class="o-table__cell--numeric">340%</td>
+						<td class="o-table__cell--numeric">63.80%</td>
+						<td class="o-table__cell--numeric">1,793</td>
+						<td class="o-table__cell--numeric">5</td>
+						<td class="o-table__cell--numeric">8</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">471</td>
+						<td><a href="http://fever-tree.com/" data-trackable="link" target="_blank">Fevertree Drinks</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/companies/food-beverage" data-trackable="link">Food &amp;
+								Beverage</a></td>
+						<td class="o-table__cell--numeric">339%</td>
+						<td class="o-table__cell--numeric">63.70%</td>
+						<td class="o-table__cell--numeric">125,173</td>
+						<td class="o-table__cell--numeric">31</td>
+						<td class="o-table__cell--numeric">48</td>
+						<td>2005</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">472</td>
+						<td><a href="http://renewa.de/" data-trackable="link" target="_blank">RENEWA</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/energy" data-trackable="link">Energy</a></td>
+						<td class="o-table__cell--numeric">338%</td>
+						<td class="o-table__cell--numeric">63.60%</td>
+						<td class="o-table__cell--numeric">7,000</td>
+						<td class="o-table__cell--numeric">16</td>
+						<td class="o-table__cell--numeric">19</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">473</td>
+						<td><a href="http://btl-logistikgmbh.de/" data-trackable="link" target="_blank">BTL Logistik</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/transport" data-trackable="link">Transport</a></td>
+						<td class="o-table__cell--numeric">337%</td>
+						<td class="o-table__cell--numeric">63.50%</td>
+						<td class="o-table__cell--numeric">4,742</td>
+						<td class="o-table__cell--numeric">60</td>
+						<td class="o-table__cell--numeric">100</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">474</td>
+						<td><a href="http://vrtelecom.es/" data-trackable="link" target="_blank">VR Telecom</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/companies/telecoms" data-trackable="link">Telecoms</a></td>
+						<td class="o-table__cell--numeric">336%</td>
+						<td class="o-table__cell--numeric">63.40%</td>
+						<td class="o-table__cell--numeric">94,297</td>
+						<td class="o-table__cell--numeric">7</td>
+						<td class="o-table__cell--numeric">12</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">475</td>
+						<td><a href="http://smart-battery-solutions.de/" data-trackable="link" target="_blank">Smart
+								Battery Solutions</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Batteries" data-trackable="link">Batteries</a>
+						</td>
+						<td class="o-table__cell--numeric">336%</td>
+						<td class="o-table__cell--numeric">63.40%</td>
+						<td class="o-table__cell--numeric">3,400</td>
+						<td class="o-table__cell--numeric">16</td>
+						<td class="o-table__cell--numeric">29</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">476</td>
+						<td><a href="http://hadriantechnology.co.uk/" data-trackable="link" target="_blank">Hadrian
+								Technology</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Cyber_Security" data-trackable="link">Cyber
+								Security</a></td>
+						<td class="o-table__cell--numeric">335%</td>
+						<td class="o-table__cell--numeric">63.30%</td>
+						<td class="o-table__cell--numeric">6,640</td>
+						<td class="o-table__cell--numeric">8</td>
+						<td class="o-table__cell--numeric">11</td>
+						<td>1999</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">477</td>
+						<td><a href="http://volonte-co.com/" data-trackable="link" target="_blank">Volontè &amp; Co</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/companies/media" data-trackable="link">Media</a></td>
+						<td class="o-table__cell--numeric">335%</td>
+						<td class="o-table__cell--numeric">63.30%</td>
+						<td class="o-table__cell--numeric">3,168</td>
+						<td class="o-table__cell--numeric">8</td>
+						<td class="o-table__cell--numeric">11</td>
+						<td>2008</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">478</td>
+						<td><a href="http://staircraft-ltd.co.uk/" data-trackable="link" target="_blank">Staircraft
+								Integrated Solutions</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/companies/construction" data-trackable="link">Construction</a>
+						</td>
+						<td class="o-table__cell--numeric">335%</td>
+						<td class="o-table__cell--numeric">63.30%</td>
+						<td class="o-table__cell--numeric">32,223</td>
+						<td class="o-table__cell--numeric">137</td>
+						<td class="o-table__cell--numeric">196</td>
+						<td>1995</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">479</td>
+						<td><a href="http://doit-solutions.de/" data-trackable="link" target="_blank">doIT solutions</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">334%</td>
+						<td class="o-table__cell--numeric">63.20%</td>
+						<td class="o-table__cell--numeric">3,940</td>
+						<td class="o-table__cell--numeric">11</td>
+						<td class="o-table__cell--numeric">15</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">480</td>
+						<td><a href="http://10clouds.com/" data-trackable="link" target="_blank">10Clouds</a></td>
+						<td><a href="https://www.ft.com/topics/places/Poland" data-trackable="link">Poland</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">333%</td>
+						<td class="o-table__cell--numeric">63%</td>
+						<td class="o-table__cell--numeric">3,036</td>
+						<td class="o-table__cell--numeric">57</td>
+						<td class="o-table__cell--numeric">87</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">481</td>
+						<td><a href="http://etuyo.com/" data-trackable="link" target="_blank">Sibaltron Experiences</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Ecommerce" data-trackable="link">Ecommerce</a>
+						</td>
+						<td class="o-table__cell--numeric">333%</td>
+						<td class="o-table__cell--numeric">63%</td>
+						<td class="o-table__cell--numeric">7,855</td>
+						<td class="o-table__cell--numeric">4</td>
+						<td class="o-table__cell--numeric">8</td>
+						<td>2009</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">482</td>
+						<td><a href="http://yele.fr/" data-trackable="link" target="_blank">Yélé Consulting</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/energy" data-trackable="link">Energy</a></td>
+						<td class="o-table__cell--numeric">333%</td>
+						<td class="o-table__cell--numeric">62.90%</td>
+						<td class="o-table__cell--numeric">4,449</td>
+						<td class="o-table__cell--numeric">28</td>
+						<td class="o-table__cell--numeric">40</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">483</td>
+						<td><a href="http://trentcs.com/" data-trackable="link" target="_blank">Trent Construction
+								Services</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/companies/construction" data-trackable="link">Construction</a>
+						</td>
+						<td class="o-table__cell--numeric">333%</td>
+						<td class="o-table__cell--numeric">62.90%</td>
+						<td class="o-table__cell--numeric">6,160</td>
+						<td class="o-table__cell--numeric">13</td>
+						<td class="o-table__cell--numeric">18</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">484</td>
+						<td><a href="http://eleven-labs.com/" data-trackable="link" target="_blank">Eleven Labs</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">332%</td>
+						<td class="o-table__cell--numeric">62.90%</td>
+						<td class="o-table__cell--numeric">5,612</td>
+						<td class="o-table__cell--numeric">46</td>
+						<td class="o-table__cell--numeric">62</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">485</td>
+						<td><a href="http://ulabox.com/" data-trackable="link" target="_blank">Ulabox</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Ecommerce" data-trackable="link">Ecommerce</a>
+						</td>
+						<td class="o-table__cell--numeric">332%</td>
+						<td class="o-table__cell--numeric">62.80%</td>
+						<td class="o-table__cell--numeric">7,783</td>
+						<td class="o-table__cell--numeric">32</td>
+						<td class="o-table__cell--numeric">53</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">486</td>
+						<td><a href="http://richter-lt.de/" data-trackable="link" target="_blank">Richter lighting
+								technologies</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">332%</td>
+						<td class="o-table__cell--numeric">62.80%</td>
+						<td class="o-table__cell--numeric">23,416</td>
+						<td class="o-table__cell--numeric">105</td>
+						<td class="o-table__cell--numeric">150</td>
+						<td>1994</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">487</td>
+						<td><a href="http://tremend.com/" data-trackable="link" target="_blank">Tremend</a></td>
+						<td><a href="https://www.ft.com/topics/places/Romania" data-trackable="link">Romania</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">331%</td>
+						<td class="o-table__cell--numeric">62.80%</td>
+						<td class="o-table__cell--numeric">3,576</td>
+						<td class="o-table__cell--numeric">60</td>
+						<td class="o-table__cell--numeric">86</td>
+						<td>2005</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">488</td>
+						<td><a href="http://nanobit.co/" data-trackable="link" target="_blank">Nanobit</a></td>
+						<td><a href="https://www.ft.com/topics/places/Croatia" data-trackable="link">Croatia</a></td>
+						<td><a href="https://www.ft.com/stream/f9c6d3fe-5e16-479c-b762-bccdeeb349fe"
+								data-trackable="link">Games industry</a></td>
+						<td class="o-table__cell--numeric">331%</td>
+						<td class="o-table__cell--numeric">62.70%</td>
+						<td class="o-table__cell--numeric">7,449</td>
+						<td class="o-table__cell--numeric">41</td>
+						<td class="o-table__cell--numeric">67</td>
+						<td>2008</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">489</td>
+						<td><a href="http://itresellers.be/" data-trackable="link" target="_blank">IT Resellers
+								Group</a></td>
+						<td><a href="https://www.ft.com/topics/places/Belgium" data-trackable="link">Belgium</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Sales_&amp;_Marketing" data-trackable="link">Sales
+								&amp; Marketing</a></td>
+						<td class="o-table__cell--numeric">331%</td>
+						<td class="o-table__cell--numeric">62.70%</td>
+						<td class="o-table__cell--numeric">6,363</td>
+						<td class="o-table__cell--numeric">2</td>
+						<td class="o-table__cell--numeric">4</td>
+						<td>2008</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">490</td>
+						<td><a href="http://horizongroup.it/" data-trackable="link" target="_blank">Horizon Group</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Sales_&amp;_Marketing" data-trackable="link">Sales
+								&amp; Marketing</a></td>
+						<td class="o-table__cell--numeric">330%</td>
+						<td class="o-table__cell--numeric">62.60%</td>
+						<td class="o-table__cell--numeric">1,588</td>
+						<td class="o-table__cell--numeric">7</td>
+						<td class="o-table__cell--numeric">13</td>
+						<td>2008</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">491</td>
+						<td><a href="http://digital-legends.com/" data-trackable="link" target="_blank">Digital Legends
+								Entertainment</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/stream/f9c6d3fe-5e16-479c-b762-bccdeeb349fe"
+								data-trackable="link">Games industry</a></td>
+						<td class="o-table__cell--numeric">330%</td>
+						<td class="o-table__cell--numeric">62.60%</td>
+						<td class="o-table__cell--numeric">8,549</td>
+						<td class="o-table__cell--numeric">30</td>
+						<td class="o-table__cell--numeric">61</td>
+						<td>2001</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">492</td>
+						<td><a href="http://socianova.com/" data-trackable="link" target="_blank">SociaNOVA</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">329%</td>
+						<td class="o-table__cell--numeric">62.50%</td>
+						<td class="o-table__cell--numeric">1,675</td>
+						<td class="o-table__cell--numeric">13</td>
+						<td class="o-table__cell--numeric">19</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">493</td>
+						<td><a href="http://con-tex-gmbh.eu/" data-trackable="link" target="_blank">Con-Tex</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/transport" data-trackable="link">Transport</a></td>
+						<td class="o-table__cell--numeric">328%</td>
+						<td class="o-table__cell--numeric">62.40%</td>
+						<td class="o-table__cell--numeric">2,285</td>
+						<td class="o-table__cell--numeric">5</td>
+						<td class="o-table__cell--numeric">8</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">494</td>
+						<td><a href="http://expospeed.de/" data-trackable="link" target="_blank">Expo Speed*</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/transport" data-trackable="link">Transport</a></td>
+						<td class="o-table__cell--numeric">328%</td>
+						<td class="o-table__cell--numeric">62.40%</td>
+						<td class="o-table__cell--numeric">2,345</td>
+						<td class="o-table__cell--numeric">2</td>
+						<td class="o-table__cell--numeric">5</td>
+						<td>2013</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">495</td>
+						<td><a href="http://voxprogroup.com/" data-trackable="link" target="_blank">Voxpro**</a></td>
+						<td><a href="https://www.ft.com/topics/places/Ireland" data-trackable="link">Ireland</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">327%</td>
+						<td class="o-table__cell--numeric">62.20%</td>
+						<td class="o-table__cell--numeric">60,559</td>
+						<td class="o-table__cell--numeric">1,339</td>
+						<td class="o-table__cell--numeric">1,699</td>
+						<td>2004</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">496</td>
+						<td><a href="http://oxfordsummercourses.com/" data-trackable="link" target="_blank">Oxford
+								Summer Courses</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/stream/d320c9d7-1638-4388-b667-a5d63bd4bbc2"
+								data-trackable="link">Education</a></td>
+						<td class="o-table__cell--numeric">326%</td>
+						<td class="o-table__cell--numeric">62.10%</td>
+						<td class="o-table__cell--numeric">2,776</td>
+						<td class="o-table__cell--numeric">3</td>
+						<td class="o-table__cell--numeric">4</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">497</td>
+						<td><a href="http://finepower.com/" data-trackable="link" target="_blank">Finepower</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/energy" data-trackable="link">Energy</a></td>
+						<td class="o-table__cell--numeric">325%</td>
+						<td class="o-table__cell--numeric">62%</td>
+						<td class="o-table__cell--numeric">21,814</td>
+						<td class="o-table__cell--numeric">6</td>
+						<td class="o-table__cell--numeric">44</td>
+						<td>2001</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">498</td>
+						<td><a href="http://blickfangmedia.de/" data-trackable="link" target="_blank">Blickfang
+								Media</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Advertising" data-trackable="link">Advertising</a>
+						</td>
+						<td class="o-table__cell--numeric">325%</td>
+						<td class="o-table__cell--numeric">62%</td>
+						<td class="o-table__cell--numeric">2,023</td>
+						<td class="o-table__cell--numeric">15</td>
+						<td class="o-table__cell--numeric">17</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">499</td>
+						<td><a href="http://satenco.com/" data-trackable="link" target="_blank">Satenco</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/retail" data-trackable="link">Retail</a></td>
+						<td class="o-table__cell--numeric">325%</td>
+						<td class="o-table__cell--numeric">62%</td>
+						<td class="o-table__cell--numeric">2,731</td>
+						<td class="o-table__cell--numeric">0</td>
+						<td class="o-table__cell--numeric">2</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">500</td>
+						<td><a href="http://lithos-minerals.at/" data-trackable="link" target="_blank">Lithos Industrial
+								Minerals</a></td>
+						<td><a href="https://www.ft.com/topics/places/Austria" data-trackable="link">Austria</a></td>
+						<td><a href="https://www.ft.com/companies/industrial-goods" data-trackable="link">Industrial
+								Goods</a></td>
+						<td class="o-table__cell--numeric">325%</td>
+						<td class="o-table__cell--numeric">61.90%</td>
+						<td class="o-table__cell--numeric">3,523</td>
+						<td class="o-table__cell--numeric">5</td>
+						<td class="o-table__cell--numeric">12</td>
+						<td>2005</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">501</td>
+						<td><a href="http://maximummedia.ie/" data-trackable="link" target="_blank">Maximum Media</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Ireland" data-trackable="link">Ireland</a></td>
+						<td><a href="https://www.ft.com/companies/media" data-trackable="link">Media</a></td>
+						<td class="o-table__cell--numeric">324%</td>
+						<td class="o-table__cell--numeric">61.90%</td>
+						<td class="o-table__cell--numeric">6,210</td>
+						<td class="o-table__cell--numeric">44</td>
+						<td class="o-table__cell--numeric">70</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">502</td>
+						<td><a href="http://techbau.it/" data-trackable="link" target="_blank">Techbau</a></td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/companies/construction" data-trackable="link">Construction</a>
+						</td>
+						<td class="o-table__cell--numeric">324%</td>
+						<td class="o-table__cell--numeric">61.80%</td>
+						<td class="o-table__cell--numeric">139,608</td>
+						<td class="o-table__cell--numeric">-25</td>
+						<td class="o-table__cell--numeric">54</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">503</td>
+						<td><a href="http://daveiga.es/" data-trackable="link" target="_blank">Lugar Da Veiga</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/companies/food-beverage" data-trackable="link">Food &amp;
+								Beverage</a></td>
+						<td class="o-table__cell--numeric">324%</td>
+						<td class="o-table__cell--numeric">61.80%</td>
+						<td class="o-table__cell--numeric">2,343</td>
+						<td class="o-table__cell--numeric">13</td>
+						<td class="o-table__cell--numeric">25</td>
+						<td>2005</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">504</td>
+						<td><a href="http://bodeboca.com/" data-trackable="link" target="_blank">Bodeboca</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Ecommerce" data-trackable="link">Ecommerce</a>
+						</td>
+						<td class="o-table__cell--numeric">323%</td>
+						<td class="o-table__cell--numeric">61.80%</td>
+						<td class="o-table__cell--numeric">5,654</td>
+						<td class="o-table__cell--numeric">15</td>
+						<td class="o-table__cell--numeric">23</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">505</td>
+						<td><a href="http://fres.fr/" data-trackable="link" target="_blank">FRES architectes</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/construction" data-trackable="link">Construction</a>
+						</td>
+						<td class="o-table__cell--numeric">323%</td>
+						<td class="o-table__cell--numeric">61.80%</td>
+						<td class="o-table__cell--numeric">2,979</td>
+						<td class="o-table__cell--numeric">15</td>
+						<td class="o-table__cell--numeric">20</td>
+						<td>2004</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">506</td>
+						<td><a href="http://trippus.com/" data-trackable="link" target="_blank">Trippus</a></td>
+						<td><a href="https://www.ft.com/topics/places/Sweden" data-trackable="link">Sweden</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">322%</td>
+						<td class="o-table__cell--numeric">61.60%</td>
+						<td class="o-table__cell--numeric">7,645</td>
+						<td class="o-table__cell--numeric">7</td>
+						<td class="o-table__cell--numeric">20</td>
+						<td>2000</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">507</td>
+						<td><a href="http://bt3.at/" data-trackable="link" target="_blank">BT3 AIH</a></td>
+						<td><a href="https://www.ft.com/topics/places/Austria" data-trackable="link">Austria</a></td>
+						<td><a href="https://www.ft.com/companies/construction" data-trackable="link">Construction</a>
+						</td>
+						<td class="o-table__cell--numeric">321%</td>
+						<td class="o-table__cell--numeric">61.40%</td>
+						<td class="o-table__cell--numeric">10,817</td>
+						<td class="o-table__cell--numeric">19</td>
+						<td class="o-table__cell--numeric">22</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">508</td>
+						<td><a href="http://infinum.co/" data-trackable="link" target="_blank">Infinum d.o.o.</a></td>
+						<td><a href="https://www.ft.com/topics/places/Croatia" data-trackable="link">Croatia</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">319%</td>
+						<td class="o-table__cell--numeric">61.30%</td>
+						<td class="o-table__cell--numeric">2,692</td>
+						<td class="o-table__cell--numeric">55</td>
+						<td class="o-table__cell--numeric">78</td>
+						<td>2005</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">509</td>
+						<td><a href="http://fashcom.nl/" data-trackable="link" target="_blank">FashCom</a></td>
+						<td><a href="https://www.ft.com/topics/places/Netherlands" data-trackable="link">The
+								Netherlands</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Ecommerce" data-trackable="link">Ecommerce</a>
+						</td>
+						<td class="o-table__cell--numeric">319%</td>
+						<td class="o-table__cell--numeric">61.20%</td>
+						<td class="o-table__cell--numeric">3,013</td>
+						<td class="o-table__cell--numeric">15</td>
+						<td class="o-table__cell--numeric">24</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">510</td>
+						<td><a href="http://ibotech.eu/" data-trackable="link" target="_blank">IBOTECH</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/transport" data-trackable="link">Transport</a></td>
+						<td class="o-table__cell--numeric">319%</td>
+						<td class="o-table__cell--numeric">61.20%</td>
+						<td class="o-table__cell--numeric">12,000</td>
+						<td class="o-table__cell--numeric">34</td>
+						<td class="o-table__cell--numeric">59</td>
+						<td>2007</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">511</td>
+						<td><a href="http://autobatterienbilliger.de/" data-trackable="link"
+								target="_blank">batterium</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/retail" data-trackable="link">Retail</a></td>
+						<td class="o-table__cell--numeric">318%</td>
+						<td class="o-table__cell--numeric">61.10%</td>
+						<td class="o-table__cell--numeric">10,160</td>
+						<td class="o-table__cell--numeric">18</td>
+						<td class="o-table__cell--numeric">27</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">512</td>
+						<td><a href="http://labalcheta.com/" data-trackable="link" target="_blank">La Balcheta
+								Reciclaje</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Waste_management_&amp;_recycling"
+								data-trackable="link">Waste management &amp; recycling</a></td>
+						<td class="o-table__cell--numeric">318%</td>
+						<td class="o-table__cell--numeric">61%</td>
+						<td class="o-table__cell--numeric">4,707</td>
+						<td class="o-table__cell--numeric">16</td>
+						<td class="o-table__cell--numeric">18</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">513</td>
+						<td><a href="http://logando.de/" data-trackable="link" target="_blank">Logando Display &amp;
+								Media Solutions</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">315%</td>
+						<td class="o-table__cell--numeric">60.80%</td>
+						<td class="o-table__cell--numeric">5,400</td>
+						<td class="o-table__cell--numeric">34</td>
+						<td class="o-table__cell--numeric">40</td>
+						<td>2008</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">514</td>
+						<td><a href="http://bebeboutik.com/" data-trackable="link" target="_blank">Bébé Boutik</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/retail" data-trackable="link">Retail</a></td>
+						<td class="o-table__cell--numeric">315%</td>
+						<td class="o-table__cell--numeric">60.70%</td>
+						<td class="o-table__cell--numeric">8,891</td>
+						<td class="o-table__cell--numeric">21</td>
+						<td class="o-table__cell--numeric">30</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">515</td>
+						<td><a href="http://be-cloud.fr/" data-trackable="link" target="_blank">Be-Cloud</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">315%</td>
+						<td class="o-table__cell--numeric">60.70%</td>
+						<td class="o-table__cell--numeric">1,929</td>
+						<td class="o-table__cell--numeric">21</td>
+						<td class="o-table__cell--numeric">25</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">516</td>
+						<td><a href="http://in-rete.net/" data-trackable="link" target="_blank">Inrete</a></td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">311%</td>
+						<td class="o-table__cell--numeric">60.20%</td>
+						<td class="o-table__cell--numeric">2,532</td>
+						<td class="o-table__cell--numeric">4</td>
+						<td class="o-table__cell--numeric">13</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">517</td>
+						<td><a href="http://the-white-label.com/" data-trackable="link" target="_blank">wleC white label
+								eCommerce</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Ecommerce" data-trackable="link">Ecommerce</a>
+						</td>
+						<td class="o-table__cell--numeric">311%</td>
+						<td class="o-table__cell--numeric">60.20%</td>
+						<td class="o-table__cell--numeric">2,683</td>
+						<td class="o-table__cell--numeric">22</td>
+						<td class="o-table__cell--numeric">32</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">518</td>
+						<td><a href="http://gizmo-retail.nl/" data-trackable="link" target="_blank">Gizmo Retail</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Netherlands" data-trackable="link">The
+								Netherlands</a></td>
+						<td><a href="https://www.ft.com/companies/personal-goods" data-trackable="link">Personal &amp;
+								Household Goods</a></td>
+						<td class="o-table__cell--numeric">311%</td>
+						<td class="o-table__cell--numeric">60.10%</td>
+						<td class="o-table__cell--numeric">2,893</td>
+						<td class="o-table__cell--numeric">1</td>
+						<td class="o-table__cell--numeric">4</td>
+						<td>2008</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">519</td>
+						<td><a href="http://cross-cargo.eu/" data-trackable="link" target="_blank">Cross Cargo
+								Logistics</a></td>
+						<td><a href="https://www.ft.com/topics/places/Austria" data-trackable="link">Austria</a></td>
+						<td><a href="https://www.ft.com/companies/transport" data-trackable="link">Transport</a></td>
+						<td class="o-table__cell--numeric">308%</td>
+						<td class="o-table__cell--numeric">59.80%</td>
+						<td class="o-table__cell--numeric">8,905</td>
+						<td class="o-table__cell--numeric">7</td>
+						<td class="o-table__cell--numeric">12</td>
+						<td>2002</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">520</td>
+						<td><a href="http://endclothing.com/" data-trackable="link" target="_blank">Ashworth and
+								Parker</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Ecommerce" data-trackable="link">Ecommerce</a>
+						</td>
+						<td class="o-table__cell--numeric">308%</td>
+						<td class="o-table__cell--numeric">59.80%</td>
+						<td class="o-table__cell--numeric">82,774</td>
+						<td class="o-table__cell--numeric">204</td>
+						<td class="o-table__cell--numeric">274</td>
+						<td>2009</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">521</td>
+						<td><a href="http://espritdigital.com/" data-trackable="link" target="_blank">Esprit Digital</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">307%</td>
+						<td class="o-table__cell--numeric">59.70%</td>
+						<td class="o-table__cell--numeric">9,328</td>
+						<td class="o-table__cell--numeric">5</td>
+						<td class="o-table__cell--numeric">11</td>
+						<td>2002</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">522</td>
+						<td><a href="http://contis.com/" data-trackable="link" target="_blank">Contis Group</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/fintech" data-trackable="link">Fintech</a></td>
+						<td class="o-table__cell--numeric">306%</td>
+						<td class="o-table__cell--numeric">59.60%</td>
+						<td class="o-table__cell--numeric">8,513</td>
+						<td class="o-table__cell--numeric">31</td>
+						<td class="o-table__cell--numeric">86</td>
+						<td>2008</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">523</td>
+						<td><a href="http://yellowstar.com/" data-trackable="link" target="_blank">Yellow Star
+								Solutions</a></td>
+						<td><a href="https://www.ft.com/topics/places/Netherlands" data-trackable="link">The
+								Netherlands</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">306%</td>
+						<td class="o-table__cell--numeric">59.50%</td>
+						<td class="o-table__cell--numeric">4,873</td>
+						<td class="o-table__cell--numeric">44</td>
+						<td class="o-table__cell--numeric">58</td>
+						<td>2009</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">524</td>
+						<td><a href="http://bakkenbaeck.com/" data-trackable="link" target="_blank">Bakken &amp;
+								Baeck</a></td>
+						<td><a href="https://www.ft.com/topics/places/Norway" data-trackable="link">Norway</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">306%</td>
+						<td class="o-table__cell--numeric">59.50%</td>
+						<td class="o-table__cell--numeric">3,648</td>
+						<td class="o-table__cell--numeric">30</td>
+						<td class="o-table__cell--numeric">40</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">525</td>
+						<td><a href="http://bibars.fr/" data-trackable="link" target="_blank">Bibars</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/food-beverage" data-trackable="link">Food &amp;
+								Beverage</a></td>
+						<td class="o-table__cell--numeric">306%</td>
+						<td class="o-table__cell--numeric">59.50%</td>
+						<td class="o-table__cell--numeric">13,054</td>
+						<td class="o-table__cell--numeric">3</td>
+						<td class="o-table__cell--numeric">7</td>
+						<td>2008</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">526</td>
+						<td><a href="http://https/www.gigglingsquid.com/" data-trackable="link" target="_blank">Giggling
+								Restaurants</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/restaurants" data-trackable="link">Restaurants</a></td>
+						<td class="o-table__cell--numeric">305%</td>
+						<td class="o-table__cell--numeric">59.40%</td>
+						<td class="o-table__cell--numeric">21,887</td>
+						<td class="o-table__cell--numeric">184</td>
+						<td class="o-table__cell--numeric">294</td>
+						<td>2002</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">527</td>
+						<td><a href="http://piazzacopernico.it/" data-trackable="link" target="_blank">Piazza
+								Copernico</a></td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/stream/d320c9d7-1638-4388-b667-a5d63bd4bbc2"
+								data-trackable="link">Education</a></td>
+						<td class="o-table__cell--numeric">304%</td>
+						<td class="o-table__cell--numeric">59.30%</td>
+						<td class="o-table__cell--numeric">1,982</td>
+						<td class="o-table__cell--numeric">9</td>
+						<td class="o-table__cell--numeric">11</td>
+						<td>2006</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">528</td>
+						<td><a href="http://adtraction.com/" data-trackable="link" target="_blank">Adtraction
+								Marketing</a></td>
+						<td><a href="https://www.ft.com/topics/places/Sweden" data-trackable="link">Sweden</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Advertising" data-trackable="link">Advertising</a>
+						</td>
+						<td class="o-table__cell--numeric">304%</td>
+						<td class="o-table__cell--numeric">59.30%</td>
+						<td class="o-table__cell--numeric">20,418</td>
+						<td class="o-table__cell--numeric">5</td>
+						<td class="o-table__cell--numeric">12</td>
+						<td>2007</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">529</td>
+						<td><a href="http://super-heraut.fr/" data-trackable="link" target="_blank">Super Heraut</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/media" data-trackable="link">Media</a></td>
+						<td class="o-table__cell--numeric">304%</td>
+						<td class="o-table__cell--numeric">59.30%</td>
+						<td class="o-table__cell--numeric">1,876</td>
+						<td class="o-table__cell--numeric">0</td>
+						<td class="o-table__cell--numeric">1</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">530</td>
+						<td><a href="http://cmore-automotive.de/" data-trackable="link" target="_blank">CMORE
+								Automotive</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/automobiles" data-trackable="link">Automobiles</a>
+						</td>
+						<td class="o-table__cell--numeric">304%</td>
+						<td class="o-table__cell--numeric">59.30%</td>
+						<td class="o-table__cell--numeric">9,736</td>
+						<td class="o-table__cell--numeric">92</td>
+						<td class="o-table__cell--numeric">130</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">531</td>
+						<td><a href="http://selectra.info/" data-trackable="link" target="_blank">Selectra</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/retail" data-trackable="link">Retail</a></td>
+						<td class="o-table__cell--numeric">304%</td>
+						<td class="o-table__cell--numeric">59.30%</td>
+						<td class="o-table__cell--numeric">9,516</td>
+						<td class="o-table__cell--numeric">363</td>
+						<td class="o-table__cell--numeric">400</td>
+						<td>2007</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">532</td>
+						<td><a href="http://arkphire.com/" data-trackable="link" target="_blank">Arkphire</a></td>
+						<td><a href="https://www.ft.com/topics/places/Ireland" data-trackable="link">Ireland</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">304%</td>
+						<td class="o-table__cell--numeric">59.20%</td>
+						<td class="o-table__cell--numeric">52,632</td>
+						<td class="o-table__cell--numeric">22</td>
+						<td class="o-table__cell--numeric">48</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">533</td>
+						<td><a href="http://geniem.fi/" data-trackable="link" target="_blank">Geniem</a></td>
+						<td><a href="https://www.ft.com/topics/places/Finland" data-trackable="link">Finland</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">303%</td>
+						<td class="o-table__cell--numeric">59.20%</td>
+						<td class="o-table__cell--numeric">2,224</td>
+						<td class="o-table__cell--numeric">26</td>
+						<td class="o-table__cell--numeric">35</td>
+						<td>2000</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">534</td>
+						<td><a href="http://blue-consult.de/" data-trackable="link" target="_blank">Blue Consult</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">303%</td>
+						<td class="o-table__cell--numeric">59.20%</td>
+						<td class="o-table__cell--numeric">27,194</td>
+						<td class="o-table__cell--numeric">32</td>
+						<td class="o-table__cell--numeric">56</td>
+						<td>2004</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">535</td>
+						<td><a href="http://prepaidfinancialservices.com/" data-trackable="link" target="_blank">Prepaid
+								Financial Services</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/companies/financial-services" data-trackable="link">Financial
+								Services</a></td>
+						<td class="o-table__cell--numeric">302%</td>
+						<td class="o-table__cell--numeric">59%</td>
+						<td class="o-table__cell--numeric">51,231</td>
+						<td class="o-table__cell--numeric">-5</td>
+						<td class="o-table__cell--numeric">42</td>
+						<td>2007</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">536</td>
+						<td><a href="http://global-support.org/" data-trackable="link" target="_blank">Global Support
+								Services (GSS)</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">302%</td>
+						<td class="o-table__cell--numeric">59%</td>
+						<td class="o-table__cell--numeric">4,285</td>
+						<td class="o-table__cell--numeric">96</td>
+						<td class="o-table__cell--numeric">110</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">537</td>
+						<td><a href="http://azzure-it.com/" data-trackable="link" target="_blank">Azzure IT</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">302%</td>
+						<td class="o-table__cell--numeric">59%</td>
+						<td class="o-table__cell--numeric">4,971</td>
+						<td class="o-table__cell--numeric">23</td>
+						<td class="o-table__cell--numeric">47</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">538</td>
+						<td><a href="http://tecodata.fr/" data-trackable="link" target="_blank">Tecodata</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">301%</td>
+						<td class="o-table__cell--numeric">58.90%</td>
+						<td class="o-table__cell--numeric">2,043</td>
+						<td class="o-table__cell--numeric">n/a</td>
+						<td class="o-table__cell--numeric">n/a</td>
+						<td>2003</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">539</td>
+						<td><a href="http://tropicai.com/" data-trackable="link" target="_blank">Coconut Business</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/food-beverage" data-trackable="link">Food &amp;
+								Beverage</a></td>
+						<td class="o-table__cell--numeric">301%</td>
+						<td class="o-table__cell--numeric">58.90%</td>
+						<td class="o-table__cell--numeric">7,196</td>
+						<td class="o-table__cell--numeric">12</td>
+						<td class="o-table__cell--numeric">28</td>
+						<td>1994</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">540</td>
+						<td><a href="http://grupoceos.com/" data-trackable="link" target="_blank">CEOS Gestión y
+								Servicios</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/companies/construction" data-trackable="link">Construction</a>
+						</td>
+						<td class="o-table__cell--numeric">301%</td>
+						<td class="o-table__cell--numeric">58.90%</td>
+						<td class="o-table__cell--numeric">5,612</td>
+						<td class="o-table__cell--numeric">20</td>
+						<td class="o-table__cell--numeric">47</td>
+						<td>2007</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">541</td>
+						<td><a href="http://emedec.com/" data-trackable="link" target="_blank">Emedec</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/companies/industrial-goods" data-trackable="link">Industrial
+								Goods</a></td>
+						<td class="o-table__cell--numeric">301%</td>
+						<td class="o-table__cell--numeric">58.90%</td>
+						<td class="o-table__cell--numeric">9,098</td>
+						<td class="o-table__cell--numeric">15</td>
+						<td class="o-table__cell--numeric">30</td>
+						<td>1998</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">542</td>
+						<td><a href="http://javista.com/" data-trackable="link" target="_blank">Javista</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">301%</td>
+						<td class="o-table__cell--numeric">58.80%</td>
+						<td class="o-table__cell--numeric">4,264</td>
+						<td class="o-table__cell--numeric">26</td>
+						<td class="o-table__cell--numeric">36</td>
+						<td>2005</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">543</td>
+						<td><a href="http://lemonde-apres.com/" data-trackable="link" target="_blank">Le Monde Après /
+								Openwork</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">300%</td>
+						<td class="o-table__cell--numeric">58.80%</td>
+						<td class="o-table__cell--numeric">12,380</td>
+						<td class="o-table__cell--numeric">89</td>
+						<td class="o-table__cell--numeric">107</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">544</td>
+						<td><a href="http://croud.com/" data-trackable="link" target="_blank">Croud Inc</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Sales_&amp;_Marketing" data-trackable="link">Sales
+								&amp; Marketing</a></td>
+						<td class="o-table__cell--numeric">300%</td>
+						<td class="o-table__cell--numeric">58.80%</td>
+						<td class="o-table__cell--numeric">9,171</td>
+						<td class="o-table__cell--numeric">56</td>
+						<td class="o-table__cell--numeric">83</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">545</td>
+						<td><a href="http://rincondelpan.es/" data-trackable="link" target="_blank">Frost Canarias</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/companies/food-beverage" data-trackable="link">Food &amp;
+								Beverage</a></td>
+						<td class="o-table__cell--numeric">299%</td>
+						<td class="o-table__cell--numeric">58.70%</td>
+						<td class="o-table__cell--numeric">3,361</td>
+						<td class="o-table__cell--numeric">60</td>
+						<td class="o-table__cell--numeric">74</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">546</td>
+						<td><a href="http://payjob.fr/" data-trackable="link" target="_blank">Pay Job Interim</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">299%</td>
+						<td class="o-table__cell--numeric">58.60%</td>
+						<td class="o-table__cell--numeric">2,944</td>
+						<td class="o-table__cell--numeric">4</td>
+						<td class="o-table__cell--numeric">8</td>
+						<td>2007</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">547</td>
+						<td><a href="http://ecommercefulfilment.com/" data-trackable="link" target="_blank">James and
+								James Fulfilment</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Ecommerce" data-trackable="link">Ecommerce</a>
+						</td>
+						<td class="o-table__cell--numeric">298%</td>
+						<td class="o-table__cell--numeric">58.50%</td>
+						<td class="o-table__cell--numeric">6,331</td>
+						<td class="o-table__cell--numeric">40</td>
+						<td class="o-table__cell--numeric">60</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">548</td>
+						<td><a href="http://synesthesia.it/" data-trackable="link" target="_blank">Synesthesia</a></td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">298%</td>
+						<td class="o-table__cell--numeric">58.50%</td>
+						<td class="o-table__cell--numeric">2,139</td>
+						<td class="o-table__cell--numeric">15</td>
+						<td class="o-table__cell--numeric">23</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">549</td>
+						<td><a href="http://predica.pl/" data-trackable="link" target="_blank">Predica Sp. z o.o.</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Poland" data-trackable="link">Poland</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">297%</td>
+						<td class="o-table__cell--numeric">58.40%</td>
+						<td class="o-table__cell--numeric">3,932</td>
+						<td class="o-table__cell--numeric">34</td>
+						<td class="o-table__cell--numeric">50</td>
+						<td>2009</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">550</td>
+						<td><a href="http://santafixie-group.com/" data-trackable="link" target="_blank">Santafixie
+								Group</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Ecommerce" data-trackable="link">Ecommerce</a>
+						</td>
+						<td class="o-table__cell--numeric">295%</td>
+						<td class="o-table__cell--numeric">58.10%</td>
+						<td class="o-table__cell--numeric">2,037</td>
+						<td class="o-table__cell--numeric">9</td>
+						<td class="o-table__cell--numeric">13</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">551</td>
+						<td><a href="http://blinklearning.com/" data-trackable="link" target="_blank">Blinklearning</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/stream/d320c9d7-1638-4388-b667-a5d63bd4bbc2"
+								data-trackable="link">Education</a></td>
+						<td class="o-table__cell--numeric">295%</td>
+						<td class="o-table__cell--numeric">58.10%</td>
+						<td class="o-table__cell--numeric">2,485</td>
+						<td class="o-table__cell--numeric">49</td>
+						<td class="o-table__cell--numeric">58</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">552</td>
+						<td><a href="http://wellandpower.net/" data-trackable="link" target="_blank">Welland Power</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/companies/energy" data-trackable="link">Energy</a></td>
+						<td class="o-table__cell--numeric">294%</td>
+						<td class="o-table__cell--numeric">58%</td>
+						<td class="o-table__cell--numeric">23,896</td>
+						<td class="o-table__cell--numeric">12</td>
+						<td class="o-table__cell--numeric">24</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">553</td>
+						<td><a href="http://morgenland.bio/" data-trackable="link" target="_blank">EgeSun</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/food-beverage" data-trackable="link">Food &amp;
+								Beverage</a></td>
+						<td class="o-table__cell--numeric">293%</td>
+						<td class="o-table__cell--numeric">57.80%</td>
+						<td class="o-table__cell--numeric">40,100</td>
+						<td class="o-table__cell--numeric">67</td>
+						<td class="o-table__cell--numeric">74</td>
+						<td>2000</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">554</td>
+						<td><a href="http://es-rm.eu/" data-trackable="link" target="_blank">Europäische Schule
+								RheinMain</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/stream/d320c9d7-1638-4388-b667-a5d63bd4bbc2"
+								data-trackable="link">Education</a></td>
+						<td class="o-table__cell--numeric">293%</td>
+						<td class="o-table__cell--numeric">57.80%</td>
+						<td class="o-table__cell--numeric">12,766</td>
+						<td class="o-table__cell--numeric">82</td>
+						<td class="o-table__cell--numeric">139</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">555</td>
+						<td><a href="http://ampacimon.com/" data-trackable="link" target="_blank">Ampacimon</a></td>
+						<td><a href="https://www.ft.com/topics/places/Belgium" data-trackable="link">Belgium</a></td>
+						<td><a href="https://www.ft.com/companies/industrial-goods" data-trackable="link">Industrial
+								Goods</a></td>
+						<td class="o-table__cell--numeric">293%</td>
+						<td class="o-table__cell--numeric">57.80%</td>
+						<td class="o-table__cell--numeric">2,258</td>
+						<td class="o-table__cell--numeric">7</td>
+						<td class="o-table__cell--numeric">12</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">556</td>
+						<td><a href="http://spotify.com/" data-trackable="link" target="_blank">Spotify</a></td>
+						<td><a href="https://www.ft.com/topics/places/Sweden" data-trackable="link">Sweden</a></td>
+						<td><a href="https://www.ft.com/companies/media" data-trackable="link">Media</a></td>
+						<td class="o-table__cell--numeric">293%</td>
+						<td class="o-table__cell--numeric">57.80%</td>
+						<td class="o-table__cell--numeric">2,933,504</td>
+						<td class="o-table__cell--numeric">1,204</td>
+						<td class="o-table__cell--numeric">2,162</td>
+						<td>2006</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">557</td>
+						<td><a href="http://oroarte.it/" data-trackable="link" target="_blank">Oro arte</a></td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Precious_metals" data-trackable="link">Precious
+								metals</a></td>
+						<td class="o-table__cell--numeric">293%</td>
+						<td class="o-table__cell--numeric">57.70%</td>
+						<td class="o-table__cell--numeric">17,097</td>
+						<td class="o-table__cell--numeric">3</td>
+						<td class="o-table__cell--numeric">5</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">558</td>
+						<td><a href="http://http/www.ethic-technology.com/ethic/" data-trackable="link"
+								target="_blank">Ethic Technology</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">292%</td>
+						<td class="o-table__cell--numeric">57.70%</td>
+						<td class="o-table__cell--numeric">1,800</td>
+						<td class="o-table__cell--numeric">0</td>
+						<td class="o-table__cell--numeric">4</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">559</td>
+						<td><a href="http://mentormaterassi.it/" data-trackable="link"
+								target="_blank">MentorMaterassi</a></td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Ecommerce" data-trackable="link">Ecommerce</a>
+						</td>
+						<td class="o-table__cell--numeric">292%</td>
+						<td class="o-table__cell--numeric">57.70%</td>
+						<td class="o-table__cell--numeric">3,769</td>
+						<td class="o-table__cell--numeric">2</td>
+						<td class="o-table__cell--numeric">5</td>
+						<td>2009</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">560</td>
+						<td><a href="http://nacatur2.com/" data-trackable="link" target="_blank">Nacatur 2</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/companies/retail" data-trackable="link">Retail</a></td>
+						<td class="o-table__cell--numeric">292%</td>
+						<td class="o-table__cell--numeric">57.60%</td>
+						<td class="o-table__cell--numeric">5,637</td>
+						<td class="o-table__cell--numeric">5</td>
+						<td class="o-table__cell--numeric">10</td>
+						<td>2008</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">561</td>
+						<td><a href="http://decoracionvintage.es/" data-trackable="link" target="_blank">Decoración
+								Vintage</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/companies/retail" data-trackable="link">Retail</a></td>
+						<td class="o-table__cell--numeric">291%</td>
+						<td class="o-table__cell--numeric">57.60%</td>
+						<td class="o-table__cell--numeric">2,404</td>
+						<td class="o-table__cell--numeric">5</td>
+						<td class="o-table__cell--numeric">16</td>
+						<td>2002</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">562</td>
+						<td><a href="http://humanas.de/" data-trackable="link" target="_blank">HUMANAS</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/energy" data-trackable="link">Energy</a></td>
+						<td class="o-table__cell--numeric">290%</td>
+						<td class="o-table__cell--numeric">57.40%</td>
+						<td class="o-table__cell--numeric">8,003</td>
+						<td class="o-table__cell--numeric">96</td>
+						<td class="o-table__cell--numeric">163</td>
+						<td>2006</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">563</td>
+						<td><a href="http://kerlink.com/" data-trackable="link" target="_blank">Kerlink</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/telecoms" data-trackable="link">Telecoms</a></td>
+						<td class="o-table__cell--numeric">290%</td>
+						<td class="o-table__cell--numeric">57.40%</td>
+						<td class="o-table__cell--numeric">14,117</td>
+						<td class="o-table__cell--numeric">41</td>
+						<td class="o-table__cell--numeric">78</td>
+						<td>2004</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">564</td>
+						<td><a href="http://justeatplc.com/" data-trackable="link" target="_blank">Just Eat</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">288%</td>
+						<td class="o-table__cell--numeric">57.20%</td>
+						<td class="o-table__cell--numeric">459,985</td>
+						<td class="o-table__cell--numeric">1,487</td>
+						<td class="o-table__cell--numeric">2,373</td>
+						<td>2009</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">565</td>
+						<td><a href="http://miquido.com/" data-trackable="link" target="_blank">Miquido Sp. z o.o.
+								Sp.k.</a></td>
+						<td><a href="https://www.ft.com/topics/places/Poland" data-trackable="link">Poland</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">288%</td>
+						<td class="o-table__cell--numeric">57.20%</td>
+						<td class="o-table__cell--numeric">2,260</td>
+						<td class="o-table__cell--numeric">56</td>
+						<td class="o-table__cell--numeric">72</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">566</td>
+						<td><a href="http://featurespace.com/" data-trackable="link" target="_blank">Featurespace</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/fintech" data-trackable="link">Fintech</a></td>
+						<td class="o-table__cell--numeric">288%</td>
+						<td class="o-table__cell--numeric">57.10%</td>
+						<td class="o-table__cell--numeric">1,501</td>
+						<td class="o-table__cell--numeric">49</td>
+						<td class="o-table__cell--numeric">62</td>
+						<td>2005</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">567</td>
+						<td><a href="http://venturaglobal.com/" data-trackable="link" target="_blank">Ventura Global</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/companies/financial-services" data-trackable="link">Financial
+								Services</a></td>
+						<td class="o-table__cell--numeric">286%</td>
+						<td class="o-table__cell--numeric">56.80%</td>
+						<td class="o-table__cell--numeric">5,125</td>
+						<td class="o-table__cell--numeric">1</td>
+						<td class="o-table__cell--numeric">3</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">568</td>
+						<td><a href="http://the-media-image.com/" data-trackable="link" target="_blank">The Media
+								Image</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Advertising" data-trackable="link">Advertising</a>
+						</td>
+						<td class="o-table__cell--numeric">285%</td>
+						<td class="o-table__cell--numeric">56.80%</td>
+						<td class="o-table__cell--numeric">22,090</td>
+						<td class="o-table__cell--numeric">16</td>
+						<td class="o-table__cell--numeric">28</td>
+						<td>2009</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">569</td>
+						<td><a href="http://castoretpollux.com/" data-trackable="link" target="_blank">Castor &amp;
+								Pollux</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/media" data-trackable="link">Media</a></td>
+						<td class="o-table__cell--numeric">284%</td>
+						<td class="o-table__cell--numeric">56.50%</td>
+						<td class="o-table__cell--numeric">3,331</td>
+						<td class="o-table__cell--numeric">27</td>
+						<td class="o-table__cell--numeric">35</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">570</td>
+						<td><a href="http://ruiter-baustrassen.de/" data-trackable="link" target="_blank">Mobile
+								Baustrassen Ruiter</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/construction" data-trackable="link">Construction</a>
+						</td>
+						<td class="o-table__cell--numeric">283%</td>
+						<td class="o-table__cell--numeric">56.50%</td>
+						<td class="o-table__cell--numeric">4,600</td>
+						<td class="o-table__cell--numeric">2</td>
+						<td class="o-table__cell--numeric">5</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">571</td>
+						<td><a href="http://kronosgroup.be/" data-trackable="link" target="_blank">Kronos Group SPRL</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Belgium" data-trackable="link">Belgium</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Management_Consulting"
+								data-trackable="link">Management Consulting</a></td>
+						<td class="o-table__cell--numeric">282%</td>
+						<td class="o-table__cell--numeric">56.40%</td>
+						<td class="o-table__cell--numeric">5,401</td>
+						<td class="o-table__cell--numeric">28</td>
+						<td class="o-table__cell--numeric">40</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">572</td>
+						<td><a href="http://paseo-marketing.de/" data-trackable="link" target="_blank">Paseo
+								Marketing</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Advertising" data-trackable="link">Advertising</a>
+						</td>
+						<td class="o-table__cell--numeric">282%</td>
+						<td class="o-table__cell--numeric">56.30%</td>
+						<td class="o-table__cell--numeric">6,038</td>
+						<td class="o-table__cell--numeric">1</td>
+						<td class="o-table__cell--numeric">10</td>
+						<td>2005</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">573</td>
+						<td><a href="http://kesmer.at/" data-trackable="link" target="_blank">Kesmer</a></td>
+						<td><a href="https://www.ft.com/topics/places/Austria" data-trackable="link">Austria</a></td>
+						<td><a href="https://www.ft.com/companies/construction" data-trackable="link">Construction</a>
+						</td>
+						<td class="o-table__cell--numeric">282%</td>
+						<td class="o-table__cell--numeric">56.30%</td>
+						<td class="o-table__cell--numeric">2,861</td>
+						<td class="o-table__cell--numeric">32</td>
+						<td class="o-table__cell--numeric">44</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">574</td>
+						<td><a href="http://workstreampeople.com/" data-trackable="link"
+								target="_blank">Workstreampeople (Anywhere365)</a></td>
+						<td><a href="https://www.ft.com/topics/places/Netherlands" data-trackable="link">The
+								Netherlands</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">281%</td>
+						<td class="o-table__cell--numeric">56.20%</td>
+						<td class="o-table__cell--numeric">7,247</td>
+						<td class="o-table__cell--numeric">14</td>
+						<td class="o-table__cell--numeric">32</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">575</td>
+						<td><a href="http://midstreamlighting.com/" data-trackable="link" target="_blank">Midstream
+								Energy*</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/companies/industrial-goods" data-trackable="link">Industrial
+								Goods</a></td>
+						<td class="o-table__cell--numeric">280%</td>
+						<td class="o-table__cell--numeric">56%</td>
+						<td class="o-table__cell--numeric">1,784</td>
+						<td class="o-table__cell--numeric">1</td>
+						<td class="o-table__cell--numeric">4</td>
+						<td>2009</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">576</td>
+						<td><a href="http://cubro.net/" data-trackable="link" target="_blank">Cubro Acronet</a></td>
+						<td><a href="https://www.ft.com/topics/places/Austria" data-trackable="link">Austria</a></td>
+						<td><a href="https://www.ft.com/companies/telecoms" data-trackable="link">Telecoms</a></td>
+						<td class="o-table__cell--numeric">277%</td>
+						<td class="o-table__cell--numeric">55.60%</td>
+						<td class="o-table__cell--numeric">4,684</td>
+						<td class="o-table__cell--numeric">6</td>
+						<td class="o-table__cell--numeric">14</td>
+						<td>2003</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">577</td>
+						<td><a href="http://newsales24.de/" data-trackable="link" target="_blank">new Sales</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/energy" data-trackable="link">Energy</a></td>
+						<td class="o-table__cell--numeric">277%</td>
+						<td class="o-table__cell--numeric">55.60%</td>
+						<td class="o-table__cell--numeric">5,881</td>
+						<td class="o-table__cell--numeric">26</td>
+						<td class="o-table__cell--numeric">37</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">578</td>
+						<td><a href="http://heol-com.fr/" data-trackable="link" target="_blank">Heol
+								Commercialisation</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/industrial-goods" data-trackable="link">Industrial
+								Goods</a></td>
+						<td class="o-table__cell--numeric">277%</td>
+						<td class="o-table__cell--numeric">55.60%</td>
+						<td class="o-table__cell--numeric">3,520</td>
+						<td class="o-table__cell--numeric">2</td>
+						<td class="o-table__cell--numeric">5</td>
+						<td>2008</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">579</td>
+						<td><a href="http://sipwise.com/" data-trackable="link" target="_blank">Sipwise</a></td>
+						<td><a href="https://www.ft.com/topics/places/Austria" data-trackable="link">Austria</a></td>
+						<td><a href="https://www.ft.com/companies/telecoms" data-trackable="link">Telecoms</a></td>
+						<td class="o-table__cell--numeric">275%</td>
+						<td class="o-table__cell--numeric">55.30%</td>
+						<td class="o-table__cell--numeric">4,033</td>
+						<td class="o-table__cell--numeric">16</td>
+						<td class="o-table__cell--numeric">35</td>
+						<td>2008</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">580</td>
+						<td><a href="http://gigas.com/" data-trackable="link" target="_blank">Gigas</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">275%</td>
+						<td class="o-table__cell--numeric">55.30%</td>
+						<td class="o-table__cell--numeric">4,834</td>
+						<td class="o-table__cell--numeric">17</td>
+						<td class="o-table__cell--numeric">69</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">581</td>
+						<td><a href="http://energineo-led.com/" data-trackable="link" target="_blank">Energineo</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">275%</td>
+						<td class="o-table__cell--numeric">55.30%</td>
+						<td class="o-table__cell--numeric">2,922</td>
+						<td class="o-table__cell--numeric">10</td>
+						<td class="o-table__cell--numeric">15</td>
+						<td>2009</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">582</td>
+						<td><a href="http://autoteile-werkzeuge.de/" data-trackable="link" target="_blank">PoTec
+								Vertriebs</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Ecommerce" data-trackable="link">Ecommerce</a>
+						</td>
+						<td class="o-table__cell--numeric">274%</td>
+						<td class="o-table__cell--numeric">55.30%</td>
+						<td class="o-table__cell--numeric">4,170</td>
+						<td class="o-table__cell--numeric">13</td>
+						<td class="o-table__cell--numeric">19</td>
+						<td>2009</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">583</td>
+						<td><a href="http://beck-schluesselfertig.de/" data-trackable="link" target="_blank">Beck Bau
+								Schlüsselfertig</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/construction" data-trackable="link">Construction</a>
+						</td>
+						<td class="o-table__cell--numeric">273%</td>
+						<td class="o-table__cell--numeric">55.10%</td>
+						<td class="o-table__cell--numeric">8,953</td>
+						<td class="o-table__cell--numeric">5</td>
+						<td class="o-table__cell--numeric">9</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">584</td>
+						<td><a href="http://leoshoes.it/" data-trackable="link" target="_blank">LEOshoes</a></td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/stream/f9f7535d-3b5c-47a7-bd15-3e10dceee597"
+								data-trackable="link">Fashion</a></td>
+						<td class="o-table__cell--numeric">273%</td>
+						<td class="o-table__cell--numeric">55%</td>
+						<td class="o-table__cell--numeric">59,743</td>
+						<td class="o-table__cell--numeric">161</td>
+						<td class="o-table__cell--numeric">301</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">585</td>
+						<td><a href="http://showcase-interiors.co.uk/" data-trackable="link" target="_blank">Showcase
+								Interiors</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_kingdom" data-trackable="link">United
+								kingdom</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Sales_&amp;_Marketing" data-trackable="link">Sales
+								&amp; Marketing</a></td>
+						<td class="o-table__cell--numeric">272%</td>
+						<td class="o-table__cell--numeric">55%</td>
+						<td class="o-table__cell--numeric">28,662</td>
+						<td class="o-table__cell--numeric">31</td>
+						<td class="o-table__cell--numeric">44</td>
+						<td>2007</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">586</td>
+						<td><a href="http://falcongreen.co.uk/" data-trackable="link" target="_blank">Falcon Green
+								Personnel</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">272%</td>
+						<td class="o-table__cell--numeric">55%</td>
+						<td class="o-table__cell--numeric">27,177</td>
+						<td class="o-table__cell--numeric">11</td>
+						<td class="o-table__cell--numeric">21</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">587</td>
+						<td><a href="http://rfs.co.uk/" data-trackable="link" target="_blank">Regulatory Finance
+								Solutions</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Management_Consulting"
+								data-trackable="link">Management Consulting</a></td>
+						<td class="o-table__cell--numeric">272%</td>
+						<td class="o-table__cell--numeric">55%</td>
+						<td class="o-table__cell--numeric">54,863</td>
+						<td class="o-table__cell--numeric">34</td>
+						<td class="o-table__cell--numeric">52</td>
+						<td>2005</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">588</td>
+						<td><a href="http://managed.co.uk/" data-trackable="link" target="_blank">Managed 24/7</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">270%</td>
+						<td class="o-table__cell--numeric">54.70%</td>
+						<td class="o-table__cell--numeric">8,559</td>
+						<td class="o-table__cell--numeric">32</td>
+						<td class="o-table__cell--numeric">48</td>
+						<td>2009</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">589</td>
+						<td><a href="http://relojitos.com/" data-trackable="link" target="_blank">Relojitos
+								Euromediterranea</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Ecommerce" data-trackable="link">Ecommerce</a>
+						</td>
+						<td class="o-table__cell--numeric">270%</td>
+						<td class="o-table__cell--numeric">54.70%</td>
+						<td class="o-table__cell--numeric">4,127</td>
+						<td class="o-table__cell--numeric">2</td>
+						<td class="o-table__cell--numeric">5</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">590</td>
+						<td><a href="http://uptoo.fr/" data-trackable="link" target="_blank">Uptoo</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">270%</td>
+						<td class="o-table__cell--numeric">54.70%</td>
+						<td class="o-table__cell--numeric">9,064</td>
+						<td class="o-table__cell--numeric">39</td>
+						<td class="o-table__cell--numeric">65</td>
+						<td>2005</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">591</td>
+						<td><a href="http://adhexpharma.com/" data-trackable="link" target="_blank">AdhexPharma</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/pharmaceuticals"
+								data-trackable="link">Pharmaceuticals</a></td>
+						<td class="o-table__cell--numeric">270%</td>
+						<td class="o-table__cell--numeric">54.60%</td>
+						<td class="o-table__cell--numeric">9,886</td>
+						<td class="o-table__cell--numeric">22</td>
+						<td class="o-table__cell--numeric">44</td>
+						<td>2007</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">592</td>
+						<td><a href="http://k3capitalgroupplc.com/" data-trackable="link" target="_blank">K3 Capital
+								Group</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/companies/financial-services" data-trackable="link">Financial
+								Services</a></td>
+						<td class="o-table__cell--numeric">269%</td>
+						<td class="o-table__cell--numeric">54.50%</td>
+						<td class="o-table__cell--numeric">12,685</td>
+						<td class="o-table__cell--numeric">27</td>
+						<td class="o-table__cell--numeric">73</td>
+						<td>2007</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">593</td>
+						<td><a href="http://taunus-hausbau.de/" data-trackable="link" target="_blank">Taunus Hausbau</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/construction" data-trackable="link">Construction</a>
+						</td>
+						<td class="o-table__cell--numeric">268%</td>
+						<td class="o-table__cell--numeric">54.40%</td>
+						<td class="o-table__cell--numeric">5,761</td>
+						<td class="o-table__cell--numeric">4</td>
+						<td class="o-table__cell--numeric">9</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">594</td>
+						<td><a href="http://sitimsrl.com/" data-trackable="link" target="_blank">S.I.T.I.M.</a></td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/companies/industrial-goods" data-trackable="link">Industrial
+								Goods</a></td>
+						<td class="o-table__cell--numeric">268%</td>
+						<td class="o-table__cell--numeric">54.30%</td>
+						<td class="o-table__cell--numeric">5,006</td>
+						<td class="o-table__cell--numeric">10</td>
+						<td class="o-table__cell--numeric">25</td>
+						<td>2008</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">595</td>
+						<td><a href="http://oxeltis.com/" data-trackable="link" target="_blank">Oxeltis</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/chemicals" data-trackable="link">Chemicals</a></td>
+						<td class="o-table__cell--numeric">266%</td>
+						<td class="o-table__cell--numeric">54.20%</td>
+						<td class="o-table__cell--numeric">1,536</td>
+						<td class="o-table__cell--numeric">7</td>
+						<td class="o-table__cell--numeric">15</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">596</td>
+						<td><a href="http://slagkryssaren.com/" data-trackable="link" target="_blank">Slagkryssaren
+								Aktiebolag</a></td>
+						<td><a href="https://www.ft.com/topics/places/Sweden" data-trackable="link">Sweden</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">266%</td>
+						<td class="o-table__cell--numeric">54.10%</td>
+						<td class="o-table__cell--numeric">3,057</td>
+						<td class="o-table__cell--numeric">12</td>
+						<td class="o-table__cell--numeric">23</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">597</td>
+						<td><a href="http://hr2day.com/" data-trackable="link" target="_blank">eMerus (HR2day)</a></td>
+						<td><a href="https://www.ft.com/topics/places/Netherlands" data-trackable="link">The
+								Netherlands</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">266%</td>
+						<td class="o-table__cell--numeric">54.10%</td>
+						<td class="o-table__cell--numeric">2,485</td>
+						<td class="o-table__cell--numeric">14</td>
+						<td class="o-table__cell--numeric">25</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">598</td>
+						<td><a href="http://tresmes.com/" data-trackable="link" target="_blank">Tresmes Eco Activa</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/stream/d320c9d7-1638-4388-b667-a5d63bd4bbc2"
+								data-trackable="link">Education</a></td>
+						<td class="o-table__cell--numeric">266%</td>
+						<td class="o-table__cell--numeric">54.10%</td>
+						<td class="o-table__cell--numeric">2,477</td>
+						<td class="o-table__cell--numeric">117</td>
+						<td class="o-table__cell--numeric">209</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">599</td>
+						<td><a href="http://lanatur.de/" data-trackable="link" target="_blank">laNatur</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/food-beverage" data-trackable="link">Food &amp;
+								Beverage</a></td>
+						<td class="o-table__cell--numeric">266%</td>
+						<td class="o-table__cell--numeric">54.10%</td>
+						<td class="o-table__cell--numeric">3,636</td>
+						<td class="o-table__cell--numeric">2</td>
+						<td class="o-table__cell--numeric">4</td>
+						<td>1994</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">600</td>
+						<td><a href="http://x4group.co.uk/" data-trackable="link" target="_blank">X4 Group</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">265%</td>
+						<td class="o-table__cell--numeric">54%</td>
+						<td class="o-table__cell--numeric">23,421</td>
+						<td class="o-table__cell--numeric">51</td>
+						<td class="o-table__cell--numeric">71</td>
+						<td>2008</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">601</td>
+						<td><a href="http://biogroupe.com/" data-trackable="link" target="_blank">Biogroupe</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Agricultural_Commodities"
+								data-trackable="link">Agricultural commodities</a></td>
+						<td class="o-table__cell--numeric">265%</td>
+						<td class="o-table__cell--numeric">53.90%</td>
+						<td class="o-table__cell--numeric">3,276</td>
+						<td class="o-table__cell--numeric">20</td>
+						<td class="o-table__cell--numeric">26</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">602</td>
+						<td><a href="http://adservio.fr/" data-trackable="link" target="_blank">Adservio</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">264%</td>
+						<td class="o-table__cell--numeric">53.80%</td>
+						<td class="o-table__cell--numeric">5,032</td>
+						<td class="o-table__cell--numeric">79</td>
+						<td class="o-table__cell--numeric">98</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">603</td>
+						<td><a href="http://prontoservice.de/" data-trackable="link" target="_blank">Pronto Service</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/food-beverage" data-trackable="link">Food &amp;
+								Beverage</a></td>
+						<td class="o-table__cell--numeric">263%</td>
+						<td class="o-table__cell--numeric">53.70%</td>
+						<td class="o-table__cell--numeric">12,700</td>
+						<td class="o-table__cell--numeric">3</td>
+						<td class="o-table__cell--numeric">4</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">604</td>
+						<td>Loro Fruit Lonigro Group</td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Agricultural_Commodities"
+								data-trackable="link">Agricultural commodities</a></td>
+						<td class="o-table__cell--numeric">262%</td>
+						<td class="o-table__cell--numeric">53.60%</td>
+						<td class="o-table__cell--numeric">2,026</td>
+						<td class="o-table__cell--numeric">80</td>
+						<td class="o-table__cell--numeric">110</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">605</td>
+						<td><a href="http://axsol.fr/" data-trackable="link" target="_blank">AXSOL</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/retail" data-trackable="link">Retail</a></td>
+						<td class="o-table__cell--numeric">262%</td>
+						<td class="o-table__cell--numeric">53.60%</td>
+						<td class="o-table__cell--numeric">1,755</td>
+						<td class="o-table__cell--numeric">7</td>
+						<td class="o-table__cell--numeric">8</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">606</td>
+						<td><a href="http://m2dot.com/" data-trackable="link" target="_blank">M2.</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">262%</td>
+						<td class="o-table__cell--numeric">53.50%</td>
+						<td class="o-table__cell--numeric">2,499</td>
+						<td class="o-table__cell--numeric">11</td>
+						<td class="o-table__cell--numeric">12</td>
+						<td>2009</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">607</td>
+						<td><a href="http://visiconsult.com/" data-trackable="link" target="_blank">VisiConsult</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/industrial-goods" data-trackable="link">Industrial
+								Goods</a></td>
+						<td class="o-table__cell--numeric">262%</td>
+						<td class="o-table__cell--numeric">53.50%</td>
+						<td class="o-table__cell--numeric">12,632</td>
+						<td class="o-table__cell--numeric">33</td>
+						<td class="o-table__cell--numeric">53</td>
+						<td>1996</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">608</td>
+						<td><a href="http://g5e.com/" data-trackable="link" target="_blank">G5 Entertainment</a></td>
+						<td><a href="https://www.ft.com/topics/places/Sweden" data-trackable="link">Sweden</a></td>
+						<td><a href="https://www.ft.com/stream/f9c6d3fe-5e16-479c-b762-bccdeeb349fe"
+								data-trackable="link">Games industry</a></td>
+						<td class="o-table__cell--numeric">262%</td>
+						<td class="o-table__cell--numeric">53.50%</td>
+						<td class="o-table__cell--numeric">54,651</td>
+						<td class="o-table__cell--numeric">160</td>
+						<td class="o-table__cell--numeric">299</td>
+						<td>2001</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">609</td>
+						<td><a href="http://nexteria.it/" data-trackable="link" target="_blank">Nexteria</a></td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">262%</td>
+						<td class="o-table__cell--numeric">53.50%</td>
+						<td class="o-table__cell--numeric">6,378</td>
+						<td class="o-table__cell--numeric">160</td>
+						<td class="o-table__cell--numeric">193</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">610</td>
+						<td><a href="http://device-insight.com/" data-trackable="link" target="_blank">Device
+								Insight</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">261%</td>
+						<td class="o-table__cell--numeric">53.50%</td>
+						<td class="o-table__cell--numeric">7,508</td>
+						<td class="o-table__cell--numeric">28</td>
+						<td class="o-table__cell--numeric">50</td>
+						<td>2003</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">611</td>
+						<td><a href="http://picturepeople.de/" data-trackable="link" target="_blank">PicturePeople</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Advertising" data-trackable="link">Advertising</a>
+						</td>
+						<td class="o-table__cell--numeric">261%</td>
+						<td class="o-table__cell--numeric">53.50%</td>
+						<td class="o-table__cell--numeric">10,224</td>
+						<td class="o-table__cell--numeric">220</td>
+						<td class="o-table__cell--numeric">300</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">612</td>
+						<td><a href="http://laboart.com/" data-trackable="link" target="_blank">labo.art</a></td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/stream/f9f7535d-3b5c-47a7-bd15-3e10dceee597"
+								data-trackable="link">Fashion</a></td>
+						<td class="o-table__cell--numeric">261%</td>
+						<td class="o-table__cell--numeric">53.40%</td>
+						<td class="o-table__cell--numeric">1,622</td>
+						<td class="o-table__cell--numeric">4</td>
+						<td class="o-table__cell--numeric">6</td>
+						<td>2009</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">613</td>
+						<td><a href="http://uwe-nickut.de/" data-trackable="link" target="_blank">Uwe Nickut</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">259%</td>
+						<td class="o-table__cell--numeric">53.20%</td>
+						<td class="o-table__cell--numeric">4,437</td>
+						<td class="o-table__cell--numeric">56</td>
+						<td class="o-table__cell--numeric">75</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">614</td>
+						<td><a href="http://thirdbridge.com/" data-trackable="link" target="_blank">Third Bridge
+								Group</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/companies/financial-services" data-trackable="link">Financial
+								Services</a></td>
+						<td class="o-table__cell--numeric">259%</td>
+						<td class="o-table__cell--numeric">53.10%</td>
+						<td class="o-table__cell--numeric">60,861</td>
+						<td class="o-table__cell--numeric">294</td>
+						<td class="o-table__cell--numeric">449</td>
+						<td>2007</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">615</td>
+						<td><a href="http://sternzeit.de/" data-trackable="link" target="_blank">Sternzeit Media</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Advertising" data-trackable="link">Advertising</a>
+						</td>
+						<td class="o-table__cell--numeric">259%</td>
+						<td class="o-table__cell--numeric">53.10%</td>
+						<td class="o-table__cell--numeric">3,431</td>
+						<td class="o-table__cell--numeric">5</td>
+						<td class="o-table__cell--numeric">10</td>
+						<td>2009</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">616</td>
+						<td><a href="http://aitenet.com/" data-trackable="link" target="_blank">Componosollertia</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/companies/industrial-goods" data-trackable="link">Industrial
+								Goods</a></td>
+						<td class="o-table__cell--numeric">257%</td>
+						<td class="o-table__cell--numeric">52.90%</td>
+						<td class="o-table__cell--numeric">3,103</td>
+						<td class="o-table__cell--numeric">6</td>
+						<td class="o-table__cell--numeric">14</td>
+						<td>1997</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">617</td>
+						<td><a href="http://fmeuropa.de/" data-trackable="link" target="_blank">FME Frachtmanagement
+								Europa</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/transport" data-trackable="link">Transport</a></td>
+						<td class="o-table__cell--numeric">257%</td>
+						<td class="o-table__cell--numeric">52.90%</td>
+						<td class="o-table__cell--numeric">12,500</td>
+						<td class="o-table__cell--numeric">24</td>
+						<td class="o-table__cell--numeric">30</td>
+						<td>2009</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">618</td>
+						<td><a href="http://alpha-net.at/" data-trackable="link" target="_blank">alphanet</a></td>
+						<td><a href="https://www.ft.com/topics/places/Austria" data-trackable="link">Austria</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">257%</td>
+						<td class="o-table__cell--numeric">52.80%</td>
+						<td class="o-table__cell--numeric">3,460</td>
+						<td class="o-table__cell--numeric">4</td>
+						<td class="o-table__cell--numeric">8</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">619</td>
+						<td><a href="http://conet24.com/" data-trackable="link" target="_blank">CO.NET</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">256%</td>
+						<td class="o-table__cell--numeric">52.70%</td>
+						<td class="o-table__cell--numeric">2,739</td>
+						<td class="o-table__cell--numeric">12</td>
+						<td class="o-table__cell--numeric">19</td>
+						<td>2001</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">620</td>
+						<td><a href="http://diamondlogistics.co.uk/" data-trackable="link" target="_blank">Diamond
+								Logistics</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/companies/transport" data-trackable="link">Transport</a></td>
+						<td class="o-table__cell--numeric">256%</td>
+						<td class="o-table__cell--numeric">52.70%</td>
+						<td class="o-table__cell--numeric">9,242</td>
+						<td class="o-table__cell--numeric">1</td>
+						<td class="o-table__cell--numeric">13</td>
+						<td>1992</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">621</td>
+						<td><a href="http://considerati.com/" data-trackable="link" target="_blank">Considerati</a></td>
+						<td><a href="https://www.ft.com/topics/places/Netherlands" data-trackable="link">The
+								Netherlands</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Management_Consulting"
+								data-trackable="link">Management Consulting</a></td>
+						<td class="o-table__cell--numeric">255%</td>
+						<td class="o-table__cell--numeric">52.60%</td>
+						<td class="o-table__cell--numeric">2,084</td>
+						<td class="o-table__cell--numeric">8</td>
+						<td class="o-table__cell--numeric">11</td>
+						<td>2007</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">622</td>
+						<td><a href="http://gsstar-hotels.de/" data-trackable="link" target="_blank">GS Star</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/travel-leisure" data-trackable="link">Travel &amp;
+								Leisure</a></td>
+						<td class="o-table__cell--numeric">255%</td>
+						<td class="o-table__cell--numeric">52.60%</td>
+						<td class="o-table__cell--numeric">9,781</td>
+						<td class="o-table__cell--numeric">47</td>
+						<td class="o-table__cell--numeric">68</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">623</td>
+						<td><a href="http://airserver.com/" data-trackable="link" target="_blank">App Dynamic</a></td>
+						<td><a href="https://www.ft.com/topics/places/Iceland" data-trackable="link">Iceland</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">255%</td>
+						<td class="o-table__cell--numeric">52.60%</td>
+						<td class="o-table__cell--numeric">1,688</td>
+						<td class="o-table__cell--numeric">-1</td>
+						<td class="o-table__cell--numeric">7</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">624</td>
+						<td><a href="http://vey.koeln/" data-trackable="link" target="_blank">Vey Versorgungstechnik</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/construction" data-trackable="link">Construction</a>
+						</td>
+						<td class="o-table__cell--numeric">255%</td>
+						<td class="o-table__cell--numeric">52.60%</td>
+						<td class="o-table__cell--numeric">6,604</td>
+						<td class="o-table__cell--numeric">38</td>
+						<td class="o-table__cell--numeric">60</td>
+						<td>1955</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">625</td>
+						<td><a href="http://sendforhelp.com/" data-trackable="link" target="_blank">Send For Help</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">254%</td>
+						<td class="o-table__cell--numeric">52.50%</td>
+						<td class="o-table__cell--numeric">9,391</td>
+						<td class="o-table__cell--numeric">31</td>
+						<td class="o-table__cell--numeric">70</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">626</td>
+						<td><a href="http://alphasights.com/" data-trackable="link" target="_blank">AlphaSights</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">254%</td>
+						<td class="o-table__cell--numeric">52.40%</td>
+						<td class="o-table__cell--numeric">81,448</td>
+						<td class="o-table__cell--numeric">210</td>
+						<td class="o-table__cell--numeric">343</td>
+						<td>2008</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">627</td>
+						<td><a href="http://park-one.com/" data-trackable="link" target="_blank">Park One</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/transport" data-trackable="link">Transport</a></td>
+						<td class="o-table__cell--numeric">253%</td>
+						<td class="o-table__cell--numeric">52.30%</td>
+						<td class="o-table__cell--numeric">6,025</td>
+						<td class="o-table__cell--numeric">0</td>
+						<td class="o-table__cell--numeric">48</td>
+						<td>2005</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">628</td>
+						<td><a href="http://rcube-lyon.com/" data-trackable="link" target="_blank">Rcube</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/construction" data-trackable="link">Construction</a>
+						</td>
+						<td class="o-table__cell--numeric">253%</td>
+						<td class="o-table__cell--numeric">52.30%</td>
+						<td class="o-table__cell--numeric">1,552</td>
+						<td class="o-table__cell--numeric">6</td>
+						<td class="o-table__cell--numeric">9</td>
+						<td>2008</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">629</td>
+						<td><a href="http://hoeller-grosskuechen.com/" data-trackable="link" target="_blank">Josef
+								Höller</a></td>
+						<td><a href="https://www.ft.com/topics/places/Austria" data-trackable="link">Austria</a></td>
+						<td><a href="https://www.ft.com/restaurants" data-trackable="link">Restaurants</a></td>
+						<td class="o-table__cell--numeric">253%</td>
+						<td class="o-table__cell--numeric">52.30%</td>
+						<td class="o-table__cell--numeric">3,057</td>
+						<td class="o-table__cell--numeric">9</td>
+						<td class="o-table__cell--numeric">16</td>
+						<td>1998</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">630</td>
+						<td><a href="http://redegal.com/" data-trackable="link" target="_blank">Redegal</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Ecommerce" data-trackable="link">Ecommerce</a>
+						</td>
+						<td class="o-table__cell--numeric">253%</td>
+						<td class="o-table__cell--numeric">52.30%</td>
+						<td class="o-table__cell--numeric">2,522</td>
+						<td class="o-table__cell--numeric">42</td>
+						<td class="o-table__cell--numeric">56</td>
+						<td>2004</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">631</td>
+						<td><a href="http://x7-telecom.de/" data-trackable="link" target="_blank">X7-telecom</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/telecoms" data-trackable="link">Telecoms</a></td>
+						<td class="o-table__cell--numeric">252%</td>
+						<td class="o-table__cell--numeric">52.20%</td>
+						<td class="o-table__cell--numeric">23,600</td>
+						<td class="o-table__cell--numeric">12</td>
+						<td class="o-table__cell--numeric">26</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">632</td>
+						<td><a href="http://pruefservice-kfk.de/" data-trackable="link" target="_blank">KFK Konrad</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">252%</td>
+						<td class="o-table__cell--numeric">52.10%</td>
+						<td class="o-table__cell--numeric">5,494</td>
+						<td class="o-table__cell--numeric">45</td>
+						<td class="o-table__cell--numeric">61</td>
+						<td>1993</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">633</td>
+						<td><a href="http://obiz.fr/" data-trackable="link" target="_blank">Obiz concept</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Sales_&amp;_Marketing" data-trackable="link">Sales
+								&amp; Marketing</a></td>
+						<td class="o-table__cell--numeric">251%</td>
+						<td class="o-table__cell--numeric">52%</td>
+						<td class="o-table__cell--numeric">1,840</td>
+						<td class="o-table__cell--numeric">20</td>
+						<td class="o-table__cell--numeric">27</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">634</td>
+						<td><a href="http://elci.it/" data-trackable="link" target="_blank">Gruppo Elci</a></td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/companies/construction" data-trackable="link">Construction</a>
+						</td>
+						<td class="o-table__cell--numeric">250%</td>
+						<td class="o-table__cell--numeric">51.90%</td>
+						<td class="o-table__cell--numeric">9,401</td>
+						<td class="o-table__cell--numeric">15</td>
+						<td class="o-table__cell--numeric">68</td>
+						<td>1977</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">635</td>
+						<td><a href="http://affinity.pt/" data-trackable="link" target="_blank">Affinity S.A.</a></td>
+						<td><a href="https://www.ft.com/topics/places/Portugal" data-trackable="link">Portugal</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">250%</td>
+						<td class="o-table__cell--numeric">51.80%</td>
+						<td class="o-table__cell--numeric">4,998</td>
+						<td class="o-table__cell--numeric">100</td>
+						<td class="o-table__cell--numeric">143</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">636</td>
+						<td><a href="http://tablettechnologies.com/" data-trackable="link" target="_blank">Tablet
+								Technologies</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">249%</td>
+						<td class="o-table__cell--numeric">51.70%</td>
+						<td class="o-table__cell--numeric">2,272</td>
+						<td class="o-table__cell--numeric">9</td>
+						<td class="o-table__cell--numeric">10</td>
+						<td>2008</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">637</td>
+						<td><a href="http://transportesquinonero.com/" data-trackable="link" target="_blank">Quiñonero
+								Servicios Logísticos</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/companies/transport" data-trackable="link">Transport</a></td>
+						<td class="o-table__cell--numeric">249%</td>
+						<td class="o-table__cell--numeric">51.60%</td>
+						<td class="o-table__cell--numeric">3,088</td>
+						<td class="o-table__cell--numeric">5</td>
+						<td class="o-table__cell--numeric">11</td>
+						<td>2002</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">638</td>
+						<td><a href="http://thehyve.nl/" data-trackable="link" target="_blank">The Hyve</a></td>
+						<td><a href="https://www.ft.com/topics/places/Netherlands" data-trackable="link">The
+								Netherlands</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">248%</td>
+						<td class="o-table__cell--numeric">51.60%</td>
+						<td class="o-table__cell--numeric">3,030</td>
+						<td class="o-table__cell--numeric">31</td>
+						<td class="o-table__cell--numeric">40</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">639</td>
+						<td><a href="http://carmao.de/" data-trackable="link" target="_blank">CARMAO</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Management_Consulting"
+								data-trackable="link">Management Consulting</a></td>
+						<td class="o-table__cell--numeric">248%</td>
+						<td class="o-table__cell--numeric">51.50%</td>
+						<td class="o-table__cell--numeric">2,889</td>
+						<td class="o-table__cell--numeric">7</td>
+						<td class="o-table__cell--numeric">15</td>
+						<td>2003</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">640</td>
+						<td><a href="http://livecookintable.de/" data-trackable="link" target="_blank">MEC2</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/house-home/interiors" data-trackable="link">Interiors</a></td>
+						<td class="o-table__cell--numeric">248%</td>
+						<td class="o-table__cell--numeric">51.50%</td>
+						<td class="o-table__cell--numeric">4,153</td>
+						<td class="o-table__cell--numeric">2</td>
+						<td class="o-table__cell--numeric">5</td>
+						<td>2003</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">641</td>
+						<td><a href="http://plattenzuschnitt24.de/" data-trackable="link" target="_blank">Nordic
+								Panel</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/retail" data-trackable="link">Retail</a></td>
+						<td class="o-table__cell--numeric">247%</td>
+						<td class="o-table__cell--numeric">51.50%</td>
+						<td class="o-table__cell--numeric">4,319</td>
+						<td class="o-table__cell--numeric">17</td>
+						<td class="o-table__cell--numeric">24</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">642</td>
+						<td><a href="http://blackrockexpertservices.com/" data-trackable="link"
+								target="_blank">Blackrock Expert Services</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/companies/construction" data-trackable="link">Construction</a>
+						</td>
+						<td class="o-table__cell--numeric">247%</td>
+						<td class="o-table__cell--numeric">51.30%</td>
+						<td class="o-table__cell--numeric">32,467</td>
+						<td class="o-table__cell--numeric">49</td>
+						<td class="o-table__cell--numeric">75</td>
+						<td>2009</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">643</td>
+						<td><a href="http://snksystem.com/" data-trackable="link" target="_blank">SNK System</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">246%</td>
+						<td class="o-table__cell--numeric">51.30%</td>
+						<td class="o-table__cell--numeric">4,975</td>
+						<td class="o-table__cell--numeric">4</td>
+						<td class="o-table__cell--numeric">9</td>
+						<td>1997</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">644</td>
+						<td><a href="http://sarl-gogy.fr/" data-trackable="link" target="_blank">GOGY</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/construction" data-trackable="link">Construction</a>
+						</td>
+						<td class="o-table__cell--numeric">246%</td>
+						<td class="o-table__cell--numeric">51.30%</td>
+						<td class="o-table__cell--numeric">1,959</td>
+						<td class="o-table__cell--numeric">9</td>
+						<td class="o-table__cell--numeric">13</td>
+						<td>2004</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">645</td>
+						<td><a href="http://paramounthaulage.com/" data-trackable="link" target="_blank">Paramount
+								Haulage</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/companies/transport" data-trackable="link">Transport</a></td>
+						<td class="o-table__cell--numeric">246%</td>
+						<td class="o-table__cell--numeric">51.20%</td>
+						<td class="o-table__cell--numeric">1,715</td>
+						<td class="o-table__cell--numeric">7</td>
+						<td class="o-table__cell--numeric">13</td>
+						<td>2007</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">646</td>
+						<td><a href="http://saxowert.de/" data-trackable="link" target="_blank">Saxowert Immobilien</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/property" data-trackable="link">Property</a></td>
+						<td class="o-table__cell--numeric">245%</td>
+						<td class="o-table__cell--numeric">51.20%</td>
+						<td class="o-table__cell--numeric">4,101</td>
+						<td class="o-table__cell--numeric">3</td>
+						<td class="o-table__cell--numeric">5</td>
+						<td>2007</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">647</td>
+						<td><a href="http://arsatec.de/" data-trackable="link" target="_blank">ARSATEC</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/property" data-trackable="link">Property</a></td>
+						<td class="o-table__cell--numeric">245%</td>
+						<td class="o-table__cell--numeric">51.10%</td>
+						<td class="o-table__cell--numeric">26,936</td>
+						<td class="o-table__cell--numeric">5</td>
+						<td class="o-table__cell--numeric">22</td>
+						<td>1996</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">648</td>
+						<td><a href="http://bigtex.de/" data-trackable="link" target="_blank">Prima Retail (bigtex)</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/retail" data-trackable="link">Retail</a></td>
+						<td class="o-table__cell--numeric">245%</td>
+						<td class="o-table__cell--numeric">51.10%</td>
+						<td class="o-table__cell--numeric">4,068</td>
+						<td class="o-table__cell--numeric">17</td>
+						<td class="o-table__cell--numeric">30</td>
+						<td>2003</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">649</td>
+						<td><a href="http://waldbach-logistik.de/" data-trackable="link" target="_blank">Waldbach
+								Fulfillment Logistik</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/transport" data-trackable="link">Transport</a></td>
+						<td class="o-table__cell--numeric">244%</td>
+						<td class="o-table__cell--numeric">51%</td>
+						<td class="o-table__cell--numeric">6,200</td>
+						<td class="o-table__cell--numeric">60</td>
+						<td class="o-table__cell--numeric">140</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">650</td>
+						<td><a href="http://bericon.de/" data-trackable="link" target="_blank">BERICON</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/telecoms" data-trackable="link">Telecoms</a></td>
+						<td class="o-table__cell--numeric">244%</td>
+						<td class="o-table__cell--numeric">51%</td>
+						<td class="o-table__cell--numeric">2,412</td>
+						<td class="o-table__cell--numeric">5</td>
+						<td class="o-table__cell--numeric">10</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">651</td>
+						<td><a href="http://niese-caravan.de/" data-trackable="link" target="_blank">Niese Caravan</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/automobiles" data-trackable="link">Automobiles</a>
+						</td>
+						<td class="o-table__cell--numeric">244%</td>
+						<td class="o-table__cell--numeric">50.90%</td>
+						<td class="o-table__cell--numeric">5,965</td>
+						<td class="o-table__cell--numeric">4</td>
+						<td class="o-table__cell--numeric">10</td>
+						<td>2003</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">652</td>
+						<td><a href="http://joeandsephs.com/" data-trackable="link" target="_blank">Joe &amp; Seph's</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/companies/food-beverage" data-trackable="link">Food &amp;
+								Beverage</a></td>
+						<td class="o-table__cell--numeric">243%</td>
+						<td class="o-table__cell--numeric">50.90%</td>
+						<td class="o-table__cell--numeric">4,317</td>
+						<td class="o-table__cell--numeric">30</td>
+						<td class="o-table__cell--numeric">60</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">653</td>
+						<td><a href="http://onsella.com/" data-trackable="link" target="_blank">Onsella Global
+								Services</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/companies/transport" data-trackable="link">Transport</a></td>
+						<td class="o-table__cell--numeric">243%</td>
+						<td class="o-table__cell--numeric">50.80%</td>
+						<td class="o-table__cell--numeric">11,596</td>
+						<td class="o-table__cell--numeric">8</td>
+						<td class="o-table__cell--numeric">22</td>
+						<td>2005</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">654</td>
+						<td><a href="http://accesa.eu/" data-trackable="link" target="_blank">Accesa IT Consulting</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Romania" data-trackable="link">Romania</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">243%</td>
+						<td class="o-table__cell--numeric">50.80%</td>
+						<td class="o-table__cell--numeric">3,622</td>
+						<td class="o-table__cell--numeric">48</td>
+						<td class="o-table__cell--numeric">115</td>
+						<td>2004</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">655</td>
+						<td><a href="http://solarsupply.se/" data-trackable="link" target="_blank">Solar Supply
+								Sweden</a></td>
+						<td><a href="https://www.ft.com/topics/places/Sweden" data-trackable="link">Sweden</a></td>
+						<td><a href="https://www.ft.com/companies/energy" data-trackable="link">Energy</a></td>
+						<td class="o-table__cell--numeric">242%</td>
+						<td class="o-table__cell--numeric">50.70%</td>
+						<td class="o-table__cell--numeric">5,451</td>
+						<td class="o-table__cell--numeric">5</td>
+						<td class="o-table__cell--numeric">7</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">656</td>
+						<td><a href="http://manainelevacio.com/" data-trackable="link" target="_blank">Manain
+								Elevació</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/companies/industrial-goods" data-trackable="link">Industrial
+								Goods</a></td>
+						<td class="o-table__cell--numeric">241%</td>
+						<td class="o-table__cell--numeric">50.50%</td>
+						<td class="o-table__cell--numeric">5,889</td>
+						<td class="o-table__cell--numeric">12</td>
+						<td class="o-table__cell--numeric">19</td>
+						<td>2006</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">657</td>
+						<td><a href="http://padelnuestro.com/" data-trackable="link" target="_blank">Padel Nuestro</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/companies/retail" data-trackable="link">Retail</a></td>
+						<td class="o-table__cell--numeric">240%</td>
+						<td class="o-table__cell--numeric">50.40%</td>
+						<td class="o-table__cell--numeric">6,871</td>
+						<td class="o-table__cell--numeric">7</td>
+						<td class="o-table__cell--numeric">13</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">658</td>
+						<td><a href="http://argentus-re.de/" data-trackable="link" target="_blank">Argentus</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/energy" data-trackable="link">Energy</a></td>
+						<td class="o-table__cell--numeric">240%</td>
+						<td class="o-table__cell--numeric">50.40%</td>
+						<td class="o-table__cell--numeric">3,245</td>
+						<td class="o-table__cell--numeric">9</td>
+						<td class="o-table__cell--numeric">14</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">659</td>
+						<td><a href="http://resrei.com/" data-trackable="link" target="_blank">RES REI</a></td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/stream/f9f7535d-3b5c-47a7-bd15-3e10dceee597"
+								data-trackable="link">Fashion</a></td>
+						<td class="o-table__cell--numeric">240%</td>
+						<td class="o-table__cell--numeric">50.30%</td>
+						<td class="o-table__cell--numeric">1,537</td>
+						<td class="o-table__cell--numeric">3</td>
+						<td class="o-table__cell--numeric">4</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">660</td>
+						<td><a href="http://spideo.tv/" data-trackable="link" target="_blank">Spideo</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">240%</td>
+						<td class="o-table__cell--numeric">50.30%</td>
+						<td class="o-table__cell--numeric">1,514</td>
+						<td class="o-table__cell--numeric">6</td>
+						<td class="o-table__cell--numeric">20</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">661</td>
+						<td><a href="http://newvoicemedia.com/" data-trackable="link" target="_blank">NewVoiceMedia</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">239%</td>
+						<td class="o-table__cell--numeric">50.20%</td>
+						<td class="o-table__cell--numeric">38,971</td>
+						<td class="o-table__cell--numeric">191</td>
+						<td class="o-table__cell--numeric">341</td>
+						<td>2000</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">662</td>
+						<td><a href="http://shopware.de/" data-trackable="link" target="_blank">shopware</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Ecommerce" data-trackable="link">Ecommerce</a>
+						</td>
+						<td class="o-table__cell--numeric">238%</td>
+						<td class="o-table__cell--numeric">50.10%</td>
+						<td class="o-table__cell--numeric">11,500</td>
+						<td class="o-table__cell--numeric">60</td>
+						<td class="o-table__cell--numeric">110</td>
+						<td>2000</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">663</td>
+						<td><a href="http://teamto.com/" data-trackable="link" target="_blank">TeamTO</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/travel-leisure" data-trackable="link">Travel &amp;
+								Leisure</a></td>
+						<td class="o-table__cell--numeric">238%</td>
+						<td class="o-table__cell--numeric">50.10%</td>
+						<td class="o-table__cell--numeric">18,986</td>
+						<td class="o-table__cell--numeric">76</td>
+						<td class="o-table__cell--numeric">248</td>
+						<td>2005</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">664</td>
+						<td><a href="http://manolete-partners.com/" data-trackable="link" target="_blank">Manolete
+								Partners</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/companies/financial-services" data-trackable="link">Financial
+								Services</a></td>
+						<td class="o-table__cell--numeric">237%</td>
+						<td class="o-table__cell--numeric">50%</td>
+						<td class="o-table__cell--numeric">5,757</td>
+						<td class="o-table__cell--numeric">5</td>
+						<td class="o-table__cell--numeric">7</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">665</td>
+						<td><a href="http://optomed.com/" data-trackable="link" target="_blank">Optomed Oy</a></td>
+						<td><a href="https://www.ft.com/topics/places/Finland" data-trackable="link">Finland</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">237%</td>
+						<td class="o-table__cell--numeric">49.90%</td>
+						<td class="o-table__cell--numeric">6,400</td>
+						<td class="o-table__cell--numeric">53</td>
+						<td class="o-table__cell--numeric">73</td>
+						<td>2004</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">666</td>
+						<td><a href="http://vulog.com/" data-trackable="link" target="_blank">Vulog</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">236%</td>
+						<td class="o-table__cell--numeric">49.80%</td>
+						<td class="o-table__cell--numeric">3,200</td>
+						<td class="o-table__cell--numeric">38</td>
+						<td class="o-table__cell--numeric">46</td>
+						<td>2006</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">667</td>
+						<td><a href="http://capadresse.com/" data-trackable="link" target="_blank">Cap Adresse</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">236%</td>
+						<td class="o-table__cell--numeric">49.70%</td>
+						<td class="o-table__cell--numeric">2,292</td>
+						<td class="o-table__cell--numeric">8</td>
+						<td class="o-table__cell--numeric">18</td>
+						<td>2007</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">668</td>
+						<td><a href="http://calconut.com/" data-trackable="link" target="_blank">Calconut</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/companies/food-beverage" data-trackable="link">Food &amp;
+								Beverage</a></td>
+						<td class="o-table__cell--numeric">235%</td>
+						<td class="o-table__cell--numeric">49.60%</td>
+						<td class="o-table__cell--numeric">108,936</td>
+						<td class="o-table__cell--numeric">19</td>
+						<td class="o-table__cell--numeric">24</td>
+						<td>2005</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">669</td>
+						<td><a href="http://hga-cosmetics.com/" data-trackable="link" target="_blank">HGA Vertriebs
+								GmbH</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/beauty" data-trackable="link">Beauty</a></td>
+						<td class="o-table__cell--numeric">234%</td>
+						<td class="o-table__cell--numeric">49.60%</td>
+						<td class="o-table__cell--numeric">9,700</td>
+						<td class="o-table__cell--numeric">3</td>
+						<td class="o-table__cell--numeric">19</td>
+						<td>2004</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">670</td>
+						<td><a href="http://kmls.de/" data-trackable="link" target="_blank">KMLS Gruppe</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/energy" data-trackable="link">Energy</a></td>
+						<td class="o-table__cell--numeric">234%</td>
+						<td class="o-table__cell--numeric">49.50%</td>
+						<td class="o-table__cell--numeric">19,800</td>
+						<td class="o-table__cell--numeric">38</td>
+						<td class="o-table__cell--numeric">68</td>
+						<td>2009</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">671</td>
+						<td><a href="http://kalpa.it/" data-trackable="link" target="_blank">KALPA</a></td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">234%</td>
+						<td class="o-table__cell--numeric">49.50%</td>
+						<td class="o-table__cell--numeric">2,398</td>
+						<td class="o-table__cell--numeric">25</td>
+						<td class="o-table__cell--numeric">42</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">672</td>
+						<td><a href="http://belmoto.de/" data-trackable="link" target="_blank">belmoto</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/automobiles" data-trackable="link">Automobiles</a>
+						</td>
+						<td class="o-table__cell--numeric">234%</td>
+						<td class="o-table__cell--numeric">49.50%</td>
+						<td class="o-table__cell--numeric">5,169</td>
+						<td class="o-table__cell--numeric">8</td>
+						<td class="o-table__cell--numeric">16</td>
+						<td>2009</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">673</td>
+						<td><a href="http://berepublic.com/" data-trackable="link" target="_blank">BeRepublic
+								Networks</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Management_Consulting"
+								data-trackable="link">Management Consulting</a></td>
+						<td class="o-table__cell--numeric">234%</td>
+						<td class="o-table__cell--numeric">49.40%</td>
+						<td class="o-table__cell--numeric">5,242</td>
+						<td class="o-table__cell--numeric">35</td>
+						<td class="o-table__cell--numeric">64</td>
+						<td>2006</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">674</td>
+						<td><a href="http://m-a-k.at/" data-trackable="link" target="_blank">MAK*</a></td>
+						<td><a href="https://www.ft.com/topics/places/Austria" data-trackable="link">Austria</a></td>
+						<td><a href="https://www.ft.com/companies/industrial-goods" data-trackable="link">Industrial
+								Goods</a></td>
+						<td class="o-table__cell--numeric">234%</td>
+						<td class="o-table__cell--numeric">49.40%</td>
+						<td class="o-table__cell--numeric">1,684</td>
+						<td class="o-table__cell--numeric">19</td>
+						<td class="o-table__cell--numeric">25</td>
+						<td>2013</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">675</td>
+						<td><a href="http://clinipartners.eu/" data-trackable="link" target="_blank">Clinipartners</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/companies/transport" data-trackable="link">Transport</a></td>
+						<td class="o-table__cell--numeric">233%</td>
+						<td class="o-table__cell--numeric">49.40%</td>
+						<td class="o-table__cell--numeric">2,591</td>
+						<td class="o-table__cell--numeric">25</td>
+						<td class="o-table__cell--numeric">41</td>
+						<td>2008</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">676</td>
+						<td><a href="http://melvin-hamilton.de/" data-trackable="link" target="_blank">Melvin &amp;
+								Hamilton</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Ecommerce" data-trackable="link">Ecommerce</a>
+						</td>
+						<td class="o-table__cell--numeric">233%</td>
+						<td class="o-table__cell--numeric">49.40%</td>
+						<td class="o-table__cell--numeric">17,070</td>
+						<td class="o-table__cell--numeric">56</td>
+						<td class="o-table__cell--numeric">86</td>
+						<td>1983</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">677</td>
+						<td><a href="http://xucker.de/" data-trackable="link" target="_blank">Xucker</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Ecommerce" data-trackable="link">Ecommerce</a>
+						</td>
+						<td class="o-table__cell--numeric">232%</td>
+						<td class="o-table__cell--numeric">49.10%</td>
+						<td class="o-table__cell--numeric">8,395</td>
+						<td class="o-table__cell--numeric">18</td>
+						<td class="o-table__cell--numeric">27</td>
+						<td>2004</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">678</td>
+						<td><a href="http://friseur-einkauf.com/" data-trackable="link" target="_blank">Reinbold
+								Friseur</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/retail" data-trackable="link">Retail</a></td>
+						<td class="o-table__cell--numeric">231%</td>
+						<td class="o-table__cell--numeric">49%</td>
+						<td class="o-table__cell--numeric">10,895</td>
+						<td class="o-table__cell--numeric">-8</td>
+						<td class="o-table__cell--numeric">22</td>
+						<td>2004</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">679</td>
+						<td><a href="http://sempreanalytics.com/" data-trackable="link" target="_blank">Sempre
+								Analytics</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">231%</td>
+						<td class="o-table__cell--numeric">49%</td>
+						<td class="o-table__cell--numeric">5,838</td>
+						<td class="o-table__cell--numeric">10</td>
+						<td class="o-table__cell--numeric">18</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">680</td>
+						<td><a href="http://mavera.com/" data-trackable="link" target="_blank">Mavera</a></td>
+						<td><a href="https://www.ft.com/topics/places/Sweden" data-trackable="link">Sweden</a></td>
+						<td><a href="https://www.ft.com/companies/insurance" data-trackable="link">Insurance</a></td>
+						<td class="o-table__cell--numeric">231%</td>
+						<td class="o-table__cell--numeric">49%</td>
+						<td class="o-table__cell--numeric">5,278</td>
+						<td class="o-table__cell--numeric">8</td>
+						<td class="o-table__cell--numeric">12</td>
+						<td>2008</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">681</td>
+						<td><a href="http://pariani.org/" data-trackable="link" target="_blank">Pariani</a></td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/companies/food-beverage" data-trackable="link">Food &amp;
+								Beverage</a></td>
+						<td class="o-table__cell--numeric">230%</td>
+						<td class="o-table__cell--numeric">48.90%</td>
+						<td class="o-table__cell--numeric">2,232</td>
+						<td class="o-table__cell--numeric">3</td>
+						<td class="o-table__cell--numeric">9</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">682</td>
+						<td><a href="http://hrpepper.de/" data-trackable="link" target="_blank">Hrpepper</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Management_Consulting"
+								data-trackable="link">Management Consulting</a></td>
+						<td class="o-table__cell--numeric">230%</td>
+						<td class="o-table__cell--numeric">48.90%</td>
+						<td class="o-table__cell--numeric">3,017</td>
+						<td class="o-table__cell--numeric">18</td>
+						<td class="o-table__cell--numeric">26</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">683</td>
+						<td><a href="http://letomotel.de/" data-trackable="link" target="_blank">LetoMotel</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/travel-leisure" data-trackable="link">Travel &amp;
+								Leisure</a></td>
+						<td class="o-table__cell--numeric">229%</td>
+						<td class="o-table__cell--numeric">48.80%</td>
+						<td class="o-table__cell--numeric">7,102</td>
+						<td class="o-table__cell--numeric">25</td>
+						<td class="o-table__cell--numeric">50</td>
+						<td>2008</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">684</td>
+						<td><a href="http://wikifolio.com/" data-trackable="link" target="_blank">wikifolio Financial
+								Technologies</a></td>
+						<td><a href="https://www.ft.com/topics/places/Austria" data-trackable="link">Austria</a></td>
+						<td><a href="https://www.ft.com/companies/financial-services" data-trackable="link">Financial
+								Services</a></td>
+						<td class="o-table__cell--numeric">229%</td>
+						<td class="o-table__cell--numeric">48.70%</td>
+						<td class="o-table__cell--numeric">3,182</td>
+						<td class="o-table__cell--numeric">23</td>
+						<td class="o-table__cell--numeric">32</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">685</td>
+						<td><a href="http://germanpersonnel.de/" data-trackable="link" target="_blank">GermanPersonnel
+								e-search</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">228%</td>
+						<td class="o-table__cell--numeric">48.60%</td>
+						<td class="o-table__cell--numeric">7,353</td>
+						<td class="o-table__cell--numeric">35</td>
+						<td class="o-table__cell--numeric">52</td>
+						<td>2002</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">686</td>
+						<td><a href="http://begear.it/" data-trackable="link" target="_blank">BeGear</a></td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">228%</td>
+						<td class="o-table__cell--numeric">48.60%</td>
+						<td class="o-table__cell--numeric">1,866</td>
+						<td class="o-table__cell--numeric">42</td>
+						<td class="o-table__cell--numeric">63</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">687</td>
+						<td><a href="http://mindthevalue.com/" data-trackable="link" target="_blank">Mind the Value</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Management_Consulting"
+								data-trackable="link">Management Consulting</a></td>
+						<td class="o-table__cell--numeric">228%</td>
+						<td class="o-table__cell--numeric">48.60%</td>
+						<td class="o-table__cell--numeric">2,672</td>
+						<td class="o-table__cell--numeric">7</td>
+						<td class="o-table__cell--numeric">20</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">688</td>
+						<td><a href="http://welljob.fr/" data-trackable="link" target="_blank">Welljob</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">227%</td>
+						<td class="o-table__cell--numeric">48.50%</td>
+						<td class="o-table__cell--numeric">42,246</td>
+						<td class="o-table__cell--numeric">76</td>
+						<td class="o-table__cell--numeric">109</td>
+						<td>1997</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">689</td>
+						<td><a href="http://emf-verlag.de/" data-trackable="link" target="_blank">Edition Michael
+								Fischer</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Advertising" data-trackable="link">Advertising</a>
+						</td>
+						<td class="o-table__cell--numeric">227%</td>
+						<td class="o-table__cell--numeric">48.50%</td>
+						<td class="o-table__cell--numeric">6,344</td>
+						<td class="o-table__cell--numeric">16</td>
+						<td class="o-table__cell--numeric">22</td>
+						<td>1991</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">690</td>
+						<td><a href="http://j-huber.de/" data-trackable="link" target="_blank">J. Huber</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/automobiles" data-trackable="link">Automobiles</a>
+						</td>
+						<td class="o-table__cell--numeric">227%</td>
+						<td class="o-table__cell--numeric">48.40%</td>
+						<td class="o-table__cell--numeric">5,835</td>
+						<td class="o-table__cell--numeric">7</td>
+						<td class="o-table__cell--numeric">26</td>
+						<td>1986</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">691</td>
+						<td><a href="http://gsm-group.de/" data-trackable="link" target="_blank">GSM Training &amp;
+								Integration</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">227%</td>
+						<td class="o-table__cell--numeric">48.40%</td>
+						<td class="o-table__cell--numeric">28,185</td>
+						<td class="o-table__cell--numeric">400</td>
+						<td class="o-table__cell--numeric">600</td>
+						<td>2008</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">692</td>
+						<td><a href="http://privatefly.com/" data-trackable="link" target="_blank">PrivateFly</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/companies/travel-leisure" data-trackable="link">Travel &amp;
+								Leisure</a></td>
+						<td class="o-table__cell--numeric">227%</td>
+						<td class="o-table__cell--numeric">48.40%</td>
+						<td class="o-table__cell--numeric">26,106</td>
+						<td class="o-table__cell--numeric">13</td>
+						<td class="o-table__cell--numeric">31</td>
+						<td>2008</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">693</td>
+						<td><a href="http://ecometrica.com/" data-trackable="link" target="_blank">Ecometrica</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">226%</td>
+						<td class="o-table__cell--numeric">48.30%</td>
+						<td class="o-table__cell--numeric">3,120</td>
+						<td class="o-table__cell--numeric">3</td>
+						<td class="o-table__cell--numeric">26</td>
+						<td>2008</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">694</td>
+						<td><a href="http://enversum.de/" data-trackable="link" target="_blank">EnVersum</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/energy" data-trackable="link">Energy</a></td>
+						<td class="o-table__cell--numeric">226%</td>
+						<td class="o-table__cell--numeric">48.30%</td>
+						<td class="o-table__cell--numeric">175,678</td>
+						<td class="o-table__cell--numeric">4</td>
+						<td class="o-table__cell--numeric">26</td>
+						<td>2006</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">695</td>
+						<td><a href="http://communicateplc.com/" data-trackable="link" target="_blank">Communicate
+								plc</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">226%</td>
+						<td class="o-table__cell--numeric">48.30%</td>
+						<td class="o-table__cell--numeric">2,428</td>
+						<td class="o-table__cell--numeric">13</td>
+						<td class="o-table__cell--numeric">18</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">696</td>
+						<td><a href="http://rawoplast.de/" data-trackable="link" target="_blank">RAWOPLAST</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/industrial-goods" data-trackable="link">Industrial
+								Goods</a></td>
+						<td class="o-table__cell--numeric">225%</td>
+						<td class="o-table__cell--numeric">48.10%</td>
+						<td class="o-table__cell--numeric">7,398</td>
+						<td class="o-table__cell--numeric">4</td>
+						<td class="o-table__cell--numeric">13</td>
+						<td>2009</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">697</td>
+						<td><a href="http://spektrix.com/" data-trackable="link" target="_blank">Spektrix</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">224%</td>
+						<td class="o-table__cell--numeric">48%</td>
+						<td class="o-table__cell--numeric">6,308</td>
+						<td class="o-table__cell--numeric">38</td>
+						<td class="o-table__cell--numeric">65</td>
+						<td>2007</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">698</td>
+						<td><a href="http://7layers.it/" data-trackable="link" target="_blank">7Layers</a></td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Cyber_Security" data-trackable="link">Cyber
+								Security</a></td>
+						<td class="o-table__cell--numeric">224%</td>
+						<td class="o-table__cell--numeric">48%</td>
+						<td class="o-table__cell--numeric">2,623</td>
+						<td class="o-table__cell--numeric">5</td>
+						<td class="o-table__cell--numeric">8</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">699</td>
+						<td><a href="http://bluecube.it/" data-trackable="link" target="_blank">Bluecube</a></td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">223%</td>
+						<td class="o-table__cell--numeric">47.80%</td>
+						<td class="o-table__cell--numeric">1,863</td>
+						<td class="o-table__cell--numeric">11</td>
+						<td class="o-table__cell--numeric">16</td>
+						<td>2009</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">700</td>
+						<td><a href="http://artialis.com/" data-trackable="link" target="_blank">Artialis SA</a></td>
+						<td><a href="https://www.ft.com/topics/places/Belgium" data-trackable="link">Belgium</a></td>
+						<td><a href="https://www.ft.com/companies/health" data-trackable="link">Health</a></td>
+						<td class="o-table__cell--numeric">223%</td>
+						<td class="o-table__cell--numeric">47.80%</td>
+						<td class="o-table__cell--numeric">2,014</td>
+						<td class="o-table__cell--numeric">11</td>
+						<td class="o-table__cell--numeric">21</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">701</td>
+						<td><a href="http://cartes-services.fr/" data-trackable="link" target="_blank">Cartes &amp;
+								Services</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">222%</td>
+						<td class="o-table__cell--numeric">47.70%</td>
+						<td class="o-table__cell--numeric">4,408</td>
+						<td class="o-table__cell--numeric">100</td>
+						<td class="o-table__cell--numeric">150</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">702</td>
+						<td><a href="http://sapelec.net/" data-trackable="link" target="_blank">SAPELEC</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/energy" data-trackable="link">Energy</a></td>
+						<td class="o-table__cell--numeric">222%</td>
+						<td class="o-table__cell--numeric">47.70%</td>
+						<td class="o-table__cell--numeric">3,374</td>
+						<td class="o-table__cell--numeric">14</td>
+						<td class="o-table__cell--numeric">21</td>
+						<td>1995</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">703</td>
+						<td><a href="http://zoomalia.com/" data-trackable="link" target="_blank">E2Evolution</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/retail" data-trackable="link">Retail</a></td>
+						<td class="o-table__cell--numeric">222%</td>
+						<td class="o-table__cell--numeric">47.70%</td>
+						<td class="o-table__cell--numeric">11,454</td>
+						<td class="o-table__cell--numeric">30</td>
+						<td class="o-table__cell--numeric">48</td>
+						<td>2009</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">704</td>
+						<td><a href="http://first-utility.com/" data-trackable="link" target="_blank">First
+								Utility**</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/companies/energy" data-trackable="link">Energy</a></td>
+						<td class="o-table__cell--numeric">221%</td>
+						<td class="o-table__cell--numeric">47.60%</td>
+						<td class="o-table__cell--numeric">1,112,192</td>
+						<td class="o-table__cell--numeric">517</td>
+						<td class="o-table__cell--numeric">927</td>
+						<td>2004</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">705</td>
+						<td><a href="http://dms-tec.de/" data-trackable="link" target="_blank">DMS Technologie</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/industrial-goods" data-trackable="link">Industrial
+								Goods</a></td>
+						<td class="o-table__cell--numeric">221%</td>
+						<td class="o-table__cell--numeric">47.50%</td>
+						<td class="o-table__cell--numeric">5,478</td>
+						<td class="o-table__cell--numeric">14</td>
+						<td class="o-table__cell--numeric">18</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">706</td>
+						<td><a href="http://frankgroup.com/" data-trackable="link" target="_blank">Frank Recruitment
+								Group</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">221%</td>
+						<td class="o-table__cell--numeric">47.50%</td>
+						<td class="o-table__cell--numeric">126,492</td>
+						<td class="o-table__cell--numeric">500</td>
+						<td class="o-table__cell--numeric">1,000</td>
+						<td>2006</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">707</td>
+						<td><a href="http://transportesmarrerosantanaehijos.es/" data-trackable="link"
+								target="_blank">Marrero Santana e Hijos</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/companies/transport" data-trackable="link">Transport</a></td>
+						<td class="o-table__cell--numeric">220%</td>
+						<td class="o-table__cell--numeric">47.40%</td>
+						<td class="o-table__cell--numeric">2,855</td>
+						<td class="o-table__cell--numeric">65</td>
+						<td class="o-table__cell--numeric">65</td>
+						<td>1997</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">708</td>
+						<td><a href="http://greencityimmobilier.fr/" data-trackable="link" target="_blank">GreenCity
+								Immobilier</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/construction" data-trackable="link">Construction</a>
+						</td>
+						<td class="o-table__cell--numeric">219%</td>
+						<td class="o-table__cell--numeric">47.20%</td>
+						<td class="o-table__cell--numeric">12,241</td>
+						<td class="o-table__cell--numeric">34</td>
+						<td class="o-table__cell--numeric">53</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">709</td>
+						<td><a href="http://flashsalelogistics.com/" data-trackable="link" target="_blank">KOLGA</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/transport" data-trackable="link">Ecommerce</a></td>
+						<td class="o-table__cell--numeric">219%</td>
+						<td class="o-table__cell--numeric">47.10%</td>
+						<td class="o-table__cell--numeric">4,027</td>
+						<td class="o-table__cell--numeric">8</td>
+						<td class="o-table__cell--numeric">18</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">710</td>
+						<td><a href="http://e-z-s.de/" data-trackable="link" target="_blank">EZS Identtechnik</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">218%</td>
+						<td class="o-table__cell--numeric">47.10%</td>
+						<td class="o-table__cell--numeric">3,281</td>
+						<td class="o-table__cell--numeric">5</td>
+						<td class="o-table__cell--numeric">8</td>
+						<td>1997</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">711</td>
+						<td><a href="http://hidramar.com/" data-trackable="link" target="_blank">Hidramar</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/companies/construction" data-trackable="link">Construction</a>
+						</td>
+						<td class="o-table__cell--numeric">218%</td>
+						<td class="o-table__cell--numeric">47%</td>
+						<td class="o-table__cell--numeric">12,008</td>
+						<td class="o-table__cell--numeric">24</td>
+						<td class="o-table__cell--numeric">56</td>
+						<td>1990</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">712</td>
+						<td><a href="http://ads-up.fr/" data-trackable="link" target="_blank">Ad's up Consulting</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/media" data-trackable="link">Media</a></td>
+						<td class="o-table__cell--numeric">218%</td>
+						<td class="o-table__cell--numeric">47%</td>
+						<td class="o-table__cell--numeric">3,045</td>
+						<td class="o-table__cell--numeric">29</td>
+						<td class="o-table__cell--numeric">37</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">713</td>
+						<td><a href="http://nationalstandard.fr/" data-trackable="link" target="_blank">National
+								Standard</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/stream/f9f7535d-3b5c-47a7-bd15-3e10dceee597"
+								data-trackable="link">Fashion</a></td>
+						<td class="o-table__cell--numeric">218%</td>
+						<td class="o-table__cell--numeric">47%</td>
+						<td class="o-table__cell--numeric">1,908</td>
+						<td class="o-table__cell--numeric">2</td>
+						<td class="o-table__cell--numeric">4</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">714</td>
+						<td><a href="http://lineup.com/" data-trackable="link" target="_blank">Lineup Systems</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">217%</td>
+						<td class="o-table__cell--numeric">47%</td>
+						<td class="o-table__cell--numeric">9,760</td>
+						<td class="o-table__cell--numeric">48</td>
+						<td class="o-table__cell--numeric">86</td>
+						<td>2009</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">715</td>
+						<td><a href="http://ipcpiping.com/" data-trackable="link" target="_blank">IPC Piping</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/industrial-goods" data-trackable="link">Industrial
+								Goods</a></td>
+						<td class="o-table__cell--numeric">217%</td>
+						<td class="o-table__cell--numeric">46.90%</td>
+						<td class="o-table__cell--numeric">3,913</td>
+						<td class="o-table__cell--numeric">0</td>
+						<td class="o-table__cell--numeric">4</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">716</td>
+						<td><a href="http://italfrom.com/" data-trackable="link" target="_blank">Italfrom</a></td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Ecommerce" data-trackable="link">Ecommerce</a>
+						</td>
+						<td class="o-table__cell--numeric">217%</td>
+						<td class="o-table__cell--numeric">46.90%</td>
+						<td class="o-table__cell--numeric">3,604</td>
+						<td class="o-table__cell--numeric">6</td>
+						<td class="o-table__cell--numeric">11</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">717</td>
+						<td><a href="http://qualitance.com/" data-trackable="link" target="_blank">Qualitance</a></td>
+						<td><a href="https://www.ft.com/topics/places/Romania" data-trackable="link">Romania</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">217%</td>
+						<td class="o-table__cell--numeric">46.90%</td>
+						<td class="o-table__cell--numeric">6,093</td>
+						<td class="o-table__cell--numeric">97</td>
+						<td class="o-table__cell--numeric">162</td>
+						<td>2007</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">718</td>
+						<td><a href="http://wellnessresort.it/" data-trackable="link" target="_blank">Alpenschloessl</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/companies/travel-leisure" data-trackable="link">Travel &amp;
+								Leisure</a></td>
+						<td class="o-table__cell--numeric">217%</td>
+						<td class="o-table__cell--numeric">46.90%</td>
+						<td class="o-table__cell--numeric">7,224</td>
+						<td class="o-table__cell--numeric">41</td>
+						<td class="o-table__cell--numeric">71</td>
+						<td>1998</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">719</td>
+						<td><a href="http://prodigiosovolcan.com/" data-trackable="link" target="_blank">Prodigioso
+								Volcán</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Advertising" data-trackable="link">Advertising</a>
+						</td>
+						<td class="o-table__cell--numeric">217%</td>
+						<td class="o-table__cell--numeric">46.90%</td>
+						<td class="o-table__cell--numeric">2,656</td>
+						<td class="o-table__cell--numeric">33</td>
+						<td class="o-table__cell--numeric">40</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">720</td>
+						<td><a href="http://edehomes.co.uk/" data-trackable="link" target="_blank">Ede Holdings</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/companies/property" data-trackable="link">Property</a></td>
+						<td class="o-table__cell--numeric">216%</td>
+						<td class="o-table__cell--numeric">46.80%</td>
+						<td class="o-table__cell--numeric">21,065</td>
+						<td class="o-table__cell--numeric">4</td>
+						<td class="o-table__cell--numeric">21</td>
+						<td>1964</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">721</td>
+						<td><a href="http://gapps.fi/" data-trackable="link" target="_blank">Gapps Oy</a></td>
+						<td><a href="https://www.ft.com/topics/places/Finland" data-trackable="link">Finland</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">216%</td>
+						<td class="o-table__cell--numeric">46.70%</td>
+						<td class="o-table__cell--numeric">1,968</td>
+						<td class="o-table__cell--numeric">14</td>
+						<td class="o-table__cell--numeric">21</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">722</td>
+						<td><a href="http://hightex-dresden.de/" data-trackable="link" target="_blank">Hightex
+								Verstärkungsstrukturen</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">215%</td>
+						<td class="o-table__cell--numeric">46.60%</td>
+						<td class="o-table__cell--numeric">5,042</td>
+						<td class="o-table__cell--numeric">34</td>
+						<td class="o-table__cell--numeric">53</td>
+						<td>1998</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">723</td>
+						<td><a href="http://housesimple.com/" data-trackable="link" target="_blank">Housesimple</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/companies/property" data-trackable="link">Property</a></td>
+						<td class="o-table__cell--numeric">215%</td>
+						<td class="o-table__cell--numeric">46.60%</td>
+						<td class="o-table__cell--numeric">2,600</td>
+						<td class="o-table__cell--numeric">39</td>
+						<td class="o-table__cell--numeric">45</td>
+						<td>2007</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">724</td>
+						<td><a href="http://agence-panenka.com/" data-trackable="link" target="_blank">Panenka</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/media" data-trackable="link">Media</a></td>
+						<td class="o-table__cell--numeric">215%</td>
+						<td class="o-table__cell--numeric">46.60%</td>
+						<td class="o-table__cell--numeric">1,802</td>
+						<td class="o-table__cell--numeric">1</td>
+						<td class="o-table__cell--numeric">2</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">725</td>
+						<td><a href="http://agencebonplan.fr/" data-trackable="link" target="_blank">Bon Plan</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/media" data-trackable="link">Media</a></td>
+						<td class="o-table__cell--numeric">214%</td>
+						<td class="o-table__cell--numeric">46.50%</td>
+						<td class="o-table__cell--numeric">4,091</td>
+						<td class="o-table__cell--numeric">8</td>
+						<td class="o-table__cell--numeric">10</td>
+						<td>2007</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">726</td>
+						<td><a href="http://callmewine.com/" data-trackable="link" target="_blank">PVZ Srl</a></td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Ecommerce" data-trackable="link">Ecommerce</a>
+						</td>
+						<td class="o-table__cell--numeric">214%</td>
+						<td class="o-table__cell--numeric">46.40%</td>
+						<td class="o-table__cell--numeric">3,460</td>
+						<td class="o-table__cell--numeric">3</td>
+						<td class="o-table__cell--numeric">6</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">727</td>
+						<td><a href="http://aspens-services.co.uk/" data-trackable="link" target="_blank">Aspens
+								Services</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/companies/food-beverage" data-trackable="link">Food &amp;
+								Beverage</a></td>
+						<td class="o-table__cell--numeric">213%</td>
+						<td class="o-table__cell--numeric">46.30%</td>
+						<td class="o-table__cell--numeric">30,628</td>
+						<td class="o-table__cell--numeric">569</td>
+						<td class="o-table__cell--numeric">1,259</td>
+						<td>2008</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">728</td>
+						<td><a href="http://basetis.com/" data-trackable="link" target="_blank">BaseTIS</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Management_Consulting"
+								data-trackable="link">Management Consulting</a></td>
+						<td class="o-table__cell--numeric">213%</td>
+						<td class="o-table__cell--numeric">46.30%</td>
+						<td class="o-table__cell--numeric">6,763</td>
+						<td class="o-table__cell--numeric">153</td>
+						<td class="o-table__cell--numeric">188</td>
+						<td>2009</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">729</td>
+						<td><a href="http://greenprojectitalia.it/" data-trackable="link" target="_blank">Greenproject
+								Italia</a></td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/beauty" data-trackable="link">Beauty</a></td>
+						<td class="o-table__cell--numeric">213%</td>
+						<td class="o-table__cell--numeric">46.30%</td>
+						<td class="o-table__cell--numeric">2,825</td>
+						<td class="o-table__cell--numeric">11</td>
+						<td class="o-table__cell--numeric">12</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">730</td>
+						<td><a href="http://gearhouseactis.com/" data-trackable="link" target="_blank">Gearhouse
+								Actis</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/media" data-trackable="link">Media</a></td>
+						<td class="o-table__cell--numeric">213%</td>
+						<td class="o-table__cell--numeric">46.20%</td>
+						<td class="o-table__cell--numeric">3,564</td>
+						<td class="o-table__cell--numeric">8</td>
+						<td class="o-table__cell--numeric">13</td>
+						<td>1991</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">731</td>
+						<td><a href="http://readieconstruction.co.uk/" data-trackable="link" target="_blank">Readie
+								Construction</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/companies/construction" data-trackable="link">Construction</a>
+						</td>
+						<td class="o-table__cell--numeric">213%</td>
+						<td class="o-table__cell--numeric">46.20%</td>
+						<td class="o-table__cell--numeric">124,734</td>
+						<td class="o-table__cell--numeric">67</td>
+						<td class="o-table__cell--numeric">90</td>
+						<td>2007</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">732</td>
+						<td><a href="http://gbcgrupo.es/" data-trackable="link" target="_blank">GBC Containers</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/companies/transport" data-trackable="link">Transport</a></td>
+						<td class="o-table__cell--numeric">212%</td>
+						<td class="o-table__cell--numeric">46.10%</td>
+						<td class="o-table__cell--numeric">1,717</td>
+						<td class="o-table__cell--numeric">16</td>
+						<td class="o-table__cell--numeric">24</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">733</td>
+						<td>Cárnicas Discarpe</td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/companies/retail" data-trackable="link">Retail</a></td>
+						<td class="o-table__cell--numeric">212%</td>
+						<td class="o-table__cell--numeric">46.10%</td>
+						<td class="o-table__cell--numeric">3,774</td>
+						<td class="o-table__cell--numeric">4</td>
+						<td class="o-table__cell--numeric">6</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">734</td>
+						<td><a href="http://alertgasoil.com/" data-trackable="link" target="_blank">Avenir Développement
+								Durable</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">212%</td>
+						<td class="o-table__cell--numeric">46.10%</td>
+						<td class="o-table__cell--numeric">4,837</td>
+						<td class="o-table__cell--numeric">28</td>
+						<td class="o-table__cell--numeric">41</td>
+						<td>2009</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">735</td>
+						<td><a href="http://buildersandpartners.com/" data-trackable="link" target="_blank">Builders and
+								Partners</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/property" data-trackable="link">Property</a></td>
+						<td class="o-table__cell--numeric">211%</td>
+						<td class="o-table__cell--numeric">46%</td>
+						<td class="o-table__cell--numeric">12,750</td>
+						<td class="o-table__cell--numeric">82</td>
+						<td class="o-table__cell--numeric">100</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">736</td>
+						<td><a href="http://insidegroup.fr/" data-trackable="link" target="_blank">Inside Group</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">211%</td>
+						<td class="o-table__cell--numeric">45.90%</td>
+						<td class="o-table__cell--numeric">12,437</td>
+						<td class="o-table__cell--numeric">135</td>
+						<td class="o-table__cell--numeric">190</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">737</td>
+						<td><a href="http://bxr-group.de/" data-trackable="link" target="_blank">BXR
+								IndustrieService</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">211%</td>
+						<td class="o-table__cell--numeric">45.90%</td>
+						<td class="o-table__cell--numeric">3,751</td>
+						<td class="o-table__cell--numeric">119</td>
+						<td class="o-table__cell--numeric">130</td>
+						<td>2006</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">738</td>
+						<td><a href="http://sekainature.com/" data-trackable="link" target="_blank">Sekai Nature</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Agricultural_Commodities"
+								data-trackable="link">Agricultural commodities</a></td>
+						<td class="o-table__cell--numeric">211%</td>
+						<td class="o-table__cell--numeric">45.90%</td>
+						<td class="o-table__cell--numeric">9,945</td>
+						<td class="o-table__cell--numeric">5</td>
+						<td class="o-table__cell--numeric">8</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">739</td>
+						<td><a href="http://colorfultrade.de/" data-trackable="link" target="_blank">Colorful Trade</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/stream/f9f7535d-3b5c-47a7-bd15-3e10dceee597"
+								data-trackable="link">Fashion</a></td>
+						<td class="o-table__cell--numeric">210%</td>
+						<td class="o-table__cell--numeric">45.80%</td>
+						<td class="o-table__cell--numeric">3,910</td>
+						<td class="o-table__cell--numeric">7</td>
+						<td class="o-table__cell--numeric">12</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">740</td>
+						<td><a href="http://salecycle.com/" data-trackable="link" target="_blank">SaleCycle</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">209%</td>
+						<td class="o-table__cell--numeric">45.70%</td>
+						<td class="o-table__cell--numeric">14,270</td>
+						<td class="o-table__cell--numeric">94</td>
+						<td class="o-table__cell--numeric">145</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">741</td>
+						<td><a href="http://skworld.es/" data-trackable="link" target="_blank">SK World</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/companies/retail" data-trackable="link">Retail</a></td>
+						<td class="o-table__cell--numeric">209%</td>
+						<td class="o-table__cell--numeric">45.70%</td>
+						<td class="o-table__cell--numeric">5,280</td>
+						<td class="o-table__cell--numeric">3</td>
+						<td class="o-table__cell--numeric">5</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">742</td>
+						<td><a href="http://cmsantagostino.it/" data-trackable="link" target="_blank">CentroMedico
+								Santagostino</a></td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/companies/health" data-trackable="link">Health</a></td>
+						<td class="o-table__cell--numeric">209%</td>
+						<td class="o-table__cell--numeric">45.60%</td>
+						<td class="o-table__cell--numeric">15,922</td>
+						<td class="o-table__cell--numeric">94</td>
+						<td class="o-table__cell--numeric">139</td>
+						<td>2006</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">743</td>
+						<td><a href="http://medeland.es/" data-trackable="link" target="_blank">Medeland Events</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Advertising" data-trackable="link">Advertising</a>
+						</td>
+						<td class="o-table__cell--numeric">208%</td>
+						<td class="o-table__cell--numeric">45.50%</td>
+						<td class="o-table__cell--numeric">1,823</td>
+						<td class="o-table__cell--numeric">4</td>
+						<td class="o-table__cell--numeric">9</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">744</td>
+						<td><a href="http://deflomas.it/" data-trackable="link" target="_blank">Deflomas Eyewear</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Sales_&amp;_Marketing" data-trackable="link">Sales
+								&amp; Marketing</a></td>
+						<td class="o-table__cell--numeric">208%</td>
+						<td class="o-table__cell--numeric">45.50%</td>
+						<td class="o-table__cell--numeric">2,443</td>
+						<td class="o-table__cell--numeric">2</td>
+						<td class="o-table__cell--numeric">3</td>
+						<td>2009</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">745</td>
+						<td><a href="http://inventivapharma.com/" data-trackable="link" target="_blank">inventiva</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/chemicals" data-trackable="link">Chemicals</a></td>
+						<td class="o-table__cell--numeric">208%</td>
+						<td class="o-table__cell--numeric">45.50%</td>
+						<td class="o-table__cell--numeric">9,446</td>
+						<td class="o-table__cell--numeric">9</td>
+						<td class="o-table__cell--numeric">107</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">746</td>
+						<td><a href="http://gepps.de/" data-trackable="link" target="_blank">Gepp's</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/retail" data-trackable="link">Retail</a></td>
+						<td class="o-table__cell--numeric">208%</td>
+						<td class="o-table__cell--numeric">45.50%</td>
+						<td class="o-table__cell--numeric">3,963</td>
+						<td class="o-table__cell--numeric">108</td>
+						<td class="o-table__cell--numeric">129</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">747</td>
+						<td><a href="http://fr-techteam.com/" data-trackable="link" target="_blank">Techteam</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">208%</td>
+						<td class="o-table__cell--numeric">45.50%</td>
+						<td class="o-table__cell--numeric">2,006</td>
+						<td class="o-table__cell--numeric">23</td>
+						<td class="o-table__cell--numeric">31</td>
+						<td>2009</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">748</td>
+						<td><a href="http://endosmart.com/" data-trackable="link" target="_blank">Endosmart</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/health" data-trackable="link">Health</a></td>
+						<td class="o-table__cell--numeric">208%</td>
+						<td class="o-table__cell--numeric">45.50%</td>
+						<td class="o-table__cell--numeric">4,659</td>
+						<td class="o-table__cell--numeric">25</td>
+						<td class="o-table__cell--numeric">50</td>
+						<td>2002</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">749</td>
+						<td><a href="http://gpp-com.de/" data-trackable="link" target="_blank">GPP Communication</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">208%</td>
+						<td class="o-table__cell--numeric">45.40%</td>
+						<td class="o-table__cell--numeric">2,000</td>
+						<td class="o-table__cell--numeric">11</td>
+						<td class="o-table__cell--numeric">16</td>
+						<td>2007</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">750</td>
+						<td><a href="http://medilog-hamburg.de/" data-trackable="link" target="_blank">Medilog</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/health" data-trackable="link">Health</a></td>
+						<td class="o-table__cell--numeric">207%</td>
+						<td class="o-table__cell--numeric">45.30%</td>
+						<td class="o-table__cell--numeric">5,558</td>
+						<td class="o-table__cell--numeric">21</td>
+						<td class="o-table__cell--numeric">41</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">751</td>
+						<td><a href="http://alamoconsulting.com/" data-trackable="link"
+								target="_blank">ÁlamoConsulting</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Management_Consulting"
+								data-trackable="link">Management Consulting</a></td>
+						<td class="o-table__cell--numeric">207%</td>
+						<td class="o-table__cell--numeric">45.30%</td>
+						<td class="o-table__cell--numeric">13,682</td>
+						<td class="o-table__cell--numeric">78</td>
+						<td class="o-table__cell--numeric">146</td>
+						<td>2007</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">752</td>
+						<td><a href="http://boldint.com/" data-trackable="link" target="_blank">BOLDInt</a></td>
+						<td><a href="https://www.ft.com/topics/places/Portugal" data-trackable="link">Portugal</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">206%</td>
+						<td class="o-table__cell--numeric">45.30%</td>
+						<td class="o-table__cell--numeric">14,333</td>
+						<td class="o-table__cell--numeric">366</td>
+						<td class="o-table__cell--numeric">502</td>
+						<td>2009</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">753</td>
+						<td><a href="http://generalmarine.it/" data-trackable="link" target="_blank">Generalmarine</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/companies/telecoms" data-trackable="link">Telecoms</a></td>
+						<td class="o-table__cell--numeric">206%</td>
+						<td class="o-table__cell--numeric">45.20%</td>
+						<td class="o-table__cell--numeric">1,943</td>
+						<td class="o-table__cell--numeric">7</td>
+						<td class="o-table__cell--numeric">11</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">754</td>
+						<td><a href="http://exxpozed.de/" data-trackable="link" target="_blank">eXXpozed</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Ecommerce" data-trackable="link">Ecommerce</a>
+						</td>
+						<td class="o-table__cell--numeric">206%</td>
+						<td class="o-table__cell--numeric">45.10%</td>
+						<td class="o-table__cell--numeric">15,029</td>
+						<td class="o-table__cell--numeric">35</td>
+						<td class="o-table__cell--numeric">69</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">755</td>
+						<td><a href="http://couteauxduchef.com/" data-trackable="link"
+								target="_blank">CouteauxduChef.com</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/retail" data-trackable="link">Retail</a></td>
+						<td class="o-table__cell--numeric">205%</td>
+						<td class="o-table__cell--numeric">45%</td>
+						<td class="o-table__cell--numeric">1,559</td>
+						<td class="o-table__cell--numeric">3</td>
+						<td class="o-table__cell--numeric">4</td>
+						<td>2009</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">756</td>
+						<td><a href="http://fmad.fr/" data-trackable="link" target="_blank">FMad</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/media" data-trackable="link">Media</a></td>
+						<td class="o-table__cell--numeric">205%</td>
+						<td class="o-table__cell--numeric">45%</td>
+						<td class="o-table__cell--numeric">2,693</td>
+						<td class="o-table__cell--numeric">5</td>
+						<td class="o-table__cell--numeric">10</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">757</td>
+						<td><a href="http://wtb-brandschutzbau.de/" data-trackable="link" target="_blank">WIESE
+								Tischlerei + Brandschutzbau</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/construction" data-trackable="link">Construction</a>
+						</td>
+						<td class="o-table__cell--numeric">204%</td>
+						<td class="o-table__cell--numeric">44.90%</td>
+						<td class="o-table__cell--numeric">1,883</td>
+						<td class="o-table__cell--numeric">8</td>
+						<td class="o-table__cell--numeric">20</td>
+						<td>2007</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">758</td>
+						<td><a href="http://adzuna.co.uk/" data-trackable="link" target="_blank">Adhunter</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Ecommerce" data-trackable="link">Ecommerce</a>
+						</td>
+						<td class="o-table__cell--numeric">204%</td>
+						<td class="o-table__cell--numeric">44.90%</td>
+						<td class="o-table__cell--numeric">7,705</td>
+						<td class="o-table__cell--numeric">27</td>
+						<td class="o-table__cell--numeric">49</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">759</td>
+						<td><a href="http://eliraweb.fr/" data-trackable="link" target="_blank">Eliraweb</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/media" data-trackable="link">Media</a></td>
+						<td class="o-table__cell--numeric">204%</td>
+						<td class="o-table__cell--numeric">44.80%</td>
+						<td class="o-table__cell--numeric">2,406</td>
+						<td class="o-table__cell--numeric">2</td>
+						<td class="o-table__cell--numeric">8</td>
+						<td>2007</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">760</td>
+						<td><a href="http://etsingegneria.it/" data-trackable="link" target="_blank">ETS</a></td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/companies/construction" data-trackable="link">Construction</a>
+						</td>
+						<td class="o-table__cell--numeric">203%</td>
+						<td class="o-table__cell--numeric">44.70%</td>
+						<td class="o-table__cell--numeric">2,602</td>
+						<td class="o-table__cell--numeric">8</td>
+						<td class="o-table__cell--numeric">11</td>
+						<td>2005</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">761</td>
+						<td><a href="http://mesaudacosmetics.it/" data-trackable="link" target="_blank">Mesauda
+								Milano</a></td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/beauty" data-trackable="link">Beauty</a></td>
+						<td class="o-table__cell--numeric">202%</td>
+						<td class="o-table__cell--numeric">44.50%</td>
+						<td class="o-table__cell--numeric">11,256</td>
+						<td class="o-table__cell--numeric">13</td>
+						<td class="o-table__cell--numeric">20</td>
+						<td>2004</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">762</td>
+						<td><a href="http://equalexperts.com/" data-trackable="link" target="_blank">Equal Experts</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">202%</td>
+						<td class="o-table__cell--numeric">44.50%</td>
+						<td class="o-table__cell--numeric">83,580</td>
+						<td class="o-table__cell--numeric">43</td>
+						<td class="o-table__cell--numeric">91</td>
+						<td>2007</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">763</td>
+						<td><a href="http://i-systems.net/" data-trackable="link" target="_blank">i-systems</a></td>
+						<td><a href="https://www.ft.com/topics/places/Poland" data-trackable="link">Poland</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Ecommerce" data-trackable="link">Ecommerce</a>
+						</td>
+						<td class="o-table__cell--numeric">201%</td>
+						<td class="o-table__cell--numeric">44.40%</td>
+						<td class="o-table__cell--numeric">2,090</td>
+						<td class="o-table__cell--numeric">40</td>
+						<td class="o-table__cell--numeric">86</td>
+						<td>2002</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">764</td>
+						<td><a href="http://e-wald.eu/" data-trackable="link" target="_blank">E-WALD</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">201%</td>
+						<td class="o-table__cell--numeric">44.40%</td>
+						<td class="o-table__cell--numeric">2,135</td>
+						<td class="o-table__cell--numeric">7</td>
+						<td class="o-table__cell--numeric">17</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">765</td>
+						<td><a href="http://quotedevil.ie/" data-trackable="link" target="_blank">Quote Devil</a></td>
+						<td><a href="https://www.ft.com/topics/places/Ireland" data-trackable="link">Ireland</a></td>
+						<td><a href="https://www.ft.com/companies/insurance" data-trackable="link">Insurance</a></td>
+						<td class="o-table__cell--numeric">201%</td>
+						<td class="o-table__cell--numeric">44.40%</td>
+						<td class="o-table__cell--numeric">2,934</td>
+						<td class="o-table__cell--numeric">26</td>
+						<td class="o-table__cell--numeric">45</td>
+						<td>2006</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">766</td>
+						<td><a href="http://panedore.it/" data-trackable="link" target="_blank">Target Spa</a></td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/companies/food-beverage" data-trackable="link">Food &amp;
+								Beverage</a></td>
+						<td class="o-table__cell--numeric">201%</td>
+						<td class="o-table__cell--numeric">44.40%</td>
+						<td class="o-table__cell--numeric">5,291</td>
+						<td class="o-table__cell--numeric">12</td>
+						<td class="o-table__cell--numeric">29</td>
+						<td>1999</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">767</td>
+						<td><a href="http://cagepat.fr/" data-trackable="link" target="_blank">Capitole Gestion
+								Patrimoine</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/financial-services" data-trackable="link">Financial
+								Services</a></td>
+						<td class="o-table__cell--numeric">200%</td>
+						<td class="o-table__cell--numeric">44.30%</td>
+						<td class="o-table__cell--numeric">2,540</td>
+						<td class="o-table__cell--numeric">35</td>
+						<td class="o-table__cell--numeric">40</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">768</td>
+						<td><a href="http://littlegreenhouse.ch/" data-trackable="link" target="_blank">Little Green
+								House</a></td>
+						<td><a href="https://www.ft.com/topics/places/Switzerland" data-trackable="link">Switzerland</a>
+						</td>
+						<td><a href="https://www.ft.com/stream/d320c9d7-1638-4388-b667-a5d63bd4bbc2"
+								data-trackable="link">Education</a></td>
+						<td class="o-table__cell--numeric">200%</td>
+						<td class="o-table__cell--numeric">44.20%</td>
+						<td class="o-table__cell--numeric">5,524</td>
+						<td class="o-table__cell--numeric">73</td>
+						<td class="o-table__cell--numeric">110</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">769</td>
+						<td><a href="http://concentrade.de/" data-trackable="link" target="_blank">concentrade</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">200%</td>
+						<td class="o-table__cell--numeric">44.20%</td>
+						<td class="o-table__cell--numeric">9,165</td>
+						<td class="o-table__cell--numeric">6</td>
+						<td class="o-table__cell--numeric">26</td>
+						<td>1997</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">769</td>
+						<td><a href="http://dolcemilano.eu/" data-trackable="link" target="_blank">Dolce Milano</a></td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/companies/food-beverage" data-trackable="link">Food &amp;
+								Beverage</a></td>
+						<td class="o-table__cell--numeric">200%</td>
+						<td class="o-table__cell--numeric">44.20%</td>
+						<td class="o-table__cell--numeric">10,800</td>
+						<td class="o-table__cell--numeric">3</td>
+						<td class="o-table__cell--numeric">6</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">771</td>
+						<td><a href="http://premio-dresden.de/" data-trackable="link" target="_blank">F.H. Wheel
+								Center</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/automobiles" data-trackable="link">Automobiles</a>
+						</td>
+						<td class="o-table__cell--numeric">199%</td>
+						<td class="o-table__cell--numeric">44%</td>
+						<td class="o-table__cell--numeric">11,100</td>
+						<td class="o-table__cell--numeric">12</td>
+						<td class="o-table__cell--numeric">34</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">772</td>
+						<td><a href="http://rebional.de/" data-trackable="link" target="_blank">Rebional</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/food-beverage" data-trackable="link">Food &amp;
+								Beverage</a></td>
+						<td class="o-table__cell--numeric">199%</td>
+						<td class="o-table__cell--numeric">44%</td>
+						<td class="o-table__cell--numeric">12,173</td>
+						<td class="o-table__cell--numeric">45</td>
+						<td class="o-table__cell--numeric">133</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">773</td>
+						<td><a href="http://alterfood.fr/" data-trackable="link" target="_blank">Alterfood</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Agricultural_Commodities"
+								data-trackable="link">Agricultural commodities</a></td>
+						<td class="o-table__cell--numeric">199%</td>
+						<td class="o-table__cell--numeric">44%</td>
+						<td class="o-table__cell--numeric">4,700</td>
+						<td class="o-table__cell--numeric">6</td>
+						<td class="o-table__cell--numeric">15</td>
+						<td>2009</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">774</td>
+						<td><a href="http://jdxconsulting.com/" data-trackable="link" target="_blank">JDX</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/companies/financial-services" data-trackable="link">Financial
+								Services</a></td>
+						<td class="o-table__cell--numeric">198%</td>
+						<td class="o-table__cell--numeric">44%</td>
+						<td class="o-table__cell--numeric">27,292</td>
+						<td class="o-table__cell--numeric">120</td>
+						<td class="o-table__cell--numeric">289</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">775</td>
+						<td><a href="http://bluetreegroup.co.uk/" data-trackable="link" target="_blank">Bluetree Design
+								&amp; Print</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Ecommerce" data-trackable="link">Ecommerce</a>
+						</td>
+						<td class="o-table__cell--numeric">198%</td>
+						<td class="o-table__cell--numeric">43.90%</td>
+						<td class="o-table__cell--numeric">32,099</td>
+						<td class="o-table__cell--numeric">151</td>
+						<td class="o-table__cell--numeric">252</td>
+						<td>1999</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">776</td>
+						<td><a href="http://petitdidierprioux.com/" data-trackable="link"
+								target="_blank">Petitdidierprioux</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/property" data-trackable="link">Property</a></td>
+						<td class="o-table__cell--numeric">198%</td>
+						<td class="o-table__cell--numeric">43.90%</td>
+						<td class="o-table__cell--numeric">2,458</td>
+						<td class="o-table__cell--numeric">10</td>
+						<td class="o-table__cell--numeric">15</td>
+						<td>2004</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">777</td>
+						<td><a href="http://feefo.com/" data-trackable="link" target="_blank">Feefo Holdings</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">198%</td>
+						<td class="o-table__cell--numeric">43.90%</td>
+						<td class="o-table__cell--numeric">9,390</td>
+						<td class="o-table__cell--numeric">57</td>
+						<td class="o-table__cell--numeric">82</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">778</td>
+						<td><a href="http://safety21.it/" data-trackable="link" target="_blank">Safety21 S.p.A.</a></td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">198%</td>
+						<td class="o-table__cell--numeric">43.90%</td>
+						<td class="o-table__cell--numeric">11,126</td>
+						<td class="o-table__cell--numeric">15</td>
+						<td class="o-table__cell--numeric">24</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">779</td>
+						<td><a href="http://wearefirma.com/" data-trackable="link" target="_blank">Firma Brand
+								Communication</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Advertising" data-trackable="link">Advertising</a>
+						</td>
+						<td class="o-table__cell--numeric">198%</td>
+						<td class="o-table__cell--numeric">43.90%</td>
+						<td class="o-table__cell--numeric">4,397</td>
+						<td class="o-table__cell--numeric">23</td>
+						<td class="o-table__cell--numeric">37</td>
+						<td>2006</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">780</td>
+						<td><a href="http://flexmind.fr/" data-trackable="link" target="_blank">Flexmind</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">198%</td>
+						<td class="o-table__cell--numeric">43.90%</td>
+						<td class="o-table__cell--numeric">5,219</td>
+						<td class="o-table__cell--numeric">24</td>
+						<td class="o-table__cell--numeric">43</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">781</td>
+						<td><a href="http://sylvide.fr/" data-trackable="link" target="_blank">Sylvide</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/transport" data-trackable="link">Transport</a></td>
+						<td class="o-table__cell--numeric">197%</td>
+						<td class="o-table__cell--numeric">43.80%</td>
+						<td class="o-table__cell--numeric">1,698</td>
+						<td class="o-table__cell--numeric">5</td>
+						<td class="o-table__cell--numeric">8</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">782</td>
+						<td><a href="http://turbodynamics.de/" data-trackable="link" target="_blank">Turbodynamics</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">197%</td>
+						<td class="o-table__cell--numeric">43.80%</td>
+						<td class="o-table__cell--numeric">2,995</td>
+						<td class="o-table__cell--numeric">7</td>
+						<td class="o-table__cell--numeric">16</td>
+						<td>2006</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">783</td>
+						<td><a href="http://3gmg.com/" data-trackable="link" target="_blank">3G Soluciones Movilidad</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">197%</td>
+						<td class="o-table__cell--numeric">43.70%</td>
+						<td class="o-table__cell--numeric">1,664</td>
+						<td class="o-table__cell--numeric">16</td>
+						<td class="o-table__cell--numeric">21</td>
+						<td>2005</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">784</td>
+						<td><a href="http://insitumed.com/" data-trackable="link" target="_blank">Insitumed</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/health" data-trackable="link">Health</a></td>
+						<td class="o-table__cell--numeric">196%</td>
+						<td class="o-table__cell--numeric">43.60%</td>
+						<td class="o-table__cell--numeric">8,253</td>
+						<td class="o-table__cell--numeric">15</td>
+						<td class="o-table__cell--numeric">23</td>
+						<td>2000</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">785</td>
+						<td><a href="http://mandale.com/" data-trackable="link" target="_blank">Arkgrove</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/companies/property" data-trackable="link">Property</a></td>
+						<td class="o-table__cell--numeric">196%</td>
+						<td class="o-table__cell--numeric">43.60%</td>
+						<td class="o-table__cell--numeric">11,055</td>
+						<td class="o-table__cell--numeric">24</td>
+						<td class="o-table__cell--numeric">59</td>
+						<td>1982</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">786</td>
+						<td><a href="http://between.com/" data-trackable="link" target="_blank">Between</a></td>
+						<td><a href="https://www.ft.com/topics/places/Netherlands" data-trackable="link">The
+								Netherlands</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">196%</td>
+						<td class="o-table__cell--numeric">43.60%</td>
+						<td class="o-table__cell--numeric">77,080</td>
+						<td class="o-table__cell--numeric">19</td>
+						<td class="o-table__cell--numeric">29</td>
+						<td>2000</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">787</td>
+						<td><a href="http://patriciaurquiola.com/" data-trackable="link" target="_blank">Urquiola</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/architecture" data-trackable="link">Architecture</a></td>
+						<td class="o-table__cell--numeric">196%</td>
+						<td class="o-table__cell--numeric">43.50%</td>
+						<td class="o-table__cell--numeric">5,803</td>
+						<td class="o-table__cell--numeric">8</td>
+						<td class="o-table__cell--numeric">16</td>
+						<td>2004</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">788</td>
+						<td><a href="http://enegan.it/" data-trackable="link" target="_blank">Enegan</a></td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/companies/energy" data-trackable="link">Energy</a></td>
+						<td class="o-table__cell--numeric">196%</td>
+						<td class="o-table__cell--numeric">43.50%</td>
+						<td class="o-table__cell--numeric">191,528</td>
+						<td class="o-table__cell--numeric">68</td>
+						<td class="o-table__cell--numeric">92</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">789</td>
+						<td>EURL Vauvert Froger</td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/retail" data-trackable="link">Retail</a></td>
+						<td class="o-table__cell--numeric">196%</td>
+						<td class="o-table__cell--numeric">43.50%</td>
+						<td class="o-table__cell--numeric">4,526</td>
+						<td class="o-table__cell--numeric">7</td>
+						<td class="o-table__cell--numeric">16</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">790</td>
+						<td>Medspa</td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/companies/retail" data-trackable="link">Retail</a></td>
+						<td class="o-table__cell--numeric">196%</td>
+						<td class="o-table__cell--numeric">43.50%</td>
+						<td class="o-table__cell--numeric">2,526</td>
+						<td class="o-table__cell--numeric">10</td>
+						<td class="o-table__cell--numeric">11</td>
+						<td>2006</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">791</td>
+						<td><a href="http://smmotor.es/" data-trackable="link" target="_blank">2008 SM Motor</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/companies/retail" data-trackable="link">Retail</a></td>
+						<td class="o-table__cell--numeric">195%</td>
+						<td class="o-table__cell--numeric">43.50%</td>
+						<td class="o-table__cell--numeric">3,051</td>
+						<td class="o-table__cell--numeric">4</td>
+						<td class="o-table__cell--numeric">8</td>
+						<td>2009</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">792</td>
+						<td><a href="http://alpitronic.it/" data-trackable="link" target="_blank">alpitronic</a></td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">194%</td>
+						<td class="o-table__cell--numeric">43.30%</td>
+						<td class="o-table__cell--numeric">3,069</td>
+						<td class="o-table__cell--numeric">12</td>
+						<td class="o-table__cell--numeric">24</td>
+						<td>2009</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">793</td>
+						<td><a href="http://goodf.co.uk/" data-trackable="link" target="_blank">Goodfellow &amp;
+								Goodfellow</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/companies/food-beverage" data-trackable="link">Food &amp;
+								Beverage</a></td>
+						<td class="o-table__cell--numeric">194%</td>
+						<td class="o-table__cell--numeric">43.30%</td>
+						<td class="o-table__cell--numeric">6,445</td>
+						<td class="o-table__cell--numeric">12</td>
+						<td class="o-table__cell--numeric">26</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">794</td>
+						<td><a href="http://all-now.it/" data-trackable="link" target="_blank">All Now</a></td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">194%</td>
+						<td class="o-table__cell--numeric">43.30%</td>
+						<td class="o-table__cell--numeric">4,125</td>
+						<td class="o-table__cell--numeric">11</td>
+						<td class="o-table__cell--numeric">18</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">795</td>
+						<td><a href="http://yourworldrecruitmentgroup.com/" data-trackable="link" target="_blank">Your
+								World Recruitment Group</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">194%</td>
+						<td class="o-table__cell--numeric">43.20%</td>
+						<td class="o-table__cell--numeric">143,774</td>
+						<td class="o-table__cell--numeric">210</td>
+						<td class="o-table__cell--numeric">295</td>
+						<td>2005</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">796</td>
+						<td><a href="http://od-group.com/" data-trackable="link" target="_blank">OD Projects
+								(Holdings)</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/companies/construction" data-trackable="link">Construction</a>
+						</td>
+						<td class="o-table__cell--numeric">193%</td>
+						<td class="o-table__cell--numeric">43.10%</td>
+						<td class="o-table__cell--numeric">92,902</td>
+						<td class="o-table__cell--numeric">54</td>
+						<td class="o-table__cell--numeric">98</td>
+						<td>2004</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">797</td>
+						<td><a href="http://laboratoriolavallonea.net/" data-trackable="link"
+								target="_blank">Laboratorio La Vallonea</a></td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/companies/health" data-trackable="link">Health</a></td>
+						<td class="o-table__cell--numeric">193%</td>
+						<td class="o-table__cell--numeric">43%</td>
+						<td class="o-table__cell--numeric">2,077</td>
+						<td class="o-table__cell--numeric">39</td>
+						<td class="o-table__cell--numeric">57</td>
+						<td>2009</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">798</td>
+						<td><a href="http://lafourmi.biz/" data-trackable="link" target="_blank">Lafourmi</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/media" data-trackable="link">Media</a></td>
+						<td class="o-table__cell--numeric">192%</td>
+						<td class="o-table__cell--numeric">43%</td>
+						<td class="o-table__cell--numeric">3,775</td>
+						<td class="o-table__cell--numeric">21</td>
+						<td class="o-table__cell--numeric">35</td>
+						<td>2007</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">799</td>
+						<td><a href="http://kinougarde.com/" data-trackable="link" target="_blank">Kinougarde</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/stream/d320c9d7-1638-4388-b667-a5d63bd4bbc2"
+								data-trackable="link">Education</a></td>
+						<td class="o-table__cell--numeric">192%</td>
+						<td class="o-table__cell--numeric">42.90%</td>
+						<td class="o-table__cell--numeric">18,912</td>
+						<td class="o-table__cell--numeric">430</td>
+						<td class="o-table__cell--numeric">620</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">800</td>
+						<td><a href="http://mmn.it/" data-trackable="link" target="_blank">MMN</a></td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Cyber_Security" data-trackable="link">Cyber
+								Security</a></td>
+						<td class="o-table__cell--numeric">191%</td>
+						<td class="o-table__cell--numeric">42.80%</td>
+						<td class="o-table__cell--numeric">29,226</td>
+						<td class="o-table__cell--numeric">9</td>
+						<td class="o-table__cell--numeric">45</td>
+						<td>1989</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">801</td>
+						<td><a href="http://modusgroup.com/" data-trackable="link" target="_blank">Workplace Futures
+								Group</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/companies/construction" data-trackable="link">Construction</a>
+						</td>
+						<td class="o-table__cell--numeric">191%</td>
+						<td class="o-table__cell--numeric">42.80%</td>
+						<td class="o-table__cell--numeric">67,184</td>
+						<td class="o-table__cell--numeric">25</td>
+						<td class="o-table__cell--numeric">68</td>
+						<td>2007</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">802</td>
+						<td><a href="http://rcteam.fr/" data-trackable="link" target="_blank">RC Team</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/retail" data-trackable="link">Retail</a></td>
+						<td class="o-table__cell--numeric">191%</td>
+						<td class="o-table__cell--numeric">42.80%</td>
+						<td class="o-table__cell--numeric">3,945</td>
+						<td class="o-table__cell--numeric">4</td>
+						<td class="o-table__cell--numeric">7</td>
+						<td>2005</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">803</td>
+						<td><a href="http://r-m.de/" data-trackable="link" target="_blank">Riese und Müller</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/personal-goods" data-trackable="link">Personal &amp;
+								Household Goods</a></td>
+						<td class="o-table__cell--numeric">191%</td>
+						<td class="o-table__cell--numeric">42.80%</td>
+						<td class="o-table__cell--numeric">38,813</td>
+						<td class="o-table__cell--numeric">69</td>
+						<td class="o-table__cell--numeric">170</td>
+						<td>1996</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">804</td>
+						<td><a href="http://mantis-roofgarden.de/" data-trackable="link" target="_blank">Spoon
+								Gastronomie</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/restaurants" data-trackable="link">Restaurants</a></td>
+						<td class="o-table__cell--numeric">191%</td>
+						<td class="o-table__cell--numeric">42.80%</td>
+						<td class="o-table__cell--numeric">4,190</td>
+						<td class="o-table__cell--numeric">74</td>
+						<td class="o-table__cell--numeric">112</td>
+						<td>2006</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">805</td>
+						<td><a href="http://biolifestyle.at/" data-trackable="link" target="_blank">BiologoN</a></td>
+						<td><a href="https://www.ft.com/topics/places/Austria" data-trackable="link">Austria</a></td>
+						<td><a href="https://www.ft.com/companies/food-beverage" data-trackable="link">Food &amp;
+								Beverage</a></td>
+						<td class="o-table__cell--numeric">191%</td>
+						<td class="o-table__cell--numeric">42.80%</td>
+						<td class="o-table__cell--numeric">7,293</td>
+						<td class="o-table__cell--numeric">20</td>
+						<td class="o-table__cell--numeric">49</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">806</td>
+						<td><a href="http://astree-software.fr/" data-trackable="link" target="_blank">Astree
+								Software</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">190%</td>
+						<td class="o-table__cell--numeric">42.70%</td>
+						<td class="o-table__cell--numeric">1,500</td>
+						<td class="o-table__cell--numeric">9</td>
+						<td class="o-table__cell--numeric">15</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">807</td>
+						<td><a href="http://pitchup.com/" data-trackable="link" target="_blank">Pitchup.com</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Ecommerce" data-trackable="link">Ecommerce</a>
+						</td>
+						<td class="o-table__cell--numeric">190%</td>
+						<td class="o-table__cell--numeric">42.60%</td>
+						<td class="o-table__cell--numeric">2,060</td>
+						<td class="o-table__cell--numeric">8</td>
+						<td class="o-table__cell--numeric">9</td>
+						<td>2008</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">808</td>
+						<td><a href="http://icont.it/" data-trackable="link" target="_blank">ICONT</a></td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/companies/industrial-goods" data-trackable="link">Industrial
+								Goods</a></td>
+						<td class="o-table__cell--numeric">190%</td>
+						<td class="o-table__cell--numeric">42.60%</td>
+						<td class="o-table__cell--numeric">12,250</td>
+						<td class="o-table__cell--numeric">18</td>
+						<td class="o-table__cell--numeric">33</td>
+						<td>2007</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">809</td>
+						<td><a href="http://maprovider.com/" data-trackable="link" target="_blank">MA Provider</a></td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Management_Consulting"
+								data-trackable="link">Management Consulting</a></td>
+						<td class="o-table__cell--numeric">189%</td>
+						<td class="o-table__cell--numeric">42.50%</td>
+						<td class="o-table__cell--numeric">3,822</td>
+						<td class="o-table__cell--numeric">11</td>
+						<td class="o-table__cell--numeric">15</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">810</td>
+						<td><a href="http://primo-gmbh.com/" data-trackable="link" target="_blank">Primo</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">189%</td>
+						<td class="o-table__cell--numeric">42.40%</td>
+						<td class="o-table__cell--numeric">2,600</td>
+						<td class="o-table__cell--numeric">10</td>
+						<td class="o-table__cell--numeric">15</td>
+						<td>2005</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">811</td>
+						<td><a href="http://medcomplet.de/" data-trackable="link" target="_blank">MedComplet</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/health" data-trackable="link">Health</a></td>
+						<td class="o-table__cell--numeric">189%</td>
+						<td class="o-table__cell--numeric">42.40%</td>
+						<td class="o-table__cell--numeric">5,810</td>
+						<td class="o-table__cell--numeric">23</td>
+						<td class="o-table__cell--numeric">34</td>
+						<td>2007</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">812</td>
+						<td><a href="http://gruener-fisher.de/" data-trackable="link" target="_blank">Grüner Fisher
+								Investments</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/financial-services" data-trackable="link">Financial
+								Services</a></td>
+						<td class="o-table__cell--numeric">188%</td>
+						<td class="o-table__cell--numeric">42.20%</td>
+						<td class="o-table__cell--numeric">18,309</td>
+						<td class="o-table__cell--numeric">50</td>
+						<td class="o-table__cell--numeric">113</td>
+						<td>1999</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">813</td>
+						<td><a href="http://http/www.pqegroup.com/" data-trackable="link" target="_blank">Pharma Quality
+								Europe</a></td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">188%</td>
+						<td class="o-table__cell--numeric">42.20%</td>
+						<td class="o-table__cell--numeric">24,436</td>
+						<td class="o-table__cell--numeric">145</td>
+						<td class="o-table__cell--numeric">229</td>
+						<td>1998</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">814</td>
+						<td><a href="http://pro-seniors.fr/" data-trackable="link" target="_blank">PRO Seniors</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">188%</td>
+						<td class="o-table__cell--numeric">42.20%</td>
+						<td class="o-table__cell--numeric">9,200</td>
+						<td class="o-table__cell--numeric">215</td>
+						<td class="o-table__cell--numeric">439</td>
+						<td>2007</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">815</td>
+						<td><a href="http://urbag.ws/" data-trackable="link" target="_blank">Ürbag</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Advertising" data-trackable="link">Advertising</a>
+						</td>
+						<td class="o-table__cell--numeric">187%</td>
+						<td class="o-table__cell--numeric">42.20%</td>
+						<td class="o-table__cell--numeric">4,816</td>
+						<td class="o-table__cell--numeric">4</td>
+						<td class="o-table__cell--numeric">9</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">816</td>
+						<td><a href="http://cesamseed.com/" data-trackable="link" target="_blank">Cesam Seed</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">187%</td>
+						<td class="o-table__cell--numeric">42.20%</td>
+						<td class="o-table__cell--numeric">2,750</td>
+						<td class="o-table__cell--numeric">21</td>
+						<td class="o-table__cell--numeric">30</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">817</td>
+						<td><a href="http://dovevivo.it/" data-trackable="link" target="_blank">DoveVivo</a></td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/companies/property" data-trackable="link">Property</a></td>
+						<td class="o-table__cell--numeric">187%</td>
+						<td class="o-table__cell--numeric">42.10%</td>
+						<td class="o-table__cell--numeric">11,683</td>
+						<td class="o-table__cell--numeric">47</td>
+						<td class="o-table__cell--numeric">54</td>
+						<td>2007</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">818</td>
+						<td><a href="http://hundt-consult.de/" data-trackable="link" target="_blank">Hundt Consult</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/property" data-trackable="link">Property</a></td>
+						<td class="o-table__cell--numeric">187%</td>
+						<td class="o-table__cell--numeric">42.10%</td>
+						<td class="o-table__cell--numeric">3,060</td>
+						<td class="o-table__cell--numeric">20</td>
+						<td class="o-table__cell--numeric">34</td>
+						<td>2008</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">819</td>
+						<td><a href="http://straka3d-lasertechnik.de/" data-trackable="link" target="_blank">Straka 3-D
+								Lasertechnik</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">186%</td>
+						<td class="o-table__cell--numeric">41.90%</td>
+						<td class="o-table__cell--numeric">2,400</td>
+						<td class="o-table__cell--numeric">16</td>
+						<td class="o-table__cell--numeric">19</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">820</td>
+						<td><a href="http://gomintec.com/" data-trackable="link" target="_blank">Gomintec</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/companies/construction" data-trackable="link">Construction</a>
+						</td>
+						<td class="o-table__cell--numeric">186%</td>
+						<td class="o-table__cell--numeric">41.90%</td>
+						<td class="o-table__cell--numeric">2,371</td>
+						<td class="o-table__cell--numeric">3</td>
+						<td class="o-table__cell--numeric">11</td>
+						<td>2006</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">821</td>
+						<td><a href="http://maconnerie-mugnier.fr/" data-trackable="link" target="_blank">Brice Mugnier
+								Bâtiment</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/construction" data-trackable="link">Construction</a>
+						</td>
+						<td class="o-table__cell--numeric">185%</td>
+						<td class="o-table__cell--numeric">41.90%</td>
+						<td class="o-table__cell--numeric">2,298</td>
+						<td class="o-table__cell--numeric">8</td>
+						<td class="o-table__cell--numeric">10</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">822</td>
+						<td><a href="http://moyseafood.com/" data-trackable="link" target="_blank">Moyseafood</a></td>
+						<td><a href="https://www.ft.com/topics/places/Netherlands" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/companies/food-beverage" data-trackable="link">Food &amp;
+								Beverage</a></td>
+						<td class="o-table__cell--numeric">185%</td>
+						<td class="o-table__cell--numeric">41.80%</td>
+						<td class="o-table__cell--numeric">44,234</td>
+						<td class="o-table__cell--numeric">33</td>
+						<td class="o-table__cell--numeric">84</td>
+						<td>2002</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">823</td>
+						<td><a href="http://fabrienvaf.es/" data-trackable="link" target="_blank">Fabrienvaf Nuca</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Netherlands" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/companies/chemicals" data-trackable="link">Chemicals</a></td>
+						<td class="o-table__cell--numeric">184%</td>
+						<td class="o-table__cell--numeric">41.70%</td>
+						<td class="o-table__cell--numeric">2,903</td>
+						<td class="o-table__cell--numeric">9</td>
+						<td class="o-table__cell--numeric">15</td>
+						<td>1999</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">824</td>
+						<td><a href="http://clemens-hobbytec.de/" data-trackable="link" target="_blank">Clemens
+								HobbyTec</a></td>
+						<td><a href="https://www.ft.com/topics/places/Netherlands" data-trackable="link">Germany</a>
+						</td>
+						<td><a href="https://www.ft.com/companies/personal-goods" data-trackable="link">Personal &amp;
+								Household Goods</a></td>
+						<td class="o-table__cell--numeric">184%</td>
+						<td class="o-table__cell--numeric">41.60%</td>
+						<td class="o-table__cell--numeric">6,823</td>
+						<td class="o-table__cell--numeric">3</td>
+						<td class="o-table__cell--numeric">9</td>
+						<td>2008</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">825</td>
+						<td><a href="http://hnida-logistik.de/" data-trackable="link" target="_blank">Hnida Transport
+								&amp; Logistik</a></td>
+						<td><a href="https://www.ft.com/topics/places/Netherlands" data-trackable="link">Germany</a>
+						</td>
+						<td><a href="https://www.ft.com/companies/transport" data-trackable="link">Transport</a></td>
+						<td class="o-table__cell--numeric">184%</td>
+						<td class="o-table__cell--numeric">41.60%</td>
+						<td class="o-table__cell--numeric">7,100</td>
+						<td class="o-table__cell--numeric">49</td>
+						<td class="o-table__cell--numeric">80</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">826</td>
+						<td><a href="http://moravia.com/" data-trackable="link" target="_blank">Moravia</a></td>
+						<td><a href="https://www.ft.com/topics/places/Netherlands" data-trackable="link">Czech
+								Republic</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">184%</td>
+						<td class="o-table__cell--numeric">41.60%</td>
+						<td class="o-table__cell--numeric">143,807</td>
+						<td class="o-table__cell--numeric">605</td>
+						<td class="o-table__cell--numeric">1,215</td>
+						<td>1990</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">827</td>
+						<td><a href="http://https/www.bg-filtration.de/english/" data-trackable="link"
+								target="_blank">bg filtration*</a></td>
+						<td><a href="https://www.ft.com/topics/places/Netherlands" data-trackable="link">Germany</a>
+						</td>
+						<td><a href="https://www.ft.com/companies/industrial-goods" data-trackable="link">Industrial
+								Goods</a></td>
+						<td class="o-table__cell--numeric">183%</td>
+						<td class="o-table__cell--numeric">41.50%</td>
+						<td class="o-table__cell--numeric">3,248</td>
+						<td class="o-table__cell--numeric">6</td>
+						<td class="o-table__cell--numeric">23</td>
+						<td>2013</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">828</td>
+						<td><a href="http://acmeo.eu/" data-trackable="link" target="_blank">acmeo</a></td>
+						<td><a href="https://www.ft.com/topics/places/Netherlands" data-trackable="link">Germany</a>
+						</td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">183%</td>
+						<td class="o-table__cell--numeric">41.50%</td>
+						<td class="o-table__cell--numeric">11,633</td>
+						<td class="o-table__cell--numeric">30</td>
+						<td class="o-table__cell--numeric">63</td>
+						<td>2009</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">829</td>
+						<td><a href="http://ptsg.co.uk/" data-trackable="link" target="_blank">Premier Technical
+								Services Group</a></td>
+						<td><a href="https://www.ft.com/topics/places/Netherlands" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">182%</td>
+						<td class="o-table__cell--numeric">41.30%</td>
+						<td class="o-table__cell--numeric">47,988</td>
+						<td class="o-table__cell--numeric">259</td>
+						<td class="o-table__cell--numeric">401</td>
+						<td>2006</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">830</td>
+						<td><a href="http://consultake.com/" data-trackable="link" target="_blank">Consultake</a></td>
+						<td><a href="https://www.ft.com/topics/places/Netherlands" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Management_Consulting"
+								data-trackable="link">Management Consulting</a></td>
+						<td class="o-table__cell--numeric">182%</td>
+						<td class="o-table__cell--numeric">41.30%</td>
+						<td class="o-table__cell--numeric">4,615</td>
+						<td class="o-table__cell--numeric">7</td>
+						<td class="o-table__cell--numeric">22</td>
+						<td>2006</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">831</td>
+						<td><a href="http://quieroenvasar.com/" data-trackable="link" target="_blank">Interactivo Tres
+								Development</a></td>
+						<td><a href="https://www.ft.com/topics/places/Netherlands" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/companies/personal-goods" data-trackable="link">Personal &amp;
+								Household Goods</a></td>
+						<td class="o-table__cell--numeric">182%</td>
+						<td class="o-table__cell--numeric">41.30%</td>
+						<td class="o-table__cell--numeric">2,217</td>
+						<td class="o-table__cell--numeric">2</td>
+						<td class="o-table__cell--numeric">4</td>
+						<td>2008</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">832</td>
+						<td><a href="http://cvbf.net/" data-trackable="link" target="_blank">CVBF</a></td>
+						<td><a href="https://www.ft.com/topics/places/Netherlands" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/companies/pharmaceuticals"
+								data-trackable="link">Pharmaceuticals</a></td>
+						<td class="o-table__cell--numeric">182%</td>
+						<td class="o-table__cell--numeric">41.20%</td>
+						<td class="o-table__cell--numeric">2,861</td>
+						<td class="o-table__cell--numeric">4</td>
+						<td class="o-table__cell--numeric">16</td>
+						<td>2000</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">833</td>
+						<td><a href="http://galenicum.com/" data-trackable="link" target="_blank">Galenicum Special
+								Ingredients</a></td>
+						<td><a href="https://www.ft.com/topics/places/Netherlands" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/companies/health" data-trackable="link">Health</a></td>
+						<td class="o-table__cell--numeric">182%</td>
+						<td class="o-table__cell--numeric">41.20%</td>
+						<td class="o-table__cell--numeric">8,980</td>
+						<td class="o-table__cell--numeric">6</td>
+						<td class="o-table__cell--numeric">9</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">834</td>
+						<td><a href="http://socialmediacom.at/" data-trackable="link" target="_blank">SMC Social Media
+								Communications</a></td>
+						<td><a href="https://www.ft.com/topics/places/Netherlands" data-trackable="link">Austria</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/themes/Advertising" data-trackable="link">Advertising</a>
+						</td>
+						<td class="o-table__cell--numeric">181%</td>
+						<td class="o-table__cell--numeric">41.20%</td>
+						<td class="o-table__cell--numeric">1,500</td>
+						<td class="o-table__cell--numeric">5</td>
+						<td class="o-table__cell--numeric">11</td>
+						<td>1990</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">835</td>
+						<td><a href="http://aspira.ie/" data-trackable="link" target="_blank">AspiraCon (Aspira)</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Netherlands" data-trackable="link">Ireland</a>
+						</td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">181%</td>
+						<td class="o-table__cell--numeric">41.20%</td>
+						<td class="o-table__cell--numeric">5,781</td>
+						<td class="o-table__cell--numeric">30</td>
+						<td class="o-table__cell--numeric">52</td>
+						<td>2007</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">836</td>
+						<td><a href="http://faro.de/" data-trackable="link" target="_blank">faro IMPORT EXPORT</a></td>
+						<td><a href="https://www.ft.com/topics/places/Netherlands" data-trackable="link">Germany</a>
+						</td>
+						<td><a href="https://www.ft.com/companies/telecoms" data-trackable="link">Telecoms</a></td>
+						<td class="o-table__cell--numeric">181%</td>
+						<td class="o-table__cell--numeric">41.20%</td>
+						<td class="o-table__cell--numeric">15,283</td>
+						<td class="o-table__cell--numeric">14</td>
+						<td class="o-table__cell--numeric">30</td>
+						<td>1997</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">837</td>
+						<td><a href="http://catbirdseat.de/" data-trackable="link" target="_blank">Catbird Seat</a></td>
+						<td><a href="https://www.ft.com/topics/places/Netherlands" data-trackable="link">Germany</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/themes/Advertising" data-trackable="link">Advertising</a>
+						</td>
+						<td class="o-table__cell--numeric">181%</td>
+						<td class="o-table__cell--numeric">41.20%</td>
+						<td class="o-table__cell--numeric">10,833</td>
+						<td class="o-table__cell--numeric">27</td>
+						<td class="o-table__cell--numeric">64</td>
+						<td>2009</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">838</td>
+						<td><a href="http://tmb-logistik.de/" data-trackable="link" target="_blank">TMB Logistik</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Netherlands" data-trackable="link">Germany</a>
+						</td>
+						<td><a href="https://www.ft.com/companies/transport" data-trackable="link">Transport</a></td>
+						<td class="o-table__cell--numeric">181%</td>
+						<td class="o-table__cell--numeric">41.10%</td>
+						<td class="o-table__cell--numeric">15,963</td>
+						<td class="o-table__cell--numeric">15</td>
+						<td class="o-table__cell--numeric">45</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">839</td>
+						<td><a href="http://tigergrip.com/" data-trackable="link" target="_blank">Tiger Grip
+								Engineering</a></td>
+						<td><a href="https://www.ft.com/topics/places/Netherlands" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/stream/f9f7535d-3b5c-47a7-bd15-3e10dceee597"
+								data-trackable="link">Fashion</a></td>
+						<td class="o-table__cell--numeric">181%</td>
+						<td class="o-table__cell--numeric">41.10%</td>
+						<td class="o-table__cell--numeric">1,565</td>
+						<td class="o-table__cell--numeric">3</td>
+						<td class="o-table__cell--numeric">6</td>
+						<td>2008</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">840</td>
+						<td><a href="http://tetro.fr/" data-trackable="link" target="_blank">TETRO</a></td>
+						<td><a href="https://www.ft.com/topics/places/Netherlands" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/media" data-trackable="link">Media</a></td>
+						<td class="o-table__cell--numeric">181%</td>
+						<td class="o-table__cell--numeric">41.10%</td>
+						<td class="o-table__cell--numeric">1,769</td>
+						<td class="o-table__cell--numeric">3</td>
+						<td class="o-table__cell--numeric">5</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">841</td>
+						<td><a href="http://ngagemedia.nl/" data-trackable="link" target="_blank">Ngage Media</a></td>
+						<td><a href="https://www.ft.com/topics/places/Netherlands" data-trackable="link">The
+								Netherlands</a></td>
+						<td><a href="https://www.ft.com/companies/media" data-trackable="link">Media</a></td>
+						<td class="o-table__cell--numeric">180%</td>
+						<td class="o-table__cell--numeric">41%</td>
+						<td class="o-table__cell--numeric">7,721</td>
+						<td class="o-table__cell--numeric">8</td>
+						<td class="o-table__cell--numeric">14</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">842</td>
+						<td><a href="http://mediasapiens.es/" data-trackable="link" target="_blank">Media Sapiens
+								Spain</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Advertising" data-trackable="link">Advertising</a>
+						</td>
+						<td class="o-table__cell--numeric">180%</td>
+						<td class="o-table__cell--numeric">41%</td>
+						<td class="o-table__cell--numeric">6,227</td>
+						<td class="o-table__cell--numeric">9</td>
+						<td class="o-table__cell--numeric">18</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">843</td>
+						<td><a href="http://duettipackaging.com/" data-trackable="link" target="_blank">Duetti
+								Packaging</a></td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/companies/industrial-goods" data-trackable="link">Industrial
+								Goods</a></td>
+						<td class="o-table__cell--numeric">180%</td>
+						<td class="o-table__cell--numeric">41%</td>
+						<td class="o-table__cell--numeric">11,057</td>
+						<td class="o-table__cell--numeric">30</td>
+						<td class="o-table__cell--numeric">44</td>
+						<td>2008</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">844</td>
+						<td><a href="http://selenium-medical.com/" data-trackable="link" target="_blank">Selenium
+								Medical</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/health" data-trackable="link">Health</a></td>
+						<td class="o-table__cell--numeric">179%</td>
+						<td class="o-table__cell--numeric">40.90%</td>
+						<td class="o-table__cell--numeric">4,058</td>
+						<td class="o-table__cell--numeric">28</td>
+						<td class="o-table__cell--numeric">52</td>
+						<td>2008</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">845</td>
+						<td>Industrialisation et Développement</td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/automobiles" data-trackable="link">Automobiles</a>
+						</td>
+						<td class="o-table__cell--numeric">179%</td>
+						<td class="o-table__cell--numeric">40.80%</td>
+						<td class="o-table__cell--numeric">6,182</td>
+						<td class="o-table__cell--numeric">10</td>
+						<td class="o-table__cell--numeric">25</td>
+						<td>1988</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">846</td>
+						<td><a href="http://vo2-group.com/" data-trackable="link" target="_blank">Vo2 Group</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">179%</td>
+						<td class="o-table__cell--numeric">40.80%</td>
+						<td class="o-table__cell--numeric">13,686</td>
+						<td class="o-table__cell--numeric">60</td>
+						<td class="o-table__cell--numeric">80</td>
+						<td>2005</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">847</td>
+						<td><a href="http://buratti.at/" data-trackable="link" target="_blank">Buratti</a></td>
+						<td><a href="https://www.ft.com/topics/places/Austria" data-trackable="link">Austria</a></td>
+						<td><a href="https://www.ft.com/companies/food-beverage" data-trackable="link">Food &amp;
+								Beverage</a></td>
+						<td class="o-table__cell--numeric">179%</td>
+						<td class="o-table__cell--numeric">40.80%</td>
+						<td class="o-table__cell--numeric">3,396</td>
+						<td class="o-table__cell--numeric">5</td>
+						<td class="o-table__cell--numeric">12</td>
+						<td>1993</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">848</td>
+						<td><a href="http://arcure.net/" data-trackable="link" target="_blank">Arcure</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">179%</td>
+						<td class="o-table__cell--numeric">40.80%</td>
+						<td class="o-table__cell--numeric">2,800</td>
+						<td class="o-table__cell--numeric">3</td>
+						<td class="o-table__cell--numeric">18</td>
+						<td>2009</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">849</td>
+						<td><a href="http://contentserv.de/" data-trackable="link" target="_blank">CONTENTSERV</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">179%</td>
+						<td class="o-table__cell--numeric">40.80%</td>
+						<td class="o-table__cell--numeric">14,500</td>
+						<td class="o-table__cell--numeric">165</td>
+						<td class="o-table__cell--numeric">210</td>
+						<td>1999</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">850</td>
+						<td><a href="http://ncd-ingredients.de/" data-trackable="link" target="_blank">NCD
+								Ingredients*</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/chemicals" data-trackable="link">Chemicals</a></td>
+						<td class="o-table__cell--numeric">178%</td>
+						<td class="o-table__cell--numeric">40.70%</td>
+						<td class="o-table__cell--numeric">4,650</td>
+						<td class="o-table__cell--numeric">4</td>
+						<td class="o-table__cell--numeric">8</td>
+						<td>2013</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">851</td>
+						<td><a href="http://htt.it/" data-trackable="link" target="_blank">HT&amp;T Consulting</a></td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">178%</td>
+						<td class="o-table__cell--numeric">40.60%</td>
+						<td class="o-table__cell--numeric">1,979</td>
+						<td class="o-table__cell--numeric">3</td>
+						<td class="o-table__cell--numeric">6</td>
+						<td>2000</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">852</td>
+						<td><a href="http://extendam.com/" data-trackable="link" target="_blank">Extendam</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/financial-services" data-trackable="link">Financial
+								Services</a></td>
+						<td class="o-table__cell--numeric">178%</td>
+						<td class="o-table__cell--numeric">40.50%</td>
+						<td class="o-table__cell--numeric">18,022</td>
+						<td class="o-table__cell--numeric">10</td>
+						<td class="o-table__cell--numeric">23</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">853</td>
+						<td><a href="http://tbspain.es/" data-trackable="link" target="_blank">Thomas Business Spain</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/companies/personal-goods" data-trackable="link">Personal &amp;
+								Household Goods</a></td>
+						<td class="o-table__cell--numeric">177%</td>
+						<td class="o-table__cell--numeric">40.50%</td>
+						<td class="o-table__cell--numeric">8,865</td>
+						<td class="o-table__cell--numeric">1</td>
+						<td class="o-table__cell--numeric">2</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">854</td>
+						<td><a href="http://wallix.com/" data-trackable="link" target="_blank">Wallix</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Cyber_Security" data-trackable="link">Cyber
+								Security</a></td>
+						<td class="o-table__cell--numeric">177%</td>
+						<td class="o-table__cell--numeric">40.40%</td>
+						<td class="o-table__cell--numeric">7,364</td>
+						<td class="o-table__cell--numeric">31</td>
+						<td class="o-table__cell--numeric">64</td>
+						<td>2003</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">855</td>
+						<td><a href="http://77onlineshop.de/" data-trackable="link" target="_blank">Styleboom
+								Textilhandel</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Ecommerce" data-trackable="link">Ecommerce</a>
+						</td>
+						<td class="o-table__cell--numeric">176%</td>
+						<td class="o-table__cell--numeric">40.30%</td>
+						<td class="o-table__cell--numeric">26,535</td>
+						<td class="o-table__cell--numeric">61</td>
+						<td class="o-table__cell--numeric">110</td>
+						<td>2009</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">856</td>
+						<td><a href="http://aundg.com/" data-trackable="link" target="_blank">a&amp;g automation and
+								gears</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/industrial-goods" data-trackable="link">Industrial
+								Goods</a></td>
+						<td class="o-table__cell--numeric">176%</td>
+						<td class="o-table__cell--numeric">40.30%</td>
+						<td class="o-table__cell--numeric">2,429</td>
+						<td class="o-table__cell--numeric">0</td>
+						<td class="o-table__cell--numeric">5</td>
+						<td>2004</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">857</td>
+						<td><a href="http://atollspeed.eu/" data-trackable="link" target="_blank">Atollspeed</a></td>
+						<td><a href="https://www.ft.com/topics/places/Austria" data-trackable="link">Austria</a></td>
+						<td><a href="https://www.ft.com/companies/industrial-goods" data-trackable="link">Industrial
+								Goods</a></td>
+						<td class="o-table__cell--numeric">176%</td>
+						<td class="o-table__cell--numeric">40.20%</td>
+						<td class="o-table__cell--numeric">4,923</td>
+						<td class="o-table__cell--numeric">3</td>
+						<td class="o-table__cell--numeric">7</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">858</td>
+						<td><a href="http://autoland.tirol/" data-trackable="link" target="_blank">Autoland PPAT</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Austria" data-trackable="link">Austria</a></td>
+						<td><a href="https://www.ft.com/companies/automobiles" data-trackable="link">Automobiles</a>
+						</td>
+						<td class="o-table__cell--numeric">176%</td>
+						<td class="o-table__cell--numeric">40.20%</td>
+						<td class="o-table__cell--numeric">9,417</td>
+						<td class="o-table__cell--numeric">10</td>
+						<td class="o-table__cell--numeric">25</td>
+						<td>2006</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">859</td>
+						<td><a href="http://massarius.com/" data-trackable="link" target="_blank">Massarius</a></td>
+						<td><a href="https://www.ft.com/topics/places/Netherlands" data-trackable="link">The
+								Netherlands</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Advertising" data-trackable="link">Advertising</a>
+						</td>
+						<td class="o-table__cell--numeric">176%</td>
+						<td class="o-table__cell--numeric">40.20%</td>
+						<td class="o-table__cell--numeric">3,041</td>
+						<td class="o-table__cell--numeric">6</td>
+						<td class="o-table__cell--numeric">10</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">860</td>
+						<td><a href="http://superior-electronics.com/" data-trackable="link"
+								target="_blank">Superior</a></td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">175%</td>
+						<td class="o-table__cell--numeric">40.20%</td>
+						<td class="o-table__cell--numeric">2,209</td>
+						<td class="o-table__cell--numeric">2</td>
+						<td class="o-table__cell--numeric">4</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">861</td>
+						<td><a href="http://biltongroup.com/" data-trackable="link" target="_blank">BILTON
+								International</a></td>
+						<td><a href="https://www.ft.com/topics/places/Austria" data-trackable="link">Austria</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">175%</td>
+						<td class="o-table__cell--numeric">40.10%</td>
+						<td class="o-table__cell--numeric">8,990</td>
+						<td class="o-table__cell--numeric">38</td>
+						<td class="o-table__cell--numeric">63</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">862</td>
+						<td><a href="http://harmony-aero.com/" data-trackable="link" target="_blank">Harmony Aerospace
+								France</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/aerospace-defence" data-trackable="link">Aerospace
+								&amp; Defence</a></td>
+						<td class="o-table__cell--numeric">175%</td>
+						<td class="o-table__cell--numeric">40.10%</td>
+						<td class="o-table__cell--numeric">7,504</td>
+						<td class="o-table__cell--numeric">5</td>
+						<td class="o-table__cell--numeric">11</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">863</td>
+						<td><a href="http://greenmangaming.com/" data-trackable="link" target="_blank">Green Man
+								Gaming</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/stream/f9c6d3fe-5e16-479c-b762-bccdeeb349fe"
+								data-trackable="link">Games industry</a></td>
+						<td class="o-table__cell--numeric">175%</td>
+						<td class="o-table__cell--numeric">40.10%</td>
+						<td class="o-table__cell--numeric">45,516</td>
+						<td class="o-table__cell--numeric">28</td>
+						<td class="o-table__cell--numeric">78</td>
+						<td>2009</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">864</td>
+						<td><a href="http://rentalscollection.com/" data-trackable="link" target="_blank">The Rentals
+								Collection</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/companies/travel-leisure" data-trackable="link">Travel &amp;
+								Leisure</a></td>
+						<td class="o-table__cell--numeric">175%</td>
+						<td class="o-table__cell--numeric">40%</td>
+						<td class="o-table__cell--numeric">2,844</td>
+						<td class="o-table__cell--numeric">-7</td>
+						<td class="o-table__cell--numeric">9</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">865</td>
+						<td><a href="http://gar-wpg.com/" data-trackable="link" target="_blank">GAR
+								Wirtschaftsprüfung</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Law" data-trackable="link">Financial Services</a>
+						</td>
+						<td class="o-table__cell--numeric">175%</td>
+						<td class="o-table__cell--numeric">40%</td>
+						<td class="o-table__cell--numeric">2,175</td>
+						<td class="o-table__cell--numeric">11</td>
+						<td class="o-table__cell--numeric">17</td>
+						<td>2009</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">866</td>
+						<td><a href="http://exceltic.com/" data-trackable="link" target="_blank">Exceltic</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">175%</td>
+						<td class="o-table__cell--numeric">40%</td>
+						<td class="o-table__cell--numeric">12,340</td>
+						<td class="o-table__cell--numeric">149</td>
+						<td class="o-table__cell--numeric">231</td>
+						<td>2005</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">867</td>
+						<td><a href="http://cichon-pm.de/" data-trackable="link" target="_blank">Cichon
+								Personalmanagement</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">174%</td>
+						<td class="o-table__cell--numeric">40%</td>
+						<td class="o-table__cell--numeric">9,980</td>
+						<td class="o-table__cell--numeric">22</td>
+						<td class="o-table__cell--numeric">26</td>
+						<td>2009</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">868</td>
+						<td><a href="http://herzog-leasing.ag/" data-trackable="link" target="_blank">Herzog Leasing</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/financial-services" data-trackable="link">Financial
+								Services</a></td>
+						<td class="o-table__cell--numeric">174%</td>
+						<td class="o-table__cell--numeric">39.90%</td>
+						<td class="o-table__cell--numeric">10,360</td>
+						<td class="o-table__cell--numeric">3</td>
+						<td class="o-table__cell--numeric">8</td>
+						<td>2006</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">869</td>
+						<td><a href="http://sfrtrucks.com/" data-trackable="link" target="_blank">Serfri Trucks</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/companies/transport" data-trackable="link">Transport</a></td>
+						<td class="o-table__cell--numeric">173%</td>
+						<td class="o-table__cell--numeric">39.80%</td>
+						<td class="o-table__cell--numeric">17,449</td>
+						<td class="o-table__cell--numeric">28</td>
+						<td class="o-table__cell--numeric">38</td>
+						<td>2007</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">870</td>
+						<td><a href="http://adam-soft.de/" data-trackable="link" target="_blank">Adam Soft</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/retail" data-trackable="link">Retail</a></td>
+						<td class="o-table__cell--numeric">173%</td>
+						<td class="o-table__cell--numeric">39.80%</td>
+						<td class="o-table__cell--numeric">13,281</td>
+						<td class="o-table__cell--numeric">24</td>
+						<td class="o-table__cell--numeric">35</td>
+						<td>1995</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">871</td>
+						<td><a href="http://dc-solution.de/" data-trackable="link" target="_blank">dynamic commerce</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">173%</td>
+						<td class="o-table__cell--numeric">39.70%</td>
+						<td class="o-table__cell--numeric">2,335</td>
+						<td class="o-table__cell--numeric">22</td>
+						<td class="o-table__cell--numeric">36</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">872</td>
+						<td><a href="http://cuisinesmaximabordeaux.fr/" data-trackable="link" target="_blank">SARL A3B
+								Cuisines Maxima</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/retail" data-trackable="link">Retail</a></td>
+						<td class="o-table__cell--numeric">172%</td>
+						<td class="o-table__cell--numeric">39.60%</td>
+						<td class="o-table__cell--numeric">1,648</td>
+						<td class="o-table__cell--numeric">5</td>
+						<td class="o-table__cell--numeric">8</td>
+						<td>2006</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">873</td>
+						<td><a href="http://lbbz.de/" data-trackable="link" target="_blank">LBBZ GmbH</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/automobiles" data-trackable="link">Automobiles</a>
+						</td>
+						<td class="o-table__cell--numeric">172%</td>
+						<td class="o-table__cell--numeric">39.60%</td>
+						<td class="o-table__cell--numeric">12,961</td>
+						<td class="o-table__cell--numeric">26</td>
+						<td class="o-table__cell--numeric">89</td>
+						<td>1991</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">874</td>
+						<td><a href="http://cirruseo.com/" data-trackable="link" target="_blank">Cirruseo</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">172%</td>
+						<td class="o-table__cell--numeric">39.60%</td>
+						<td class="o-table__cell--numeric">4,931</td>
+						<td class="o-table__cell--numeric">19</td>
+						<td class="o-table__cell--numeric">36</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">875</td>
+						<td><a href="http://mit-uns.eu/" data-trackable="link" target="_blank">mit-uns GmbH
+								Personaldienstleist.</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">172%</td>
+						<td class="o-table__cell--numeric">39.60%</td>
+						<td class="o-table__cell--numeric">12,140</td>
+						<td class="o-table__cell--numeric">350</td>
+						<td class="o-table__cell--numeric">600</td>
+						<td>2007</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">876</td>
+						<td><a href="http://af-pack.de/" data-trackable="link" target="_blank">Af Pack</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">172%</td>
+						<td class="o-table__cell--numeric">39.50%</td>
+						<td class="o-table__cell--numeric">29,578</td>
+						<td class="o-table__cell--numeric">26</td>
+						<td class="o-table__cell--numeric">44</td>
+						<td>2008</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">877</td>
+						<td><a href="http://opw-ingredients.com/" data-trackable="link" target="_blank">OPW
+								Ingredients</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/food-beverage" data-trackable="link">Food &amp;
+								Beverage</a></td>
+						<td class="o-table__cell--numeric">171%</td>
+						<td class="o-table__cell--numeric">39.50%</td>
+						<td class="o-table__cell--numeric">19,000</td>
+						<td class="o-table__cell--numeric">17</td>
+						<td class="o-table__cell--numeric">25</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">878</td>
+						<td><a href="http://esglobalsolutions.com/" data-trackable="link" target="_blank">ES Global</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/companies/travel-leisure" data-trackable="link">Travel &amp;
+								Leisure</a></td>
+						<td class="o-table__cell--numeric">171%</td>
+						<td class="o-table__cell--numeric">39.50%</td>
+						<td class="o-table__cell--numeric">11,073</td>
+						<td class="o-table__cell--numeric">-2</td>
+						<td class="o-table__cell--numeric">13</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">879</td>
+						<td><a href="http://intelligencepartner.com/" data-trackable="link" target="_blank">Intelligence
+								Partner</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">171%</td>
+						<td class="o-table__cell--numeric">39.50%</td>
+						<td class="o-table__cell--numeric">6,823</td>
+						<td class="o-table__cell--numeric">24</td>
+						<td class="o-table__cell--numeric">60</td>
+						<td>2009</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">880</td>
+						<td><a href="http://motivationdirect.pl/" data-trackable="link" target="_blank">Motivation
+								Direct</a></td>
+						<td><a href="https://www.ft.com/topics/places/Poland" data-trackable="link">Poland</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Sales_&amp;_Marketing" data-trackable="link">Sales
+								&amp; Marketing</a></td>
+						<td class="o-table__cell--numeric">171%</td>
+						<td class="o-table__cell--numeric">39.50%</td>
+						<td class="o-table__cell--numeric">3,724</td>
+						<td class="o-table__cell--numeric">8</td>
+						<td class="o-table__cell--numeric">15</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">881</td>
+						<td><a href="http://agello.de/" data-trackable="link" target="_blank">Agello Service</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">171%</td>
+						<td class="o-table__cell--numeric">39.40%</td>
+						<td class="o-table__cell--numeric">10,788</td>
+						<td class="o-table__cell--numeric">295</td>
+						<td class="o-table__cell--numeric">479</td>
+						<td>2009</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">882</td>
+						<td><a href="http://sixsentix.com/" data-trackable="link" target="_blank">Sixsentix</a></td>
+						<td><a href="https://www.ft.com/topics/places/Switzerland" data-trackable="link">Switzerland</a>
+						</td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">171%</td>
+						<td class="o-table__cell--numeric">39.40%</td>
+						<td class="o-table__cell--numeric">7,704</td>
+						<td class="o-table__cell--numeric">74</td>
+						<td class="o-table__cell--numeric">111</td>
+						<td>2013</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">883</td>
+						<td><a href="http://nectere.org/" data-trackable="link" target="_blank">Nectere</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">171%</td>
+						<td class="o-table__cell--numeric">39.40%</td>
+						<td class="o-table__cell--numeric">36,633</td>
+						<td class="o-table__cell--numeric">20</td>
+						<td class="o-table__cell--numeric">55</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">884</td>
+						<td><a href="http://via-numerica.net/" data-trackable="link" target="_blank">Via Numerica</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/telecoms" data-trackable="link">Telecoms</a></td>
+						<td class="o-table__cell--numeric">171%</td>
+						<td class="o-table__cell--numeric">39.40%</td>
+						<td class="o-table__cell--numeric">3,358</td>
+						<td class="o-table__cell--numeric">5</td>
+						<td class="o-table__cell--numeric">14</td>
+						<td>2005</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">885</td>
+						<td><a href="http://tower-crane.co.uk/" data-trackable="link" target="_blank">Bennetts
+								Cranes</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/companies/construction" data-trackable="link">Construction</a>
+						</td>
+						<td class="o-table__cell--numeric">171%</td>
+						<td class="o-table__cell--numeric">39.40%</td>
+						<td class="o-table__cell--numeric">13,774</td>
+						<td class="o-table__cell--numeric">12</td>
+						<td class="o-table__cell--numeric">30</td>
+						<td>2008</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">886</td>
+						<td><a href="http://steinmueller.biz/" data-trackable="link" target="_blank">Steinmüller</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/stream/f9f7535d-3b5c-47a7-bd15-3e10dceee597"
+								data-trackable="link">Fashion</a></td>
+						<td class="o-table__cell--numeric">170%</td>
+						<td class="o-table__cell--numeric">39.30%</td>
+						<td class="o-table__cell--numeric">2,181</td>
+						<td class="o-table__cell--numeric">9</td>
+						<td class="o-table__cell--numeric">16</td>
+						<td>2007</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">887</td>
+						<td><a href="http://eypro.de/" data-trackable="link" target="_blank">EYPro Mugrauer &amp;
+								Schnele</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/industrial-goods" data-trackable="link">Industrial
+								Goods</a></td>
+						<td class="o-table__cell--numeric">170%</td>
+						<td class="o-table__cell--numeric">39.30%</td>
+						<td class="o-table__cell--numeric">2,832</td>
+						<td class="o-table__cell--numeric">6</td>
+						<td class="o-table__cell--numeric">14</td>
+						<td>2009</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">888</td>
+						<td><a href="http://pacwan.net/" data-trackable="link" target="_blank">PacWan</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/telecoms" data-trackable="link">Telecoms</a></td>
+						<td class="o-table__cell--numeric">170%</td>
+						<td class="o-table__cell--numeric">39.30%</td>
+						<td class="o-table__cell--numeric">5,915</td>
+						<td class="o-table__cell--numeric">11</td>
+						<td class="o-table__cell--numeric">21</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">889</td>
+						<td><a href="http://i-alarmsysteme.at/" data-trackable="link" target="_blank">i-Alarmsysteme</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Austria" data-trackable="link">Austria</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">170%</td>
+						<td class="o-table__cell--numeric">39.20%</td>
+						<td class="o-table__cell--numeric">9,208</td>
+						<td class="o-table__cell--numeric">11</td>
+						<td class="o-table__cell--numeric">21</td>
+						<td>2008</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">890</td>
+						<td><a href="http://https/www.audleyvillages.co.uk/" data-trackable="link"
+								target="_blank">Audley Group</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/companies/property" data-trackable="link">Property</a></td>
+						<td class="o-table__cell--numeric">170%</td>
+						<td class="o-table__cell--numeric">39.20%</td>
+						<td class="o-table__cell--numeric">113,369</td>
+						<td class="o-table__cell--numeric">110</td>
+						<td class="o-table__cell--numeric">464</td>
+						<td>2004</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">891</td>
+						<td><a href="http://schoofs-frankfurt.de/" data-trackable="link" target="_blank">Schoofs
+								Immobilien</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/property" data-trackable="link">Property</a></td>
+						<td class="o-table__cell--numeric">169%</td>
+						<td class="o-table__cell--numeric">39.10%</td>
+						<td class="o-table__cell--numeric">21,657</td>
+						<td class="o-table__cell--numeric">12</td>
+						<td class="o-table__cell--numeric">39</td>
+						<td>2006</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">892</td>
+						<td><a href="http://onedaygroup.it/" data-trackable="link" target="_blank">One Day</a></td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/companies/media" data-trackable="link">Media</a></td>
+						<td class="o-table__cell--numeric">169%</td>
+						<td class="o-table__cell--numeric">39.10%</td>
+						<td class="o-table__cell--numeric">9,847</td>
+						<td class="o-table__cell--numeric">42</td>
+						<td class="o-table__cell--numeric">50</td>
+						<td>2009</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">893</td>
+						<td><a href="http://nettowelt.de/" data-trackable="link" target="_blank">Nettowelt</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/financial-services" data-trackable="link">Financial
+								Services</a></td>
+						<td class="o-table__cell--numeric">169%</td>
+						<td class="o-table__cell--numeric">39%</td>
+						<td class="o-table__cell--numeric">3,844</td>
+						<td class="o-table__cell--numeric">1</td>
+						<td class="o-table__cell--numeric">8</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">894</td>
+						<td><a href="http://lucasuk.com/" data-trackable="link" target="_blank">Lucas UK</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/companies/construction" data-trackable="link">Construction</a>
+						</td>
+						<td class="o-table__cell--numeric">169%</td>
+						<td class="o-table__cell--numeric">39%</td>
+						<td class="o-table__cell--numeric">36,123</td>
+						<td class="o-table__cell--numeric">12</td>
+						<td class="o-table__cell--numeric">44</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">895</td>
+						<td><a href="http://reischsprengtechnik-gmbh.de/" data-trackable="link" target="_blank">Reisch
+								Sprengtechnik</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/construction" data-trackable="link">Construction</a>
+						</td>
+						<td class="o-table__cell--numeric">168%</td>
+						<td class="o-table__cell--numeric">39%</td>
+						<td class="o-table__cell--numeric">2,134</td>
+						<td class="o-table__cell--numeric">4</td>
+						<td class="o-table__cell--numeric">19</td>
+						<td>1999</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">896</td>
+						<td><a href="http://eco-shopper.it/" data-trackable="link" target="_blank">2win SRL</a></td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/companies/industrial-goods" data-trackable="link">Industrial
+								Goods</a></td>
+						<td class="o-table__cell--numeric">167%</td>
+						<td class="o-table__cell--numeric">38.70%</td>
+						<td class="o-table__cell--numeric">2,586</td>
+						<td class="o-table__cell--numeric">1</td>
+						<td class="o-table__cell--numeric">2</td>
+						<td>2009</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">897</td>
+						<td><a href="http://https/www.marcel-et-fils.com" data-trackable="link"
+								target="_blank">Marcel&amp;fils</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/retail" data-trackable="link">Retail</a></td>
+						<td class="o-table__cell--numeric">167%</td>
+						<td class="o-table__cell--numeric">38.70%</td>
+						<td class="o-table__cell--numeric">33,900</td>
+						<td class="o-table__cell--numeric">94</td>
+						<td class="o-table__cell--numeric">155</td>
+						<td>2008</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">898</td>
+						<td><a href="http://dcfordata.com/" data-trackable="link" target="_blank">DCforData</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">167%</td>
+						<td class="o-table__cell--numeric">38.70%</td>
+						<td class="o-table__cell--numeric">1,908</td>
+						<td class="o-table__cell--numeric">2</td>
+						<td class="o-table__cell--numeric">6</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">899</td>
+						<td><a href="http://cargointernational.de/" data-trackable="link" target="_blank">Cargo
+								International</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/transport" data-trackable="link">Transport</a></td>
+						<td class="o-table__cell--numeric">167%</td>
+						<td class="o-table__cell--numeric">38.70%</td>
+						<td class="o-table__cell--numeric">4,000</td>
+						<td class="o-table__cell--numeric">3</td>
+						<td class="o-table__cell--numeric">10</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">900</td>
+						<td><a href="http://wito.pro/" data-trackable="link" target="_blank">WITO</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/construction" data-trackable="link">Construction</a>
+						</td>
+						<td class="o-table__cell--numeric">167%</td>
+						<td class="o-table__cell--numeric">38.70%</td>
+						<td class="o-table__cell--numeric">2,927</td>
+						<td class="o-table__cell--numeric">11</td>
+						<td class="o-table__cell--numeric">17</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">901</td>
+						<td><a href="http://ksg-logistics.eu/" data-trackable="link" target="_blank">KSG Logistics</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Austria" data-trackable="link">Austria</a></td>
+						<td><a href="https://www.ft.com/companies/transport" data-trackable="link">Transport</a></td>
+						<td class="o-table__cell--numeric">166%</td>
+						<td class="o-table__cell--numeric">38.60%</td>
+						<td class="o-table__cell--numeric">6,947</td>
+						<td class="o-table__cell--numeric">3</td>
+						<td class="o-table__cell--numeric">9</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">902</td>
+						<td><a href="http://persofort.de/" data-trackable="link" target="_blank">persofort PDL</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">166%</td>
+						<td class="o-table__cell--numeric">38.50%</td>
+						<td class="o-table__cell--numeric">4,363</td>
+						<td class="o-table__cell--numeric">79</td>
+						<td class="o-table__cell--numeric">135</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">903</td>
+						<td><a href="http://gevekom.de/" data-trackable="link" target="_blank">gevekom</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">166%</td>
+						<td class="o-table__cell--numeric">38.50%</td>
+						<td class="o-table__cell--numeric">9,982</td>
+						<td class="o-table__cell--numeric">217</td>
+						<td class="o-table__cell--numeric">380</td>
+						<td>2006</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">904</td>
+						<td><a href="http://liebeautos.de/" data-trackable="link" target="_blank">Autohaus Liebe</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/automobiles" data-trackable="link">Automobiles</a>
+						</td>
+						<td class="o-table__cell--numeric">165%</td>
+						<td class="o-table__cell--numeric">38.40%</td>
+						<td class="o-table__cell--numeric">21,032</td>
+						<td class="o-table__cell--numeric">9</td>
+						<td class="o-table__cell--numeric">30</td>
+						<td>2000</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">905</td>
+						<td><a href="http://e-service-check.de/" data-trackable="link"
+								target="_blank">E+Service+Check</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">165%</td>
+						<td class="o-table__cell--numeric">38.40%</td>
+						<td class="o-table__cell--numeric">5,291</td>
+						<td class="o-table__cell--numeric">40</td>
+						<td class="o-table__cell--numeric">95</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">906</td>
+						<td><a href="http://privis.at/" data-trackable="link" target="_blank">Privis</a></td>
+						<td><a href="https://www.ft.com/topics/places/Austria" data-trackable="link">Austria</a></td>
+						<td><a href="https://www.ft.com/companies/property" data-trackable="link">Property</a></td>
+						<td class="o-table__cell--numeric">165%</td>
+						<td class="o-table__cell--numeric">38.30%</td>
+						<td class="o-table__cell--numeric">4,500</td>
+						<td class="o-table__cell--numeric">31</td>
+						<td class="o-table__cell--numeric">45</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">907</td>
+						<td><a href="http://diamond-toolingsystems.com/" data-trackable="link" target="_blank">DTS</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/industrial-goods" data-trackable="link">Industrial
+								Goods</a></td>
+						<td class="o-table__cell--numeric">164%</td>
+						<td class="o-table__cell--numeric">38.30%</td>
+						<td class="o-table__cell--numeric">4,462</td>
+						<td class="o-table__cell--numeric">26</td>
+						<td class="o-table__cell--numeric">31</td>
+						<td>2009</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">908</td>
+						<td><a href="http://energysolutions24.de/" data-trackable="link"
+								target="_blank">energysolutions24</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/energy" data-trackable="link">Energy</a></td>
+						<td class="o-table__cell--numeric">164%</td>
+						<td class="o-table__cell--numeric">38.30%</td>
+						<td class="o-table__cell--numeric">4,198</td>
+						<td class="o-table__cell--numeric">2</td>
+						<td class="o-table__cell--numeric">10</td>
+						<td>2008</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">909</td>
+						<td><a href="http://e-logik.fr/" data-trackable="link" target="_blank">e-LOGIK</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/transport" data-trackable="link">Transport</a></td>
+						<td class="o-table__cell--numeric">164%</td>
+						<td class="o-table__cell--numeric">38.30%</td>
+						<td class="o-table__cell--numeric">5,155</td>
+						<td class="o-table__cell--numeric">6</td>
+						<td class="o-table__cell--numeric">26</td>
+						<td>2008</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">910</td>
+						<td><a href="http://amido.com/" data-trackable="link" target="_blank">Amido</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">164%</td>
+						<td class="o-table__cell--numeric">38.20%</td>
+						<td class="o-table__cell--numeric">6,552</td>
+						<td class="o-table__cell--numeric">30</td>
+						<td class="o-table__cell--numeric">55</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">911</td>
+						<td><a href="http://for4you.at/" data-trackable="link" target="_blank">For 4 You</a></td>
+						<td><a href="https://www.ft.com/topics/places/Austria" data-trackable="link">Austria</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Ecommerce" data-trackable="link">Ecommerce</a>
+						</td>
+						<td class="o-table__cell--numeric">164%</td>
+						<td class="o-table__cell--numeric">38.20%</td>
+						<td class="o-table__cell--numeric">2,611</td>
+						<td class="o-table__cell--numeric">8</td>
+						<td class="o-table__cell--numeric">18</td>
+						<td>2004</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">912</td>
+						<td><a href="http://april.studio/" data-trackable="link" target="_blank">APRIL</a></td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Advertising" data-trackable="link">Advertising</a>
+						</td>
+						<td class="o-table__cell--numeric">164%</td>
+						<td class="o-table__cell--numeric">38.10%</td>
+						<td class="o-table__cell--numeric">2,242</td>
+						<td class="o-table__cell--numeric">4</td>
+						<td class="o-table__cell--numeric">5</td>
+						<td>2008</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">913</td>
+						<td><a href="http://phmg.com/" data-trackable="link" target="_blank">PHMG</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Advertising" data-trackable="link">Advertising</a>
+						</td>
+						<td class="o-table__cell--numeric">164%</td>
+						<td class="o-table__cell--numeric">38.10%</td>
+						<td class="o-table__cell--numeric">35,936</td>
+						<td class="o-table__cell--numeric">247</td>
+						<td class="o-table__cell--numeric">420</td>
+						<td>1998</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">914</td>
+						<td><a href="http://quanteam.fr/" data-trackable="link" target="_blank">Quanteam</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/financial-services" data-trackable="link">Financial
+								Services</a></td>
+						<td class="o-table__cell--numeric">163%</td>
+						<td class="o-table__cell--numeric">38.10%</td>
+						<td class="o-table__cell--numeric">54,000</td>
+						<td class="o-table__cell--numeric">419</td>
+						<td class="o-table__cell--numeric">617</td>
+						<td>2007</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">915</td>
+						<td><a href="http://qosenergy.com/" data-trackable="link" target="_blank">QOS Energy</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">163%</td>
+						<td class="o-table__cell--numeric">38%</td>
+						<td class="o-table__cell--numeric">1,521</td>
+						<td class="o-table__cell--numeric">16</td>
+						<td class="o-table__cell--numeric">25</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">916</td>
+						<td><a href="http://prianto.com/" data-trackable="link" target="_blank">Prianto</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/retail" data-trackable="link">Retail</a></td>
+						<td class="o-table__cell--numeric">163%</td>
+						<td class="o-table__cell--numeric">38%</td>
+						<td class="o-table__cell--numeric">56,159</td>
+						<td class="o-table__cell--numeric">24</td>
+						<td class="o-table__cell--numeric">56</td>
+						<td>2005</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">917</td>
+						<td><a href="http://metallhandel-berlin.de/" data-trackable="link" target="_blank">MG Handel</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/industrial-goods" data-trackable="link">Industrial
+								Goods</a></td>
+						<td class="o-table__cell--numeric">163%</td>
+						<td class="o-table__cell--numeric">38%</td>
+						<td class="o-table__cell--numeric">6,700</td>
+						<td class="o-table__cell--numeric">4</td>
+						<td class="o-table__cell--numeric">6</td>
+						<td>2006</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">918</td>
+						<td><a href="http://bnova.it/" data-trackable="link" target="_blank">Bnova</a></td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">163%</td>
+						<td class="o-table__cell--numeric">38%</td>
+						<td class="o-table__cell--numeric">2,655</td>
+						<td class="o-table__cell--numeric">24</td>
+						<td class="o-table__cell--numeric">35</td>
+						<td>2006</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">919</td>
+						<td><a href="http://r-evolutionvoyages.com/" data-trackable="link" target="_blank">(R)Evolution
+								Voyages</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/travel-leisure" data-trackable="link">Travel &amp;
+								Leisure</a></td>
+						<td class="o-table__cell--numeric">163%</td>
+						<td class="o-table__cell--numeric">38%</td>
+						<td class="o-table__cell--numeric">7,184</td>
+						<td class="o-table__cell--numeric">7</td>
+						<td class="o-table__cell--numeric">15</td>
+						<td>2006</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">920</td>
+						<td><a href="http://panelsandwich.com/" data-trackable="link" target="_blank">Panel Sandwich
+								Group</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/companies/retail" data-trackable="link">Retail</a></td>
+						<td class="o-table__cell--numeric">162%</td>
+						<td class="o-table__cell--numeric">37.90%</td>
+						<td class="o-table__cell--numeric">3,006</td>
+						<td class="o-table__cell--numeric">5</td>
+						<td class="o-table__cell--numeric">6</td>
+						<td>2009</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">921</td>
+						<td><a href="http://woodall-nocholson.co.uk/" data-trackable="link" target="_blank">Woodall
+								Nicholson Holdings*</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/companies/automobiles" data-trackable="link">Automobiles</a>
+						</td>
+						<td class="o-table__cell--numeric">162%</td>
+						<td class="o-table__cell--numeric">37.90%</td>
+						<td class="o-table__cell--numeric">41,512</td>
+						<td class="o-table__cell--numeric">47</td>
+						<td class="o-table__cell--numeric">249</td>
+						<td>2013</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">922</td>
+						<td><a href="http://skargardstunnan.se/" data-trackable="link" target="_blank">Badtunna
+								Skärgårdstunnan</a></td>
+						<td><a href="https://www.ft.com/topics/places/Sweden" data-trackable="link">Sweden</a></td>
+						<td><a href="https://www.ft.com/companies/personal-goods" data-trackable="link">Personal &amp;
+								Household Goods</a></td>
+						<td class="o-table__cell--numeric">162%</td>
+						<td class="o-table__cell--numeric">37.90%</td>
+						<td class="o-table__cell--numeric">4,761</td>
+						<td class="o-table__cell--numeric">6</td>
+						<td class="o-table__cell--numeric">11</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">923</td>
+						<td><a href="http://strato-personal.de/" data-trackable="link" target="_blank">STRATO
+								Personal</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">162%</td>
+						<td class="o-table__cell--numeric">37.80%</td>
+						<td class="o-table__cell--numeric">4,744</td>
+						<td class="o-table__cell--numeric">4</td>
+						<td class="o-table__cell--numeric">8</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">924</td>
+						<td><a href="http://consense-as.de/" data-trackable="link" target="_blank">Consense</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/transport" data-trackable="link">Transport</a></td>
+						<td class="o-table__cell--numeric">162%</td>
+						<td class="o-table__cell--numeric">37.80%</td>
+						<td class="o-table__cell--numeric">3,400</td>
+						<td class="o-table__cell--numeric">3</td>
+						<td class="o-table__cell--numeric">8</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">925</td>
+						<td><a href="http://finlibera.it/" data-trackable="link" target="_blank">Finlibera</a></td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/companies/property" data-trackable="link">Property</a></td>
+						<td class="o-table__cell--numeric">161%</td>
+						<td class="o-table__cell--numeric">37.80%</td>
+						<td class="o-table__cell--numeric">2,693</td>
+						<td class="o-table__cell--numeric">6</td>
+						<td class="o-table__cell--numeric">7</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">926</td>
+						<td><a href="http://dft-ag.de/" data-trackable="link" target="_blank">DFT Deutsche
+								Finetrading</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/financial-services" data-trackable="link">Financial
+								Services</a></td>
+						<td class="o-table__cell--numeric">161%</td>
+						<td class="o-table__cell--numeric">37.70%</td>
+						<td class="o-table__cell--numeric">15,087</td>
+						<td class="o-table__cell--numeric">4</td>
+						<td class="o-table__cell--numeric">10</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">927</td>
+						<td><a href="http://profino.net/" data-trackable="link" target="_blank">PROFINO</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/retail" data-trackable="link">Retail</a></td>
+						<td class="o-table__cell--numeric">161%</td>
+						<td class="o-table__cell--numeric">37.60%</td>
+						<td class="o-table__cell--numeric">3,227</td>
+						<td class="o-table__cell--numeric">2</td>
+						<td class="o-table__cell--numeric">9</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">928</td>
+						<td><a href="http://elvis-ag.com/" data-trackable="link" target="_blank">E.L.V.I.S.
+								Teilladungssystem</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/transport" data-trackable="link">Transport</a></td>
+						<td class="o-table__cell--numeric">160%</td>
+						<td class="o-table__cell--numeric">37.60%</td>
+						<td class="o-table__cell--numeric">19,583</td>
+						<td class="o-table__cell--numeric">17</td>
+						<td class="o-table__cell--numeric">31</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">929</td>
+						<td><a href="http://bueromarkt-ag.de/" data-trackable="link" target="_blank">Büromarkt
+								Böttcher</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Ecommerce" data-trackable="link">Ecommerce</a>
+						</td>
+						<td class="o-table__cell--numeric">160%</td>
+						<td class="o-table__cell--numeric">37.50%</td>
+						<td class="o-table__cell--numeric">216,000</td>
+						<td class="o-table__cell--numeric">128</td>
+						<td class="o-table__cell--numeric">300</td>
+						<td>2001</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">930</td>
+						<td><a href="http://moo.com/" data-trackable="link" target="_blank">MOO Print</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/companies/media" data-trackable="link">Media</a></td>
+						<td class="o-table__cell--numeric">160%</td>
+						<td class="o-table__cell--numeric">37.50%</td>
+						<td class="o-table__cell--numeric">91,888</td>
+						<td class="o-table__cell--numeric">223</td>
+						<td class="o-table__cell--numeric">392</td>
+						<td>2004</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">931</td>
+						<td><a href="http://https/www.bos-amenagement.com/" data-trackable="link" target="_blank">BOS
+								Aménagement</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/house-home/interiors" data-trackable="link">Interiors</a></td>
+						<td class="o-table__cell--numeric">159%</td>
+						<td class="o-table__cell--numeric">37.30%</td>
+						<td class="o-table__cell--numeric">2,035</td>
+						<td class="o-table__cell--numeric">3</td>
+						<td class="o-table__cell--numeric">8</td>
+						<td>2007</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">932</td>
+						<td><a href="http://flowmon.com/" data-trackable="link" target="_blank">Flowmon Networks</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Czech_Republic" data-trackable="link">Czech
+								Republic</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Cyber_Security" data-trackable="link">Cyber
+								Security</a></td>
+						<td class="o-table__cell--numeric">159%</td>
+						<td class="o-table__cell--numeric">37.30%</td>
+						<td class="o-table__cell--numeric">5,598</td>
+						<td class="o-table__cell--numeric">27</td>
+						<td class="o-table__cell--numeric">51</td>
+						<td>2007</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">933</td>
+						<td><a href="http://longitude.co.uk/" data-trackable="link" target="_blank">Longitude
+								Research**</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/companies/media" data-trackable="link">Media</a></td>
+						<td class="o-table__cell--numeric">159%</td>
+						<td class="o-table__cell--numeric">37.30%</td>
+						<td class="o-table__cell--numeric">5,023</td>
+						<td class="o-table__cell--numeric">17</td>
+						<td class="o-table__cell--numeric">22</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">934</td>
+						<td><a href="http://dexturis.de/" data-trackable="link" target="_blank">Dexturis-Bau</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/construction" data-trackable="link">Construction</a>
+						</td>
+						<td class="o-table__cell--numeric">159%</td>
+						<td class="o-table__cell--numeric">37.30%</td>
+						<td class="o-table__cell--numeric">8,739</td>
+						<td class="o-table__cell--numeric">4</td>
+						<td class="o-table__cell--numeric">8</td>
+						<td>2008</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">935</td>
+						<td><a href="http://ixds.com/" data-trackable="link" target="_blank">IXDS</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Advertising" data-trackable="link">Advertising</a>
+						</td>
+						<td class="o-table__cell--numeric">158%</td>
+						<td class="o-table__cell--numeric">37.20%</td>
+						<td class="o-table__cell--numeric">6,200</td>
+						<td class="o-table__cell--numeric">44</td>
+						<td class="o-table__cell--numeric">80</td>
+						<td>2009</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">936</td>
+						<td><a href="http://gpflewis.co.uk/" data-trackable="link" target="_blank">GPF Lewis</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/companies/construction" data-trackable="link">Construction</a>
+						</td>
+						<td class="o-table__cell--numeric">158%</td>
+						<td class="o-table__cell--numeric">37.20%</td>
+						<td class="o-table__cell--numeric">25,392</td>
+						<td class="o-table__cell--numeric">5</td>
+						<td class="o-table__cell--numeric">33</td>
+						<td>2006</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">937</td>
+						<td><a href="http://benjamins.it/" data-trackable="link" target="_blank">Benjamins</a></td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">158%</td>
+						<td class="o-table__cell--numeric">37.10%</td>
+						<td class="o-table__cell--numeric">2,280</td>
+						<td class="o-table__cell--numeric">4</td>
+						<td class="o-table__cell--numeric">7</td>
+						<td>2009</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">938</td>
+						<td><a href="http://fiagon.de/" data-trackable="link" target="_blank">Fiagon</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/health" data-trackable="link">Health</a></td>
+						<td class="o-table__cell--numeric">157%</td>
+						<td class="o-table__cell--numeric">37%</td>
+						<td class="o-table__cell--numeric">7,200</td>
+						<td class="o-table__cell--numeric">45</td>
+						<td class="o-table__cell--numeric">69</td>
+						<td>2007</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">939</td>
+						<td><a href="http://everymancinema.com/" data-trackable="link" target="_blank">Everyman Media
+								Group</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/companies/travel-leisure" data-trackable="link">Travel &amp;
+								Leisure</a></td>
+						<td class="o-table__cell--numeric">157%</td>
+						<td class="o-table__cell--numeric">36.90%</td>
+						<td class="o-table__cell--numeric">36,184</td>
+						<td class="o-table__cell--numeric">364</td>
+						<td class="o-table__cell--numeric">600</td>
+						<td>1933</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">940</td>
+						<td><a href="http://ecogam.fr/" data-trackable="link" target="_blank">EcoGam</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Waste_management_&amp;_recycling"
+								data-trackable="link">Waste management &amp; recycling</a></td>
+						<td class="o-table__cell--numeric">157%</td>
+						<td class="o-table__cell--numeric">36.90%</td>
+						<td class="o-table__cell--numeric">4,461</td>
+						<td class="o-table__cell--numeric">0</td>
+						<td class="o-table__cell--numeric">11</td>
+						<td>2008</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">941</td>
+						<td><a href="http://sebotherm.de/" data-trackable="link" target="_blank">SeboTherm</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/construction" data-trackable="link">Construction</a>
+						</td>
+						<td class="o-table__cell--numeric">157%</td>
+						<td class="o-table__cell--numeric">36.90%</td>
+						<td class="o-table__cell--numeric">6,821</td>
+						<td class="o-table__cell--numeric">33</td>
+						<td class="o-table__cell--numeric">36</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">942</td>
+						<td><a href="http://sbprocess.fr/" data-trackable="link" target="_blank">SBPprocess</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">156%</td>
+						<td class="o-table__cell--numeric">36.80%</td>
+						<td class="o-table__cell--numeric">2,788</td>
+						<td class="o-table__cell--numeric">n/a</td>
+						<td class="o-table__cell--numeric">10</td>
+						<td>2009</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">943</td>
+						<td><a href="http://compax.at/" data-trackable="link" target="_blank">Compax Software
+								Development</a></td>
+						<td><a href="https://www.ft.com/topics/places/Austria" data-trackable="link">Austria</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">156%</td>
+						<td class="o-table__cell--numeric">36.70%</td>
+						<td class="o-table__cell--numeric">16,900</td>
+						<td class="o-table__cell--numeric">67</td>
+						<td class="o-table__cell--numeric">125</td>
+						<td>2004</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">944</td>
+						<td><a href="http://viajesinsularcorporativo.com/" data-trackable="link" target="_blank">Viajes
+								Insular</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/companies/travel-leisure" data-trackable="link">Travel &amp;
+								Leisure</a></td>
+						<td class="o-table__cell--numeric">156%</td>
+						<td class="o-table__cell--numeric">36.70%</td>
+						<td class="o-table__cell--numeric">12,806</td>
+						<td class="o-table__cell--numeric">15</td>
+						<td class="o-table__cell--numeric">85</td>
+						<td>1961</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">945</td>
+						<td><a href="http://veserkal.com/" data-trackable="link" target="_blank">Tesi Industrial
+								Europa</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/companies/industrial-goods" data-trackable="link">Industrial
+								Goods</a></td>
+						<td class="o-table__cell--numeric">156%</td>
+						<td class="o-table__cell--numeric">36.70%</td>
+						<td class="o-table__cell--numeric">4,228</td>
+						<td class="o-table__cell--numeric">36</td>
+						<td class="o-table__cell--numeric">54</td>
+						<td>1996</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">946</td>
+						<td><a href="http://atsp.com/" data-trackable="link" target="_blank">AT Solution Partner</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Austria" data-trackable="link">Austria</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">155%</td>
+						<td class="o-table__cell--numeric">36.70%</td>
+						<td class="o-table__cell--numeric">6,793</td>
+						<td class="o-table__cell--numeric">17</td>
+						<td class="o-table__cell--numeric">36</td>
+						<td>2002</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">947</td>
+						<td><a href="http://caffeborbone.it/" data-trackable="link" target="_blank">L'Aromatika Srl</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/companies/food-beverage" data-trackable="link">Food &amp;
+								Beverage</a></td>
+						<td class="o-table__cell--numeric">155%</td>
+						<td class="o-table__cell--numeric">36.60%</td>
+						<td class="o-table__cell--numeric">7,625</td>
+						<td class="o-table__cell--numeric">60</td>
+						<td class="o-table__cell--numeric">91</td>
+						<td>1996</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">948</td>
+						<td><a href="http://imprendiroma.it/" data-trackable="link" target="_blank">Imprendiroma</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/companies/construction" data-trackable="link">Construction</a>
+						</td>
+						<td class="o-table__cell--numeric">155%</td>
+						<td class="o-table__cell--numeric">36.60%</td>
+						<td class="o-table__cell--numeric">2,696</td>
+						<td class="o-table__cell--numeric">7</td>
+						<td class="o-table__cell--numeric">17</td>
+						<td>2008</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">949</td>
+						<td><a href="http://bhtsrl.com/" data-trackable="link" target="_blank">BHT</a></td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/companies/industrial-goods" data-trackable="link">Industrial
+								Goods</a></td>
+						<td class="o-table__cell--numeric">155%</td>
+						<td class="o-table__cell--numeric">36.60%</td>
+						<td class="o-table__cell--numeric">1,795</td>
+						<td class="o-table__cell--numeric">5</td>
+						<td class="o-table__cell--numeric">12</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">950</td>
+						<td><a href="http://aldoveacatering.com/" data-trackable="link" target="_blank">Aldovea</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/restaurants" data-trackable="link">Restaurants</a></td>
+						<td class="o-table__cell--numeric">155%</td>
+						<td class="o-table__cell--numeric">36.50%</td>
+						<td class="o-table__cell--numeric">1,811</td>
+						<td class="o-table__cell--numeric">3</td>
+						<td class="o-table__cell--numeric">18</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">951</td>
+						<td><a href="http://lb-solutions.de/" data-trackable="link" target="_blank">l&amp;b
+								solutions</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Management_Consulting"
+								data-trackable="link">Management Consulting</a></td>
+						<td class="o-table__cell--numeric">154%</td>
+						<td class="o-table__cell--numeric">36.50%</td>
+						<td class="o-table__cell--numeric">4,986</td>
+						<td class="o-table__cell--numeric">20</td>
+						<td class="o-table__cell--numeric">35</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">952</td>
+						<td>Occarent</td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/transport" data-trackable="link">Transport</a></td>
+						<td class="o-table__cell--numeric">154%</td>
+						<td class="o-table__cell--numeric">36.50%</td>
+						<td class="o-table__cell--numeric">3,209</td>
+						<td class="o-table__cell--numeric">0</td>
+						<td class="o-table__cell--numeric">2</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">953</td>
+						<td><a href="http://sgpuk.com/" data-trackable="link" target="_blank">Smart Garden Products</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/companies/personal-goods" data-trackable="link">Personal &amp;
+								Household Goods</a></td>
+						<td class="o-table__cell--numeric">154%</td>
+						<td class="o-table__cell--numeric">36.50%</td>
+						<td class="o-table__cell--numeric">33,657</td>
+						<td class="o-table__cell--numeric">40</td>
+						<td class="o-table__cell--numeric">62</td>
+						<td>2003</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">954</td>
+						<td><a href="http://castasrl.it/" data-trackable="link" target="_blank">Casta</a></td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/companies/industrial-goods" data-trackable="link">Industrial
+								Goods</a></td>
+						<td class="o-table__cell--numeric">153%</td>
+						<td class="o-table__cell--numeric">36.30%</td>
+						<td class="o-table__cell--numeric">19,924</td>
+						<td class="o-table__cell--numeric">38</td>
+						<td class="o-table__cell--numeric">95</td>
+						<td>2005</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">955</td>
+						<td><a href="http://jechange.fr/" data-trackable="link" target="_blank">JeChange</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">153%</td>
+						<td class="o-table__cell--numeric">36.20%</td>
+						<td class="o-table__cell--numeric">11,145</td>
+						<td class="o-table__cell--numeric">20</td>
+						<td class="o-table__cell--numeric">37</td>
+						<td>2007</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">956</td>
+						<td><a href="http://northwave-security.com/" data-trackable="link" target="_blank">Northwave
+								Security</a></td>
+						<td><a href="https://www.ft.com/topics/places/Netherlands" data-trackable="link">The
+								Netherlands</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Cyber_Security" data-trackable="link">Cyber
+								Security</a></td>
+						<td class="o-table__cell--numeric">153%</td>
+						<td class="o-table__cell--numeric">36.20%</td>
+						<td class="o-table__cell--numeric">3,222</td>
+						<td class="o-table__cell--numeric">24</td>
+						<td class="o-table__cell--numeric">35</td>
+						<td>2006</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">957</td>
+						<td><a href="http://londonwallpartners.com/" data-trackable="link" target="_blank">London Wall
+								Partners</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/companies/financial-services" data-trackable="link">Financial
+								Services</a></td>
+						<td class="o-table__cell--numeric">152%</td>
+						<td class="o-table__cell--numeric">36.20%</td>
+						<td class="o-table__cell--numeric">2,534</td>
+						<td class="o-table__cell--numeric">9</td>
+						<td class="o-table__cell--numeric">18</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">958</td>
+						<td><a href="http://fleetpool.de/" data-trackable="link" target="_blank">Fleetpool</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/automobiles" data-trackable="link">Automobiles</a>
+						</td>
+						<td class="o-table__cell--numeric">152%</td>
+						<td class="o-table__cell--numeric">36.10%</td>
+						<td class="o-table__cell--numeric">24,445</td>
+						<td class="o-table__cell--numeric">16</td>
+						<td class="o-table__cell--numeric">21</td>
+						<td>2008</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">959</td>
+						<td><a href="http://secursat.eu/" data-trackable="link" target="_blank">SecurSAT</a></td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">152%</td>
+						<td class="o-table__cell--numeric">36.10%</td>
+						<td class="o-table__cell--numeric">4,699</td>
+						<td class="o-table__cell--numeric">18</td>
+						<td class="o-table__cell--numeric">25</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">960</td>
+						<td><a href="http://reax-transporte.de/" data-trackable="link" target="_blank">REAX
+								Transporte</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/transport" data-trackable="link">Transport</a></td>
+						<td class="o-table__cell--numeric">151%</td>
+						<td class="o-table__cell--numeric">35.90%</td>
+						<td class="o-table__cell--numeric">11,800</td>
+						<td class="o-table__cell--numeric">60</td>
+						<td class="o-table__cell--numeric">70</td>
+						<td>2013</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">961</td>
+						<td><a href="http://efficioconsulting.com/" data-trackable="link" target="_blank">Efficio</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Management_Consulting"
+								data-trackable="link">Management Consulting</a></td>
+						<td class="o-table__cell--numeric">151%</td>
+						<td class="o-table__cell--numeric">35.90%</td>
+						<td class="o-table__cell--numeric">58,859</td>
+						<td class="o-table__cell--numeric">152</td>
+						<td class="o-table__cell--numeric">289</td>
+						<td>2000</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">962</td>
+						<td><a href="http://european-road-trucking.eu/" data-trackable="link" target="_blank">ERT
+								European Road Trucking</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/transport" data-trackable="link">Transport</a></td>
+						<td class="o-table__cell--numeric">151%</td>
+						<td class="o-table__cell--numeric">35.90%</td>
+						<td class="o-table__cell--numeric">8,030</td>
+						<td class="o-table__cell--numeric">5</td>
+						<td class="o-table__cell--numeric">13</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">963</td>
+						<td><a href="http://pro-liberis.org/" data-trackable="link" target="_blank">Pro-Liberis</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/stream/d320c9d7-1638-4388-b667-a5d63bd4bbc2"
+								data-trackable="link">Education</a></td>
+						<td class="o-table__cell--numeric">151%</td>
+						<td class="o-table__cell--numeric">35.90%</td>
+						<td class="o-table__cell--numeric">10,476</td>
+						<td class="o-table__cell--numeric">96</td>
+						<td class="o-table__cell--numeric">350</td>
+						<td>2006</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">964</td>
+						<td><a href="http://ding.com/" data-trackable="link" target="_blank">Ding</a></td>
+						<td><a href="https://www.ft.com/topics/places/Ireland" data-trackable="link">Ireland</a></td>
+						<td><a href="https://www.ft.com/fintech" data-trackable="link">Fintech</a></td>
+						<td class="o-table__cell--numeric">151%</td>
+						<td class="o-table__cell--numeric">35.90%</td>
+						<td class="o-table__cell--numeric">460,359</td>
+						<td class="o-table__cell--numeric">-2</td>
+						<td class="o-table__cell--numeric">196</td>
+						<td>2006</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">965</td>
+						<td><a href="http://eurofirms.es/" data-trackable="link" target="_blank">Eurofirms</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">151%</td>
+						<td class="o-table__cell--numeric">35.80%</td>
+						<td class="o-table__cell--numeric">236,240</td>
+						<td class="o-table__cell--numeric">330</td>
+						<td class="o-table__cell--numeric">490</td>
+						<td>1991</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">966</td>
+						<td><a href="http://standbyme.tv/" data-trackable="link" target="_blank">Stand by Me</a></td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/companies/media" data-trackable="link">Media</a></td>
+						<td class="o-table__cell--numeric">150%</td>
+						<td class="o-table__cell--numeric">35.80%</td>
+						<td class="o-table__cell--numeric">10,363</td>
+						<td class="o-table__cell--numeric">157</td>
+						<td class="o-table__cell--numeric">203</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">967</td>
+						<td><a href="http://meilleurtaux.com/" data-trackable="link" target="_blank">Meilleurtaux</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/financial-services" data-trackable="link">Financial
+								Services</a></td>
+						<td class="o-table__cell--numeric">150%</td>
+						<td class="o-table__cell--numeric">35.70%</td>
+						<td class="o-table__cell--numeric">54,659</td>
+						<td class="o-table__cell--numeric">213</td>
+						<td class="o-table__cell--numeric">323</td>
+						<td>1999</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">968</td>
+						<td><a href="http://harwell-management.com/" data-trackable="link" target="_blank">Harwell
+								Management</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Management_Consulting"
+								data-trackable="link">Management Consulting</a></td>
+						<td class="o-table__cell--numeric">150%</td>
+						<td class="o-table__cell--numeric">35.60%</td>
+						<td class="o-table__cell--numeric">16,621</td>
+						<td class="o-table__cell--numeric">32</td>
+						<td class="o-table__cell--numeric">80</td>
+						<td>2008</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">969</td>
+						<td><a href="http://endava.com/" data-trackable="link" target="_blank">Endava</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">149%</td>
+						<td class="o-table__cell--numeric">35.60%</td>
+						<td class="o-table__cell--numeric">185,343</td>
+						<td class="o-table__cell--numeric">2,056</td>
+						<td class="o-table__cell--numeric">3,471</td>
+						<td>2006</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">970</td>
+						<td><a href="http://euromarlaspezia.com/" data-trackable="link" target="_blank">EURO M.A.R.</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/companies/travel-leisure" data-trackable="link">Travel &amp;
+								Leisure</a></td>
+						<td class="o-table__cell--numeric">149%</td>
+						<td class="o-table__cell--numeric">35.60%</td>
+						<td class="o-table__cell--numeric">8,373</td>
+						<td class="o-table__cell--numeric">105</td>
+						<td class="o-table__cell--numeric">157</td>
+						<td>2001</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">971</td>
+						<td><a href="http://principleglobal.com/" data-trackable="link" target="_blank">Principle
+								Holdings</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Management_Consulting"
+								data-trackable="link">Management Consulting</a></td>
+						<td class="o-table__cell--numeric">149%</td>
+						<td class="o-table__cell--numeric">35.60%</td>
+						<td class="o-table__cell--numeric">183,088</td>
+						<td class="o-table__cell--numeric">168</td>
+						<td class="o-table__cell--numeric">454</td>
+						<td>1987</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">972</td>
+						<td><a href="http://reticulae.com/" data-trackable="link" target="_blank">Reticulae</a></td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Sales_&amp;_Marketing" data-trackable="link">Sales
+								&amp; Marketing</a></td>
+						<td class="o-table__cell--numeric">149%</td>
+						<td class="o-table__cell--numeric">35.50%</td>
+						<td class="o-table__cell--numeric">9,280</td>
+						<td class="o-table__cell--numeric">225</td>
+						<td class="o-table__cell--numeric">375</td>
+						<td>2007</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">973</td>
+						<td><a href="http://www.soltengroup.com/" data-trackable="link" target="_blank">Solten Business
+								International</a></td>
+						<td><a href="https://www.ft.com/topics/places/Ireland" data-trackable="link">Ireland</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">149%</td>
+						<td class="o-table__cell--numeric">35.50%</td>
+						<td class="o-table__cell--numeric">1,813</td>
+						<td class="o-table__cell--numeric">17</td>
+						<td class="o-table__cell--numeric">23</td>
+						<td>2008</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">974</td>
+						<td><a href="http://ediths.at/" data-trackable="link" target="_blank">reedit (ediths)</a></td>
+						<td><a href="https://www.ft.com/topics/places/Austria" data-trackable="link">Austria</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Ecommerce" data-trackable="link">Ecommerce</a>
+						</td>
+						<td class="o-table__cell--numeric">149%</td>
+						<td class="o-table__cell--numeric">35.50%</td>
+						<td class="o-table__cell--numeric">3,146</td>
+						<td class="o-table__cell--numeric">27</td>
+						<td class="o-table__cell--numeric">40</td>
+						<td>2010</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">975</td>
+						<td><a href="http://domainex.co.uk/" data-trackable="link" target="_blank">Domainex</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/companies/pharmaceuticals"
+								data-trackable="link">Pharmaceuticals</a></td>
+						<td class="o-table__cell--numeric">149%</td>
+						<td class="o-table__cell--numeric">35.50%</td>
+						<td class="o-table__cell--numeric">8,269</td>
+						<td class="o-table__cell--numeric">34</td>
+						<td class="o-table__cell--numeric">65</td>
+						<td>2001</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">976</td>
+						<td><a href="http://araner.com/" data-trackable="link" target="_blank">Araner Tecnologías</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/companies/energy" data-trackable="link">Energy</a></td>
+						<td class="o-table__cell--numeric">149%</td>
+						<td class="o-table__cell--numeric">35.50%</td>
+						<td class="o-table__cell--numeric">4,240</td>
+						<td class="o-table__cell--numeric">10</td>
+						<td class="o-table__cell--numeric">25</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">977</td>
+						<td><a href="http://compuwave.de/" data-trackable="link" target="_blank">Compuwave</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">148%</td>
+						<td class="o-table__cell--numeric">35.40%</td>
+						<td class="o-table__cell--numeric">16,239</td>
+						<td class="o-table__cell--numeric">10</td>
+						<td class="o-table__cell--numeric">21</td>
+						<td>2007</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">978</td>
+						<td><a href="http://ok-haus.at/" data-trackable="link" target="_blank">O.K. Energie Haus</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/Austria" data-trackable="link">Austria</a></td>
+						<td><a href="https://www.ft.com/companies/construction" data-trackable="link">Construction</a>
+						</td>
+						<td class="o-table__cell--numeric">148%</td>
+						<td class="o-table__cell--numeric">35.40%</td>
+						<td class="o-table__cell--numeric">3,654</td>
+						<td class="o-table__cell--numeric">14</td>
+						<td class="o-table__cell--numeric">24</td>
+						<td>2004</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">979</td>
+						<td><a href="http://aletheia-personal.de/" data-trackable="link" target="_blank">Aletheia
+								Personalservice</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">148%</td>
+						<td class="o-table__cell--numeric">35.40%</td>
+						<td class="o-table__cell--numeric">7,626</td>
+						<td class="o-table__cell--numeric">153</td>
+						<td class="o-table__cell--numeric">315</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">980</td>
+						<td><a href="http://bs-expresslogistik.de/" data-trackable="link" target="_blank">BS Logistic
+								&amp; Consulting</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/transport" data-trackable="link">Transport</a></td>
+						<td class="o-table__cell--numeric">148%</td>
+						<td class="o-table__cell--numeric">35.40%</td>
+						<td class="o-table__cell--numeric">6,203</td>
+						<td class="o-table__cell--numeric">7</td>
+						<td class="o-table__cell--numeric">48</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">981</td>
+						<td><a href="http://infranorm.com/" data-trackable="link" target="_blank">Infranorm
+								Technologie</a></td>
+						<td><a href="https://www.ft.com/topics/places/Austria" data-trackable="link">Austria</a></td>
+						<td><a href="https://www.ft.com/companies/industrial-goods" data-trackable="link">Industrial
+								Goods</a></td>
+						<td class="o-table__cell--numeric">148%</td>
+						<td class="o-table__cell--numeric">35.40%</td>
+						<td class="o-table__cell--numeric">7,761</td>
+						<td class="o-table__cell--numeric">3</td>
+						<td class="o-table__cell--numeric">13</td>
+						<td>2004</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">982</td>
+						<td><a href="http://arnold-ps.de/" data-trackable="link" target="_blank">Arnold
+								Personalservice</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">148%</td>
+						<td class="o-table__cell--numeric">35.40%</td>
+						<td class="o-table__cell--numeric">3,200</td>
+						<td class="o-table__cell--numeric">49</td>
+						<td class="o-table__cell--numeric">87</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">983</td>
+						<td><a href="http://mebag-bau.de/" data-trackable="link" target="_blank">MEBAG</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/construction" data-trackable="link">Construction</a>
+						</td>
+						<td class="o-table__cell--numeric">148%</td>
+						<td class="o-table__cell--numeric">35.40%</td>
+						<td class="o-table__cell--numeric">4,234</td>
+						<td class="o-table__cell--numeric">13</td>
+						<td class="o-table__cell--numeric">23</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">984</td>
+						<td><a href="http://krusto.de/" data-trackable="link" target="_blank">KRUSTO</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/technology" data-trackable="link">Technology</a></td>
+						<td class="o-table__cell--numeric">148%</td>
+						<td class="o-table__cell--numeric">35.30%</td>
+						<td class="o-table__cell--numeric">5,647</td>
+						<td class="o-table__cell--numeric">5</td>
+						<td class="o-table__cell--numeric">15</td>
+						<td>2008</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">985</td>
+						<td><a href="http://aroma-zone.com/" data-trackable="link" target="_blank">Aroma Zone</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/chemicals" data-trackable="link">Chemicals</a></td>
+						<td class="o-table__cell--numeric">148%</td>
+						<td class="o-table__cell--numeric">35.30%</td>
+						<td class="o-table__cell--numeric">52,458</td>
+						<td class="o-table__cell--numeric">35</td>
+						<td class="o-table__cell--numeric">82</td>
+						<td>1986</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">986</td>
+						<td><a href="http://ciar.it/" data-trackable="link" target="_blank">Ciar SpA</a></td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/companies/industrial-goods" data-trackable="link">Industrial
+								Goods</a></td>
+						<td class="o-table__cell--numeric">147%</td>
+						<td class="o-table__cell--numeric">35.20%</td>
+						<td class="o-table__cell--numeric">34,218</td>
+						<td class="o-table__cell--numeric">37</td>
+						<td class="o-table__cell--numeric">110</td>
+						<td>1979</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">987</td>
+						<td><a href="http://evolutionpeople.it/" data-trackable="link" target="_blank">Evolution
+								People</a></td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Advertising" data-trackable="link">Advertising</a>
+						</td>
+						<td class="o-table__cell--numeric">147%</td>
+						<td class="o-table__cell--numeric">35.20%</td>
+						<td class="o-table__cell--numeric">3,076</td>
+						<td class="o-table__cell--numeric">5</td>
+						<td class="o-table__cell--numeric">15</td>
+						<td>2011</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">988</td>
+						<td><a href="http://clicktravel.com/" data-trackable="link" target="_blank">Click Travel</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">147%</td>
+						<td class="o-table__cell--numeric">35.10%</td>
+						<td class="o-table__cell--numeric">194,813</td>
+						<td class="o-table__cell--numeric">78</td>
+						<td class="o-table__cell--numeric">142</td>
+						<td>1999</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">989</td>
+						<td><a href="http://blaudirekt.de/" data-trackable="link" target="_blank">blau direkt</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/fintech" data-trackable="link">Fintech</a></td>
+						<td class="o-table__cell--numeric">146%</td>
+						<td class="o-table__cell--numeric">35%</td>
+						<td class="o-table__cell--numeric">27,410</td>
+						<td class="o-table__cell--numeric">58</td>
+						<td class="o-table__cell--numeric">112</td>
+						<td>2000</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">990</td>
+						<td><a href="http://bb-pack.de/" data-trackable="link" target="_blank">BB Pack</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/industrial-goods" data-trackable="link">Industrial
+								Goods</a></td>
+						<td class="o-table__cell--numeric">146%</td>
+						<td class="o-table__cell--numeric">35%</td>
+						<td class="o-table__cell--numeric">28,973</td>
+						<td class="o-table__cell--numeric">4</td>
+						<td class="o-table__cell--numeric">15</td>
+						<td>2008</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">991</td>
+						<td><a href="http://omar.co.uk/" data-trackable="link" target="_blank">Omar Park Homes</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/companies/construction" data-trackable="link">Construction</a>
+						</td>
+						<td class="o-table__cell--numeric">146%</td>
+						<td class="o-table__cell--numeric">35%</td>
+						<td class="o-table__cell--numeric">46,533</td>
+						<td class="o-table__cell--numeric">207</td>
+						<td class="o-table__cell--numeric">379</td>
+						<td>1965</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">992</td>
+						<td><a href="http://petsnature.de/" data-trackable="link" target="_blank">Pets Nature</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Ecommerce" data-trackable="link">Ecommerce</a>
+						</td>
+						<td class="o-table__cell--numeric">146%</td>
+						<td class="o-table__cell--numeric">34.90%</td>
+						<td class="o-table__cell--numeric">14,079</td>
+						<td class="o-table__cell--numeric">5</td>
+						<td class="o-table__cell--numeric">17</td>
+						<td>1999</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">993</td>
+						<td><a href="http://tempservice.de/" data-trackable="link" target="_blank">TEMP.Service</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">145%</td>
+						<td class="o-table__cell--numeric">34.90%</td>
+						<td class="o-table__cell--numeric">3,019</td>
+						<td class="o-table__cell--numeric">52</td>
+						<td class="o-table__cell--numeric">95</td>
+						<td>2012</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">994</td>
+						<td><a href="http://castlefield.com/" data-trackable="link" target="_blank">Castlefield
+								Partners</a></td>
+						<td><a href="https://www.ft.com/topics/places/United_Kingdom" data-trackable="link">United
+								Kingdom</a></td>
+						<td><a href="https://www.ft.com/companies/financial-services" data-trackable="link">Financial
+								Services</a></td>
+						<td class="o-table__cell--numeric">145%</td>
+						<td class="o-table__cell--numeric">34.80%</td>
+						<td class="o-table__cell--numeric">4,858</td>
+						<td class="o-table__cell--numeric">12</td>
+						<td class="o-table__cell--numeric">31</td>
+						<td>2002</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">995</td>
+						<td><a href="http://urbanlinker.com/" data-trackable="link" target="_blank">Urban Linker</a>
+						</td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">145%</td>
+						<td class="o-table__cell--numeric">34.80%</td>
+						<td class="o-table__cell--numeric">2,811</td>
+						<td class="o-table__cell--numeric">15</td>
+						<td class="o-table__cell--numeric">28</td>
+						<td>2009</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">996</td>
+						<td><a href="http://vicris.it/" data-trackable="link" target="_blank">VICRIS</a></td>
+						<td><a href="https://www.ft.com/topics/places/Italy" data-trackable="link">Italy</a></td>
+						<td><a href="https://www.ft.com/companies/chemicals" data-trackable="link">Chemicals</a></td>
+						<td class="o-table__cell--numeric">144%</td>
+						<td class="o-table__cell--numeric">34.70%</td>
+						<td class="o-table__cell--numeric">4,043</td>
+						<td class="o-table__cell--numeric">4</td>
+						<td class="o-table__cell--numeric">5</td>
+						<td>1989</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">997</td>
+						<td><a href="http://futurecom-world.com/" data-trackable="link" target="_blank">FUTURECOM
+								Austria GmbH</a></td>
+						<td><a href="https://www.ft.com/topics/places/Austria" data-trackable="link">Austria</a></td>
+						<td><a href="https://www.ft.com/companies/support-services" data-trackable="link">Support
+								Services</a></td>
+						<td class="o-table__cell--numeric">144%</td>
+						<td class="o-table__cell--numeric">34.70%</td>
+						<td class="o-table__cell--numeric">2,075</td>
+						<td class="o-table__cell--numeric">4</td>
+						<td class="o-table__cell--numeric">6</td>
+						<td>2013</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">998</td>
+						<td><a href="http://digitalrepublic.com/" data-trackable="link" target="_blank">Digital Republic
+								Media Group</a></td>
+						<td><a href="https://www.ft.com/topics/places/Germany" data-trackable="link">Germany</a></td>
+						<td><a href="https://www.ft.com/topics/themes/Advertising" data-trackable="link">Advertising</a>
+						</td>
+						<td class="o-table__cell--numeric">144%</td>
+						<td class="o-table__cell--numeric">34.70%</td>
+						<td class="o-table__cell--numeric">7,011</td>
+						<td class="o-table__cell--numeric">18</td>
+						<td class="o-table__cell--numeric">30</td>
+						<td>2003</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">999</td>
+						<td>Jorge A. Gómez Rebollo</td>
+						<td><a href="https://www.ft.com/topics/places/Spain" data-trackable="link">Spain</a></td>
+						<td><a href="https://www.ft.com/restaurants" data-trackable="link">Restaurants</a></td>
+						<td class="o-table__cell--numeric">144%</td>
+						<td class="o-table__cell--numeric">34.60%</td>
+						<td class="o-table__cell--numeric">3,100</td>
+						<td class="o-table__cell--numeric">45</td>
+						<td class="o-table__cell--numeric">87</td>
+						<td>1997</td>
+					</tr>
+					<tr>
+						<td class="o-table__cell--numeric">1,000</td>
+						<td><a href="http://bioburger.fr/" data-trackable="link" target="_blank">Bioburger</a></td>
+						<td><a href="https://www.ft.com/topics/places/France" data-trackable="link">France</a></td>
+						<td><a href="https://www.ft.com/restaurants" data-trackable="link">Restaurants</a></td>
+						<td class="o-table__cell--numeric">144%</td>
+						<td class="o-table__cell--numeric">34.60%</td>
+						<td class="o-table__cell--numeric">1,613</td>
+						<td class="o-table__cell--numeric">8</td>
+						<td class="o-table__cell--numeric">16</td>
+						<td>2011</td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+	</div>
+</div>

--- a/origami.json
+++ b/origami.json
@@ -144,6 +144,13 @@
 			"description": ""
 		},
 		{
+			"title": "Huge sortable table",
+			"name": "huge",
+			"template": "demos/src/huge.mustache",
+			"description": "A huge, sortable, expandable table - useful to test sort performance.",
+			"hidden": true
+		},
+		{
 			"title": "Pa11y",
 			"name": "pa11y",
 			"template": "demos/src/pa11y.mustache",

--- a/src/js/Sort/TableSorter.js
+++ b/src/js/Sort/TableSorter.js
@@ -107,10 +107,6 @@ class TableSorter {
 			throw new Error(`Sort order "${sortOrder}" is not supported. Must be "ascending" or "descending".`);
 		}
 
-		if (!batch || isNaN(batch)) {
-			batch = 100;
-		}
-
 		const intlCollator = getIntlCollator();
 		const cellFormatter = this._cellFormatter;
 		const type = tableHeaderElement.getAttribute('data-o-table-data-type') || undefined;
@@ -129,13 +125,17 @@ class TableSorter {
 		let updatedRowCount = 0;
 		function updateSortedRowBatch() {
 			window.requestAnimationFrame(() => {
-				const rowBatch = table.tableRows.slice(updatedRowCount, updatedRowCount + batch);
-				if (updatedRowCount === 0) {
+				if (updatedRowCount === 0 && isNaN(batch) === false) {
+					// On first run, update a batch of rows.
+					const rowBatch = table.tableRows.slice(updatedRowCount, batch);
 					prepend(table.tbody, rowBatch);
+					updatedRowCount = updatedRowCount + batch;
 				} else {
+					// On second run, update all the rest.
+					const rowBatch = table.tableRows.slice(updatedRowCount);
 					append(table.tbody, rowBatch);
+					updatedRowCount = table.tableRows.length;
 				}
-				updatedRowCount = updatedRowCount + batch;
 				if (updatedRowCount < table.tableRows.length) {
 					updateSortedRowBatch();
 				}

--- a/src/js/Tables/BaseTable.js
+++ b/src/js/Tables/BaseTable.js
@@ -65,7 +65,7 @@ class BaseTable {
 		}, { cancelable: true });
 
 		if (defaultSort) {
-			this._sorter.sortRowsByColumn(this, columnIndex, sortOrder, this._opts.sortBatchNumber);
+			this._sorter.sortRowsByColumn(this, columnIndex, sortOrder, this._sortBatchNumber);
 		}
 	}
 

--- a/src/js/Tables/OverflowTable.js
+++ b/src/js/Tables/OverflowTable.js
@@ -20,7 +20,6 @@ class OverflowTable extends BaseTable {
 			expanded: this.rootEl.hasAttribute('data-o-table-expanded') ? this.rootEl.getAttribute('data-o-table-expanded') !== 'false' : null,
 			minimumRowCount: this.rootEl.getAttribute('data-o-table-minimum-row-count')
 		}, this._opts);
-		this._opts.sortBatchNumber = this._opts.minimumRowCount && !this._opts.expanded ? parseInt(this._opts.minimumRowCount, 10) + 5 : null;
 		window.requestAnimationFrame(this.addSortButtons.bind(this));
 		window.requestAnimationFrame(this._setupScroll.bind(this));
 		window.requestAnimationFrame(this._setupExpander.bind(this));
@@ -72,6 +71,8 @@ class OverflowTable extends BaseTable {
 		}, 0);
 		const extraHeight = (rowsToHide[0] ? rowsToHide[0].getBoundingClientRect().height / 2 : 0);
 		const contractedHeight = tableHeight + extraHeight - rowsToHideHeight;
+		// When the table is contracted, only the rows which will be visible need to be rendered immediately when sorting.
+		this._sortBatchNumber = this._opts.minimumRowCount && !this._opts.expanded ? parseInt(this._opts.minimumRowCount, 10) + 5 : null;
 		// Contract table.
 		window.requestAnimationFrame(() => {
 			this._updateRowVisibility(false);
@@ -106,6 +107,8 @@ class OverflowTable extends BaseTable {
 			this._opts.expanded = true;
 			return;
 		}
+		// When the table is expanded, render sorted rows at once as they are all visible.
+		this._sortBatchNumber = undefined;
 		const expanderButton = this.controls ? this.controls.expanderButton.querySelector('button') : null;
 		window.requestAnimationFrame(() => {
 			this.container.classList.remove('o-table-container--contracted');


### PR DESCRIPTION
In a [previous PR](https://github.com/Financial-Times/o-table/pull/138), we rendered sorted table rows in batches to improve persevered performance. This works great when an expandable table is contracted as only those rows which are visible are updated immediately. However `o-table` does not currently account for when the table is expanded, in which case the user can see the rows as they update.

So:
- If the table is expandable and is currently contracted, on sort render the visible batch of rows first. Then render the rest.
- Otherwise, on sort render all sorted rows at once.

I've added a hidden demo with many rows to preview `o-table` with a large set of data.