### PR TITLE
Improve table render performance.

### DIFF
--- a/demos/src/huge.mustache
+++ b/demos/src/huge.mustache
@@ -1,5 +1,5 @@
 <div class="o-table-container">
-	<div class="o-table-overlay-wrapper n-content-layout__container">
+	<div class="o-table-overlay-wrapper">
 		<div class="o-table-scroll-wrapper">
 			<table
 				class="o-table o-table--row-stripes o-table--compact o-table--responsive-overflow o-table--responsive-overflow"

--- a/src/js/Sort/TableSorter.js
+++ b/src/js/Sort/TableSorter.js
@@ -47,41 +47,6 @@ function descendingSort(...args) {
 }
 
 /**
- * Append rows to table.
- *
- * @access private
- * @param {Element} tbody - The table body to append the row batch to.
- * @param {Array} rowBatch - An array of rows to append to the table body.
- * @returns {undefined}
- */
-function append(tbody, rowBatch) {
-	if (tbody.append) {
-		tbody.append(...rowBatch);
-	} else {
-		rowBatch.forEach(row => tbody.appendChild(row));
-	}
-
-}
-
-/**
- * Prepend rows to table.
- *
- * @access private
- * @param {Element} tbody - The table body to prepend the row batch to.
- * @param {Array} rowBatch - An array of rows to prepend to the table body.
- * @returns {undefined}
- */
-function prepend(tbody, rowBatch) {
-	if (tbody.prepend) {
-		tbody.prepend(...rowBatch);
-	} else {
-		rowBatch.reverse().forEach(row => {
-			tbody.insertBefore(row, tbody.firstChild);
-		});
-	}
-}
-
-/**
  * Provides methods to sort table instances.
  */
 class TableSorter {
@@ -96,7 +61,7 @@ class TableSorter {
 	 * @access public
 	 * @param {BaseTable} table - The table instance to sort.
 	 * @param {Number} columnIndex - The index of the table column to sort.
-	 * @param {Number} sortOrder - How to sort the column, "ascending" or "descending"
+	 * @param {String} sortOrder - How to sort the column, "ascending" or "descending"
 	 * @param {Number} batch [100] - How many rows to update at once when sorting.
 	 * @returns {undefined}
 	 */
@@ -110,7 +75,7 @@ class TableSorter {
 		const intlCollator = getIntlCollator();
 		const cellFormatter = this._cellFormatter;
 		const type = tableHeaderElement.getAttribute('data-o-table-data-type') || undefined;
-		table.tableRows.sort((a, b) => {
+		table.tableRows = table.tableRows.sort((a, b) => {
 			let aCol = a.querySelectorAll('td,th:not(.o-table__duplicate-heading)')[columnIndex];
 			let bCol = b.querySelectorAll('td,th:not(.o-table__duplicate-heading)')[columnIndex];
 			aCol = cellFormatter.formatCell({ cell: aCol, type });
@@ -122,27 +87,10 @@ class TableSorter {
 			}
 		});
 
-		let updatedRowCount = 0;
-		function updateSortedRowBatch() {
-			window.requestAnimationFrame(() => {
-				if (updatedRowCount === 0 && isNaN(batch) === false) {
-					// On first run, update a batch of rows.
-					const rowBatch = table.tableRows.slice(updatedRowCount, batch);
-					prepend(table.tbody, rowBatch);
-					updatedRowCount = updatedRowCount + batch;
-				} else {
-					// On second run, update all the rest.
-					const rowBatch = table.tableRows.slice(updatedRowCount);
-					append(table.tbody, rowBatch);
-					updatedRowCount = table.tableRows.length;
-				}
-				if (updatedRowCount < table.tableRows.length) {
-					updateSortedRowBatch();
-				}
-			});
-		}
-		updateSortedRowBatch();
+		// Render sorted table rows.
+		table.renderRows(batch);
 
+		// Table sorted.
 		window.requestAnimationFrame(() => {
 			table.tableHeaders.forEach((header) => {
 				const headerSort = (header === tableHeaderElement ? sortOrder : 'none');

--- a/src/js/Sort/TableSorter.js
+++ b/src/js/Sort/TableSorter.js
@@ -75,7 +75,7 @@ class TableSorter {
 		const intlCollator = getIntlCollator();
 		const cellFormatter = this._cellFormatter;
 		const type = tableHeaderElement.getAttribute('data-o-table-data-type') || undefined;
-		table.tableRows = table.tableRows.sort((a, b) => {
+		table.tableRows.sort((a, b) => {
 			let aCol = a.querySelectorAll('td,th:not(.o-table__duplicate-heading)')[columnIndex];
 			let bCol = b.querySelectorAll('td,th:not(.o-table__duplicate-heading)')[columnIndex];
 			aCol = cellFormatter.formatCell({ cell: aCol, type });

--- a/src/js/Tables/BasicTable.js
+++ b/src/js/Tables/BasicTable.js
@@ -14,7 +14,7 @@ class BasicTable extends BaseTable {
 	 */
 	constructor(rootEl, sorter, opts = {}) {
 		super(rootEl, sorter, opts);
-		window.requestAnimationFrame(this.addSortButtons.bind(this));
+		window.setTimeout(this.addSortButtons.bind(this), 0);
 		this._ready();
 		return this;
 	}

--- a/src/js/Tables/FlatTable.js
+++ b/src/js/Tables/FlatTable.js
@@ -15,14 +15,15 @@ class FlatTable extends BaseTable {
 	constructor(rootEl, sorter, opts = {}) {
 		super(rootEl, sorter, opts);
 		// Flat table can only work given headers.
+		// Duplicate row headings before adding sort buttons.
 		if (this.tableHeaders.length > 0) {
 			this._duplicateHeaders(rootEl);
 		} else {
 			console.warn('Could not create a "flat" table as no headers were found. Ensure table headers are placed within "<thead>". Removing class "o-table--responsive-flat".', rootEl);
 			rootEl.classList.remove('o-table--responsive-flat');
 		}
-		window.requestAnimationFrame(this.addSortButtons.bind(this));
-		this._ready();
+		window.setTimeout(this.addSortButtons.bind(this), 0);
+		window.setTimeout(this._ready.bind(this), 0);
 		return this;
 	}
 
@@ -32,12 +33,19 @@ class FlatTable extends BaseTable {
 	_duplicateHeaders() {
 		this.tableRows.forEach((row) => {
 			const data = Array.from(row.getElementsByTagName('td'));
-			data.forEach((td, dataIndex) => {
+			const dataHeadings = data.map((td, dataIndex) => {
 				const clonedHeader = this.tableHeaders[dataIndex].cloneNode(true);
 				clonedHeader.setAttribute('scope', 'row');
 				clonedHeader.setAttribute('role', 'rowheader');
 				clonedHeader.classList.add('o-table__duplicate-heading');
-				td.parentNode.insertBefore(clonedHeader, td);
+				return clonedHeader;
+			});
+
+			window.requestAnimationFrame(() => {
+				dataHeadings.forEach((clonedHeader, index) => {
+					const td = data[index];
+					td.parentNode.insertBefore(clonedHeader, td);
+				});
 			});
 		});
 	}

--- a/src/js/Tables/ScrollTable.js
+++ b/src/js/Tables/ScrollTable.js
@@ -13,9 +13,9 @@ class ScrollTable extends BaseTable {
 	 */
 	constructor(rootEl, sorter, opts = {}) {
 		super(rootEl, sorter, opts);
-		this._duplicateRowsWithAddedHeader();
-		window.requestAnimationFrame(this.addSortButtons.bind(this));
-		this._ready();
+		this._duplicateRowsWithAddedHeader(); // Duplicate rows before adding heading sort buttons.
+		window.setTimeout(this.addSortButtons.bind(this), 0);
+		window.setTimeout(this._ready.bind(this), 0);
 		return this;
 	}
 
@@ -24,7 +24,8 @@ class ScrollTable extends BaseTable {
 	 * @returns {undefined}
 	 */
 	_duplicateRowsWithAddedHeader() {
-		this.tableHeaders.forEach((header, index) => {
+		// Clone headings and data into new rows.
+		const clonedRows = this.tableHeaders.map((header, index) => {
 			const headerRow = document.createElement('tr');
 			headerRow.classList.add('o-table__duplicate-row');
 			// Clone column heading and turn into a row heading.
@@ -37,8 +38,17 @@ class ScrollTable extends BaseTable {
 				const data = row.querySelectorAll('td')[index];
 				headerRow.appendChild(data.cloneNode(true));
 			});
-			this.tbody.appendChild(headerRow);
+			return headerRow;
 		});
+
+		// Add new rows, which have a row rather than column headings, to the table body.
+		window.requestAnimationFrame(function () {
+			if (this.tbody.append) {
+				this.tbody.append(...clonedRows);
+			} else {
+				clonedRows.forEach(row => this.tbody.appendChild(row));
+			}
+		}.bind(this));
 	}
 }
 

--- a/src/scss/_responsive-flat.scss
+++ b/src/scss/_responsive-flat.scss
@@ -47,7 +47,7 @@
 			}
 
 			&.o-table--horizontal-lines th:not(:last-of-type),
-			&.o-table--horizontal-lines td:not(:last-of-type), {
+			&.o-table--horizontal-lines td:not(:last-of-type) {
 				// When flat, only show row border if a colour is defined.
 				// Else the browser will use a black border.
 				@if _oTableGet('table-border-color') {

--- a/test/FlatTable.test.js
+++ b/test/FlatTable.test.js
@@ -44,6 +44,6 @@ describe("FlatTable", () => {
 				done(error);
 			}
 			done();
-		}, 2); // wait for window.requestAnimationFrame
+		}, 100); // wait for window.requestAnimationFrame
 	});
 });

--- a/test/OverflowTable.test.js
+++ b/test/OverflowTable.test.js
@@ -10,8 +10,12 @@ import TableSorter from './../src/js/Sort/TableSorter';
 const sorter = new TableSorter();
 
 function expandable(oTableEl, { minimumRowCount, expanded }) {
-	oTableEl.setAttribute('data-o-table-expanded', expanded);
-	oTableEl.setAttribute('data-o-table-minimum-row-count', minimumRowCount);
+	if (expanded !== undefined) {
+		oTableEl.setAttribute('data-o-table-expanded', expanded);
+	}
+	if (minimumRowCount !== undefined) {
+		oTableEl.setAttribute('data-o-table-minimum-row-count', minimumRowCount);
+	}
 }
 
 function noTableWrapperOrContainer(oTableEl) {
@@ -135,7 +139,7 @@ describe("OverflowTable", () => {
 			setTimeout(() => {
 				assertExpanded(table, { expanded: true });
 				done();
-			}, 100);
+			}, 150);
 		});
 
 		it("can be configured to be contracted by default", (done) => {
@@ -144,7 +148,7 @@ describe("OverflowTable", () => {
 			setTimeout(() => {
 				assertExpanded(table, { expanded: false });
 				done();
-			}, 100);
+			}, 150);
 		});
 
 		it("can toggle between expanded and contracted programmatically when expandable", (done) => {
@@ -167,7 +171,7 @@ describe("OverflowTable", () => {
 			setTimeout(() => {
 				assertExpanded(table, { expanded: false, minimumRowCount: 2});
 				done();
-			}, 100);
+			}, 150);
 		});
 
 		it("is not used if the number of rows to contract to is larger than the table", (done) => {
@@ -177,7 +181,7 @@ describe("OverflowTable", () => {
 				proclaim.isFalse(table.canExpand());
 				proclaim.isFalse(table.rootEl.hasAttribute('aria-expanded'), `Did not expect "aria-expanded" on a table which can not expand.`);
 				done();
-			}, 100);
+			}, 150);
 		});
 	});
 
@@ -194,7 +198,7 @@ describe("OverflowTable", () => {
 				proclaim.isNull(oTableEl.querySelector('.o-table-control--forward'), 'Did not expect to find a forward button.');
 				proclaim.isNull(oTableEl.querySelector('.o-table-control--back'), 'Did not expect to find a back button.');
 				done();
-			}, 100);
+			}, 150);
 		});
 
 		it("forward / backward buttons are added given wrapper and container elements", (done) => {
@@ -203,7 +207,7 @@ describe("OverflowTable", () => {
 				proclaim.isNotNull(document.querySelector('.o-table-control--forward'), 'Did not find forward button.');
 				proclaim.isNotNull(document.querySelector('.o-table-control--back'), 'Did not find back button.');
 				done();
-			}, 100);
+			}, 150);
 		});
 
 		it("backward button is disabled and visualy hidden at the start of the table, if the table is shorter than the viewport and scrolling past the table is not possible", (done) => {
@@ -218,7 +222,7 @@ describe("OverflowTable", () => {
 					visuallyHidden: true
 				});
 				done();
-			}, 100);
+			}, 150);
 		});
 
 		it("forward button is disabled and visualy hidden at the end of the table, if the table is shorter than the viewport and scrolling past the table is not possible", (done) => {
@@ -233,7 +237,7 @@ describe("OverflowTable", () => {
 					visuallyHidden: true
 				});
 				done();
-			}, 100);
+			}, 150);
 		});
 
 		it("backward button is disabled but visible at the start of the table, when the table can be scrolled past", (done) => {
@@ -245,7 +249,7 @@ describe("OverflowTable", () => {
 					visuallyHidden: false
 				});
 				done();
-			}, 100);
+			}, 150);
 		});
 
 		it("forward button is disabled but visible at the end of the table, when the table can be scrolled past", (done) => {
@@ -258,7 +262,7 @@ describe("OverflowTable", () => {
 					visuallyHidden: false
 				});
 				done();
-			}, 100);
+			}, 150);
 		});
 		it("forward / backward buttons are sticky and hidden when the table is scrolled past", (done) => {
 			canScrollPastTable();
@@ -276,7 +280,7 @@ describe("OverflowTable", () => {
 					sticky: true
 				});
 				done();
-			}, 100);
+			}, 150);
 		});
 		it("forward / backward buttons are not sticky when the table can not be scrolled past", (done) => {
 			// reset sandbox to use a table smaller than the viewport
@@ -295,7 +299,7 @@ describe("OverflowTable", () => {
 					sticky: false
 				});
 				done();
-			}, 100);
+			}, 150);
 		});
 	});
 
@@ -313,7 +317,7 @@ describe("OverflowTable", () => {
 			setTimeout(() => {
 				assertDock(true);
 				done();
-			}, 100);
+			}, 150);
 		});
 		it("is not added given the table is smaller than the viewport", (done) => {
 			canScrollTable();
@@ -322,7 +326,7 @@ describe("OverflowTable", () => {
 			setTimeout(() => {
 				assertDock(false);
 				done();
-			}, 100);
+			}, 150);
 		});
 		it("is added if the table is smaller than the viewport and can be scrolled past", (done) => {
 			canScrollTable();
@@ -332,7 +336,7 @@ describe("OverflowTable", () => {
 			setTimeout(() => {
 				assertDock(true);
 				done();
-			}, 100);
+			}, 150);
 		});
 		it("is not added given the table is not scrollable", (done) => {
 			expandable(oTableEl, { expanded: false });
@@ -340,7 +344,7 @@ describe("OverflowTable", () => {
 			setTimeout(() => {
 				assertDock(false);
 				done();
-			}, 100);
+			}, 150);
 		});
 		it("is not added given the table is not expandable", (done) => {
 			canScrollTable();
@@ -348,7 +352,7 @@ describe("OverflowTable", () => {
 			setTimeout(() => {
 				assertDock(false);
 				done();
-			}, 100);
+			}, 150);
 		});
 		it("scroll controls are not sticky and instead \"dock\" given the dock exists and the table is shorter than the viewport", (done) => {
 			canScrollTable();
@@ -362,7 +366,7 @@ describe("OverflowTable", () => {
 					dock: true
 				});
 				done();
-			}, 100);
+			}, 150);
 		});
 		it("scroll controls do not \"dock\" if the dock does not exist", (done) => {
 			canScrollTable();
@@ -374,7 +378,7 @@ describe("OverflowTable", () => {
 					dock: false
 				});
 				done();
-			}, 100);
+			}, 150);
 		});
 		it("scroll controls do not \"dock\" when the table is taller than the viewport", (done) => {
 			canScrollTable();
@@ -388,7 +392,7 @@ describe("OverflowTable", () => {
 					dock: false
 				});
 				done();
-			}, 100);
+			}, 150);
 		});
 		it("sticky scroll controls are visually hidden when scrolling past a table with no \"dock\".", (done) => {
 			canScrollTable();
@@ -403,7 +407,7 @@ describe("OverflowTable", () => {
 					dock: false
 				});
 				done();
-			}, 100);
+			}, 150);
 		});
 		it("sticky scroll controls remain visible when scrolling past a table with a \"dock\".", (done) => {
 			canScrollTable();
@@ -419,7 +423,7 @@ describe("OverflowTable", () => {
 					dock: true
 				});
 				done();
-			}, 100);
+			}, 150);
 		});
 	});
 });

--- a/test/ScrollTable.test.js
+++ b/test/ScrollTable.test.js
@@ -45,7 +45,7 @@ describe("ScrollTable", () => {
 				done(error);
 			}
 			done();
-		}, 2); // wait for window.requestAnimationFrame
+		}, 100); // wait for window.requestAnimationFrame
 	});
 
 });


### PR DESCRIPTION
- Makes better use of window.requestAnimationFrame to prevent forced reflows.
- Moves the table row render function so rows may be hidden in one place ([ready for the filter feature](https://github.com/Financial-Times/o-table/pull/150)).

This shows the Chrome Dev Tools performance profile of the "huge" table demo on load, with cpu throttled x6. The demo has 1000 rows, 10 columns, sortable headings, and an expander. The render time is much less thanks to avoiding some forced reflows  (before / after):
<img width="599" alt="Screenshot 2019-03-18 at 16 28 03" src="https://user-images.githubusercontent.com/10405691/54550632-3f7afe00-49a4-11e9-9445-30c22b0e1412.png">
