### PR TITLE
Introduce o-spacing.

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -28,10 +28,10 @@
 +</div>
 ```
 - Style updates:
-	- The default bottom margin of `o-table` has been removed. Please apply the margin as needed, depending on the context of the table e.g. within typical body copy:
+	- The default bottom margin of `o-table` has been removed. Please apply the margin as needed, depending on the context of the table e.g. [see o-spacing](https://registry.origami.ft.com/components/o-spacing):
 	```scss
 		.o-table {
-			margin-bottom: oTypographySpacingSize($units: 4);
+			margin-bottom: oSpacingByName('s4');
 		}
 	```
 	If it's not possible or practical to apply a custom margin, add the  `o-table-margin-bottom` class to the table (or table container, if you are using a responsive table).

--- a/bower.json
+++ b/bower.json
@@ -8,7 +8,8 @@
     "o-brand": "^3.1.1",
     "o-visual-effects": "^2.0.3",
     "o-buttons": "^5.14.0",
-    "ftdomdelegate": ">=2.2.0 <4.0.0"
+    "ftdomdelegate": ">=2.2.0 <4.0.0",
+    "o-spacing": "^2.0.0"
   },
   "main": [
     "main.scss",

--- a/main.scss
+++ b/main.scss
@@ -1,6 +1,5 @@
-$o-table-is-silent: true !default;
-
 // Dependancies
+@import "o-spacing/main";
 @import "o-brand/main";
 @import "o-buttons/main";
 @import "o-colors/main";
@@ -11,6 +10,7 @@ $o-table-is-silent: true !default;
 // Branding
 @import "src/scss/brand";
 // Main
+@import "src/scss/variables";
 @import "src/scss/base";
 @import "src/scss/borders";
 @import "src/scss/compact";

--- a/src/scss/_base.scss
+++ b/src/scss/_base.scss
@@ -71,10 +71,12 @@
 		margin-left: 10px;
 	}
 
-	// A spacing class until we have a generic spacing component users can include.
+	// A spacing class.
 	// e.g. .o-table.o-table-margin-bottom or .o-table-container.o-table-margin-bottom
+	// @deprecated - this is no longer needed now we have `o-spacing`.
+	// @see https://registry.origami.ft.com/components/o-spacing
 	.o-table-margin-bottom {
-		margin-bottom: oTypographySpacingSize($units: 4);
+		margin-bottom: oSpacingByName('s4');
 	}
 
 	// Visually hide any filtered rows.

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -1,0 +1,2 @@
+/// @type Bool
+$o-table-is-silent: true !default;


### PR DESCRIPTION
Replace o-typography spacing Sass which will be deprecated.
This is not considered a breaking change as o-spacing is a
new component.

This PR also moves the global silient mode variable to a
`variables.scss` file for consistency with other components.