### PR TITLE
Only visually hide filtered and update the contracted table height if needed

### DIFF
--- a/src/js/Tables/BaseTable.js
+++ b/src/js/Tables/BaseTable.js
@@ -148,6 +148,7 @@ class BaseTable {
 	 */
 	updateRows() {
 		this._updateRowAriaHidden();
+		this._hideFilteredRows();
 		this._updateTableHeight();
 		this._updateRowOrder();
 	}
@@ -201,6 +202,24 @@ class BaseTable {
 		this._updateRowAriaHiddenScheduled = window.requestAnimationFrame(function () {
 			this.tableRows.forEach((row) => {
 				row.setAttribute('aria-hidden', rowsToHide.indexOf(row) !== -1);
+			});
+		}.bind(this));
+	}
+
+	/**
+	 * Hide filtered rows by updating the "data-o-table-filtered" attribute.
+	 * Filtered rows are removed from the table using CSS so column width is
+	 * not recalculated.
+	 */
+	_hideFilteredRows() {
+		if (this._hideFilteredRowsScheduled) {
+			window.cancelAnimationFrame(this._hideFilteredRowsScheduled);
+		}
+
+		const filteredRows = this._filteredTableRows || [];
+		this._hideFilteredRowsScheduled = window.requestAnimationFrame(function () {
+			this.tableRows.forEach((row) => {
+				row.setAttribute('data-o-table-filtered', filteredRows.indexOf(row) !== -1);
 			});
 		}.bind(this));
 	}

--- a/src/js/Tables/OverflowTable.js
+++ b/src/js/Tables/OverflowTable.js
@@ -80,6 +80,7 @@ class OverflowTable extends BaseTable {
 	updateRows() {
 		this._updateExpander();
 		this._updateRowAriaHidden();
+		this._hideFilteredRows();
 		this._updateTableHeight();
 		this._updateRowOrder();
 	}
@@ -101,6 +102,7 @@ class OverflowTable extends BaseTable {
 
 		this._updateTableHeight();
 		this._updateRowAriaHidden();
+		this._updateControls();
 
 		this._expanderUpdateScheduled = window.requestAnimationFrame(function () {
 			this.rootEl.setAttribute('data-o-table-expanded', Boolean(expand));
@@ -156,11 +158,12 @@ class OverflowTable extends BaseTable {
 	 */
 	_getTableHeight() {
 		if (this.isContracted()) {
-			if (!this._contractedWrapperHeight) {
+			const maxTableHeight = super._getTableHeight();
+			if (!this._contractedWrapperHeight || this._contractedWrapperHeight > maxTableHeight) {
 				const rowsToHide = this._rowsToHide;
 				const buttonHeight = this.controls.expanderButton.getBoundingClientRect().height;
 				const extraHeight = rowsToHide ? rowsToHide[0].getBoundingClientRect().height / 2 : 0;
-				this._contractedWrapperHeight = super._getTableHeight() + buttonHeight + (this.isContracted() ? extraHeight : 0);
+				this._contractedWrapperHeight = maxTableHeight + buttonHeight + extraHeight;
 			}
 			return this._contractedWrapperHeight;
 		}

--- a/src/scss/_base.scss
+++ b/src/scss/_base.scss
@@ -77,11 +77,11 @@
 		margin-bottom: oTypographySpacingSize($units: 4);
 	}
 
-	// Visually hide any hidden row.
+	// Visually hide any filtered rows.
 	// `display: none` is not used to avoid recalculating column row.
 	// `visibility: collaposed` is not used due to inconsistent browser support.
 	// sass-lint:disable no-qualifying-elements
-	tr[aria-hidden="true"] {
+	tr[data-o-table-filtered="true"] {
 		visibility: hidden;
 	}
 	// sass-lint:enable no-qualifying-elements


### PR DESCRIPTION
- When a table is contracted, half of one hidden row is visually shown behind a fade out to indicate expandability.
- When a contracted table is sorted its height does not change. However if the rows now at the top of the table are less tall, some "hidden" rows may become visually visible.
- We do not update the contracted table height to avoid the table causing the rest of the page to re-render. Unless the max table height becomes smaller than the current contracted table height upon filter.