### PR TITLE
Allow version 2 or 3 of ftdomdelegate. 

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,7 +8,7 @@
     "o-brand": "^3.1.1",
     "o-visual-effects": "^2.0.3",
     "o-buttons": "^5.14.0",
-    "dom-delegate": "ftdomdelegate#^2.2.0"
+    "ftdomdelegate": ">=2.2.0 <4.0.0"
   },
   "main": [
     "main.scss",

--- a/src/js/Tables/BaseTable.js
+++ b/src/js/Tables/BaseTable.js
@@ -1,4 +1,4 @@
-import Delegate from 'dom-delegate';
+import Delegate from 'ftdomdelegate';
 
 class BaseTable {
 


### PR DESCRIPTION
v3 of ftdomdelegate has the same api as v2. It was named
dom-delegate in its manifest files and v3 makes the name
consistent. It was also released (renamed) as 2.2.0 on npm.

https://github.com/Financial-Times/ftdomdelegate/pull/93