### PR TITLE
Update demo to o-forms@^7.0.0 :tada:

### DIFF
--- a/demos/src/base.mustache
+++ b/demos/src/base.mustache
@@ -1,21 +1,25 @@
 {{#showFilter}}
 	<div id="demo-table-caption">
 		<h2 class="o-typography-heading-level-2">Table Caption</h2>
-		<div class="o--if-js o-forms o-forms--inline">
-			<div class="o-forms__inline-item">
-				<label aria-describedby="select-box-info" for="demo-filter-select" class="o-forms__label">
+
+		<label class="o-forms-field o-forms-field--inline o--if-js o-forms-field--demo">
+			<span class="o-forms-title o-forms-title--vertical-center o-forms-title--shrink">
+				<span class="o-forms-title__main">
 					Showing data for:
-				</label>
-			</div>
-			<select data-o-table-filter-id="{{tableId}}" data-o-table-filter-column="2" id="demo-filter-select" class="o-forms__select">
-				<option value="">All</option>
-				<option value="Juicy">Juicy</option>
-				<option value="Smelly">Smelly</option>
-				<option value="Chewy">Chewy</option>
-				<option value="Sweet">Sweet</option>
-				<option value="Crunchy">Crunchy</option>
-			</select>
-		</div>
+				</span>
+			</span>
+
+			<span class="o-forms-input o-forms-input--select o-forms-input--invalid">
+				<select data-o-table-filter-id="{{tableId}}" data-o-table-filter-column="2" id="demo-filter-select" class="o-forms__select">
+					<option value="">All</option>
+					<option value="Juicy">Juicy</option>
+					<option value="Smelly">Smelly</option>
+					<option value="Chewy">Chewy</option>
+					<option value="Sweet">Sweet</option>
+					<option value="Crunchy">Crunchy</option>
+				</select>
+			</span>
+		</label>
 	</div>
 {{/showFilter}}
 

--- a/demos/src/demo.scss
+++ b/demos/src/demo.scss
@@ -7,6 +7,10 @@ html {
 	background: oColorsGetColorFor('page', 'background');
 }
 
+.o-forms-field--demo {
+	max-width: 24rem;
+}
+
 .o-table-demo-constrain {
 	max-width: 600px;
 }

--- a/demos/src/huge.mustache
+++ b/demos/src/huge.mustache
@@ -1,37 +1,41 @@
 {{#showFilter}}
 	<div id="demo-table-caption">
 		<h2 class="o-typography-heading-level-2">Table Caption</h2>
-		<div class="o--if-js o-forms o-forms--inline">
-			<div class="o-forms__inline-item">
-				<label aria-describedby="select-box-info" for="demo-filter-select" class="o-forms__label">
+
+		<label class="o-forms-field o-forms-field--inline o-forms-field--inline o--if-js o-forms-field--demo">
+			<span class="o-forms-title o-forms-title--vertical-center o-forms-title--shrink">
+				<span class="o-forms-title__main">
 					Showing data for:
-				</label>
-			</div>
-			<select data-o-table-filter-id="{{tableId}}" data-o-table-filter-column="2" id="demo-filter-select" class="o-forms__select">
-				<option value="">All</option>
-				<option value="​Austria">​Austria</option>
-				<option value="​Belgium">​Belgium</option>
-				<option value="​Bulgaria">​Bulgaria</option>
-				<option value="​Croatia">​Croatia</option>
-				<option value="​Czech Republic">​Czech Republic</option>
-				<option value="​Finland">​Finland</option>
-				<option value="​France">​France</option>
-				<option value="​Germany">​Germany</option>
-				<option value="​Hungary">​Hungary</option>
-				<option value="​Iceland">​Iceland</option>
-				<option value="Ireland">Ireland</option>
-				<option value="Italy">Italy</option>
-				<option value="Norway">Norway</option>
-				<option value="Poland">Poland</option>
-				<option value="Portugal">Portugal</option>
-				<option value="Romania">Romania</option>
-				<option value="Spain">Spain</option>
-				<option value="Sweden">Sweden</option>
-				<option value="Switzerland">Switzerland</option>
-				<option value="The Netherlands">The Netherlands</option>
-				<option value="United Kingdom" selected>United Kingdom</option>
-			</select>
-		</div>
+				</span>
+			</span>
+
+			<span class="o-forms-input o-forms-input--select o-forms-input--invalid">
+					<select data-o-table-filter-id="{{tableId}}" data-o-table-filter-column="2" id="demo-filter-select" class="o-forms__select">
+						<option value="">All</option>
+						<option value="​Austria">​Austria</option>
+						<option value="​Belgium">​Belgium</option>
+						<option value="​Bulgaria">​Bulgaria</option>
+						<option value="​Croatia">​Croatia</option>
+						<option value="​Czech Republic">​Czech Republic</option>
+						<option value="​Finland">​Finland</option>
+						<option value="​France">​France</option>
+						<option value="​Germany">​Germany</option>
+						<option value="​Hungary">​Hungary</option>
+						<option value="​Iceland">​Iceland</option>
+						<option value="Ireland">Ireland</option>
+						<option value="Italy">Italy</option>
+						<option value="Norway">Norway</option>
+						<option value="Poland">Poland</option>
+						<option value="Portugal">Portugal</option>
+						<option value="Romania">Romania</option>
+						<option value="Spain">Spain</option>
+						<option value="Sweden">Sweden</option>
+						<option value="Switzerland">Switzerland</option>
+						<option value="The Netherlands">The Netherlands</option>
+						<option value="United Kingdom" selected>United Kingdom</option>
+					</select>
+			</span>
+		</label>
 	</div>
 {{/showFilter}}
 

--- a/origami.json
+++ b/origami.json
@@ -31,7 +31,7 @@
 			"o-fonts@^3.0.0",
 			"o-normalise@^1.0.0",
 			"o-typography@^5.7.8",
-			"o-forms@^6.0.1",
+			"o-forms@^7.0.2",
 			"o-buttons@^5.16.2"
 		]
 	},


### PR DESCRIPTION
Will maybe create an issue to propose adding a field modifer to o-forms
to contain the width of a field. I've had to write custom CSS here and
when adding v6 to https://github.com/Financial-Times/tech.in.ft.com.

Before: Unwanted padding to the left, unwanted space after the label.
<img width="977" alt="Screenshot 2019-05-14 at 17 23 35" src="https://user-images.githubusercontent.com/10405691/57714728-093cc080-766d-11e9-9f69-8df0a3c09323.png">

Now: Beautiful 🎉 (but with some custom css to constrain the width)
<img width="977" alt="Screenshot 2019-05-14 at 17 23 37" src="https://user-images.githubusercontent.com/10405691/57714769-1bb6fa00-766d-11e9-942d-6f49fea96ca7.png">
