### PR TITLE
Remove use of "visibility: collapsed" to hide filtered rows.

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ To enable declarative table filtering add the `data-o-table-filter-id` and `data
 For example, to filter a table based on a users selected option:
 ```html
 	<label>Filter the table by country:</label>
+	<!-- the filter input specifies the table id in "data-o-table-filter-id" -->
 	<select data-o-table-filter-id="example-table" data-o-table-filter-column="0">
 		<option value="" selected>All</option>
 		<option value="​Austria">​Austria</option>
@@ -258,9 +259,13 @@ For example, to filter a table based on a users selected option:
 		<!-- more options  -->
 	</select>
 
-	<table id="example-table">
-		<!-- table markup -->
-	</table>
+	<!-- the table markup, this may be a resposnive table -->
+	<div class="o-table-container">
+		<!-- the table element with an id -->
+		<table id="example-table">
+			<!-- ... -->
+		</table>
+	</div>
 ```
 
 Declarative filters are case insensitive and perform partial matches, e.g. a filter of "Kingdom" would reveal "United Kingdom".

--- a/demos/src/huge.mustache
+++ b/demos/src/huge.mustache
@@ -13303,4 +13303,7 @@
 			</table>
 		</div>
 	</div>
+	<div class="o-table-footnote">
+		Data for demo purposes only.
+	</div>
 </div>

--- a/src/js/Tables/BaseTable.js
+++ b/src/js/Tables/BaseTable.js
@@ -148,6 +148,7 @@ class BaseTable {
 	 */
 	updateRows() {
 		this._updateRowAriaHidden();
+		this._hideFilteredRows();
 		this._updateTableHeight();
 		this._updateRowOrder();
 	}
@@ -201,6 +202,24 @@ class BaseTable {
 		this._updateRowAriaHiddenScheduled = window.requestAnimationFrame(function () {
 			this.tableRows.forEach((row) => {
 				row.setAttribute('aria-hidden', rowsToHide.indexOf(row) !== -1);
+			});
+		}.bind(this));
+	}
+
+	/**
+	 * Hide filtered rows by updating the "data-o-table-filtered" attribute.
+	 * Filtered rows are removed from the table using CSS so column width is
+	 * not recalculated.
+	 */
+	_hideFilteredRows() {
+		if (this._hideFilteredRowsScheduled) {
+			window.cancelAnimationFrame(this._hideFilteredRowsScheduled);
+		}
+
+		const filteredRows = this._filteredTableRows || [];
+		this._hideFilteredRowsScheduled = window.requestAnimationFrame(function () {
+			this.tableRows.forEach((row) => {
+				row.setAttribute('data-o-table-filtered', filteredRows.indexOf(row) !== -1);
 			});
 		}.bind(this));
 	}

--- a/src/js/Tables/BaseTable.js
+++ b/src/js/Tables/BaseTable.js
@@ -177,6 +177,7 @@ class BaseTable {
 
 	/**
 	 * Get the table height, accounting for "hidden" rows.
+	 * @return {Number|Null}
 	 */
 	_getTableHeight() {
 		const tableHeight = this.rootEl.getBoundingClientRect().height;

--- a/src/js/Tables/BaseTable.js
+++ b/src/js/Tables/BaseTable.js
@@ -456,6 +456,7 @@ class BaseTable {
 		delete this.wrapper;
 		delete this.container;
 		delete this.overlayWrapper;
+		delete this.filterContainer;
 	}
 
 	/**

--- a/src/js/Tables/OverflowTable.js
+++ b/src/js/Tables/OverflowTable.js
@@ -1,18 +1,5 @@
 import BaseTable from './BaseTable';
 
-function getContractedWrapperHeight(table) {
-	const tableHeight = table.rootEl.getBoundingClientRect().height;
-
-	const buttonHeight = table.controls.expanderButton.getBoundingClientRect().height;
-	const hiddenRows = table._rowsToHide;
-	const hiddenRowsHeight = table._rowsToHide.reduce((accumulatedHeight, row) => {
-		return accumulatedHeight + row.getBoundingClientRect().height;
-	}, 0);
-	const extraHeight = (hiddenRows[0] ? hiddenRows[0].getBoundingClientRect().height / 2 : 0);
-
-	return tableHeight + buttonHeight + extraHeight - hiddenRowsHeight;
-}
-
 class OverflowTable extends BaseTable {
 
 	/**

--- a/src/js/Tables/OverflowTable.js
+++ b/src/js/Tables/OverflowTable.js
@@ -80,6 +80,7 @@ class OverflowTable extends BaseTable {
 	updateRows() {
 		this._updateExpander();
 		this._updateRowAriaHidden();
+		this._hideFilteredRows();
 		this._updateTableHeight();
 		this._updateRowOrder();
 	}
@@ -101,6 +102,7 @@ class OverflowTable extends BaseTable {
 
 		this._updateTableHeight();
 		this._updateRowAriaHidden();
+		this._updateControls();
 
 		this._expanderUpdateScheduled = window.requestAnimationFrame(function () {
 			this.rootEl.setAttribute('data-o-table-expanded', Boolean(expand));
@@ -156,11 +158,12 @@ class OverflowTable extends BaseTable {
 	 */
 	_getTableHeight() {
 		if (this.isContracted()) {
-			if (!this._contractedWrapperHeight) {
+			const maxTableHeight = super._getTableHeight();
+			if (!this._contractedWrapperHeight || this._contractedWrapperHeight > maxTableHeight) {
 				const rowsToHide = this._rowsToHide;
 				const buttonHeight = this.controls.expanderButton.getBoundingClientRect().height;
 				const extraHeight = rowsToHide ? rowsToHide[0].getBoundingClientRect().height / 2 : 0;
-				this._contractedWrapperHeight = super._getTableHeight() + buttonHeight + (this.isContracted() ? extraHeight : 0);
+				this._contractedWrapperHeight = maxTableHeight + buttonHeight + extraHeight;
 			}
 			return this._contractedWrapperHeight;
 		}

--- a/src/js/Tables/OverflowTable.js
+++ b/src/js/Tables/OverflowTable.js
@@ -152,6 +152,7 @@ class OverflowTable extends BaseTable {
 
 	/**
 	 * Get the table height, accounting for "hidden" rows.
+	 * @return {Number|Null}
 	 */
 	_getTableHeight() {
 		if (this.isContracted()) {

--- a/src/js/Tables/ScrollTable.js
+++ b/src/js/Tables/ScrollTable.js
@@ -83,6 +83,7 @@ class ScrollTable extends BaseTable {
 					this.tbody.insertBefore(row, this.tbody.firstChild);
 				});
 			}
+			this._updateTableHeight();
 		}.bind(this));
 	}
 }

--- a/src/scss/_base.scss
+++ b/src/scss/_base.scss
@@ -77,11 +77,11 @@
 		margin-bottom: oTypographySpacingSize($units: 4);
 	}
 
-	// Visually hide any hidden row.
+	// Visually hide any filtered rows.
 	// `display: none` is not used to avoid recalculating column row.
 	// `visibility: collaposed` is not used due to inconsistent browser support.
 	// sass-lint:disable no-qualifying-elements
-	tr[aria-hidden="true"] {
+	tr[data-o-table-filtered="true"] {
 		visibility: hidden;
 	}
 	// sass-lint:enable no-qualifying-elements

--- a/src/scss/_base.scss
+++ b/src/scss/_base.scss
@@ -77,10 +77,12 @@
 		margin-bottom: oTypographySpacingSize($units: 4);
 	}
 
-	// Collapse filtered rows.
-	// The size of columns are still calculated.
-	// https://developer.mozilla.org/en-US/docs/Web/CSS/visibility#Values
-	.o-table [data-o-table-filtered="true"] {
-		visibility: collapse;
+	// Visually hide any hidden row.
+	// `display: none` is not used to avoid recalculating column row.
+	// `visibility: collaposed` is not used due to inconsistent browser support.
+	// sass-lint:disable no-qualifying-elements
+	tr[aria-hidden="true"] {
+		visibility: hidden;
 	}
+	// sass-lint:enable no-qualifying-elements
 }

--- a/src/scss/_responsive-flat.scss
+++ b/src/scss/_responsive-flat.scss
@@ -55,13 +55,6 @@
 				}
 			}
 
-			// Totally hide any hidden row when the table is flat.
-			// sass-lint:disable no-qualifying-elements
-			tr[aria-hidden="true"] {
-				display: none;
-			}
-			// sass-lint:enable no-qualifying-elements
-
 			.o-table__duplicate-heading {
 				display: block;
 				float: left;

--- a/test/BaseTable.test.js
+++ b/test/BaseTable.test.js
@@ -20,12 +20,13 @@ describe("BaseTable", () => {
 
 	function assertFilter(data, expectedData) {
 		const tbody = oTableEl.querySelector('tbody');
-		const filterdRows = tbody.querySelectorAll('tr[data-o-table-filtered="true"]');
-		const visibleRows = tbody.querySelectorAll('tr[data-o-table-filtered="false"]');
+		const filterdRows = tbody.querySelectorAll('tr[aria-hidden="true"]');
+		const visibleRows = tbody.querySelectorAll('tr[aria-hidden="false"]');
 		const expectedFiltered = data.length - expectedData.length;
 		const expectedVisible = expectedData.length;
 		proclaim.equal(filterdRows.length, expectedFiltered, `Expected ${expectedFiltered} filtered rows but found ${filterdRows.length}.`);
 		proclaim.equal(visibleRows.length, expectedVisible, `Expected ${expectedVisible} visible rows but found ${visibleRows.length}.`);
+		proclaim.isTrue(table.wrapper.style.height !== '', `Expect the table to have a set height on its parent container to hide rows visually.`);
 	}
 
 	const click = element => {

--- a/test/BaseTable.test.js
+++ b/test/BaseTable.test.js
@@ -470,7 +470,8 @@ describe("BaseTable", () => {
 				'_filteredTableRows',
 				'wrapper',
 				'container',
-				'overlayWrapper'
+				'overlayWrapper',
+				'filterContainer'
 			];
 			table.destroy();
 			expectedToBeRemoved.forEach(property => {

--- a/test/OverflowTable.test.js
+++ b/test/OverflowTable.test.js
@@ -84,11 +84,12 @@ function assertExpanded(table, { expanded, minimumRowCount }) {
 	const expectedButtonContent = expanded ? 'show fewer' : 'show more';
 	const expectedAriaExpanded = expanded ? 'true' : 'false';
 	const expectedHidden = expanded ? 0 : table.tableRows.length - minimumRowCount;
-	const wrapperHeightCorrect = (table.wrapper.style.height === '' && expanded) || (table.wrapper.style.height !== '' && !expanded);
 	proclaim.include(table.container.innerHTML.toLowerCase(), expectedButtonContent, `Expected to see "${expectedButtonContent}" within an expanded table.`);
 	proclaim.isTrue(table.rootEl.getAttribute('aria-expanded') === expectedAriaExpanded, `Expected to see \'aria-expanded="${expectedAriaExpanded}"\' on an expanded table.`);
 	proclaim.equal(table.tbody.querySelectorAll('tr[aria-hidden="true"]').length, expectedHidden, `Expected ${expectedHidden} table rows to be hidden in an expanded table,`);
-	proclaim.isTrue(wrapperHeightCorrect, `Expect the table wrapper to ${expanded ? 'not have' : 'have'} a set height to hide rows visually.`);
+	if (expanded) {
+		proclaim.isTrue(table.wrapper.style.height !== '', `Expect an expanded table to have a set height on its wrapper to hide rows visually.`);
+	}
 }
 
 describe("OverflowTable", () => {


### PR DESCRIPTION
This is due to inconsistent browser support. For example Safari treated "visibility: collapsed" as "visibility: hidden", which caused large blank tables. Now a height is set on the table container to hide filtered rows with overflow. "display: none" can't be used as this would cause column widths to be recalculated.