### PR TITLE
Break o-table

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,27 +2,18 @@ version: 2
 jobs:
   test:
     docker:
-      - image: circleci/node:10-browsers
+      - image: 'circleci/node:10-browsers'
     steps:
       - checkout
-      - run: npm config set prefix "$HOME/.local"
-      - run: npm i -g origami-build-tools@^7
-      - run: $HOME/.local/bin/obt install
-      - run: $HOME/.local/bin/obt demo --demo-filter pa11y --suppress-errors
-      - run: $HOME/.local/bin/obt verify
-      - run: $HOME/.local/bin/obt test
-      - run: git clean -fxd
-      - run: npx occ 0.0.0
-      - run: $HOME/.local/bin/obt install --ignore-bower
-      - run: $HOME/.local/bin/obt test --ignore-bower
+      - run: npm install --only=dev
+      - run: npx origami-ci branch
   publish_to_npm:
     docker:
-      - image: circleci/node:10
+      - image: 'circleci/node:10'
     steps:
       - checkout
-      - run: npx occ ${CIRCLE_TAG##v}
-      - run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > $HOME/.npmrc
-      - run: npm publish --access public 
+      - run: npm install --only=dev
+      - run: npx origami-ci release
 workflows:
   version: 2
   test:

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,14 +1,14 @@
 ## Migration
 
-### Migration from v7 to v8
-
-- `.o-table-margin-bottom` has been removed. Use `.o-spacing-s4` from [o-spacing](https://registry.origami.ft.com/components/o-spacing@2.0.0) instead, or apply margin as needed, depending on the context of the table e.g.
+### Migrating from v7 to v8
+- `.o-table-margin-bottom` has been removed. Use `.o-spacing-s4` from [o-spacing](https://registry.origami.ft.com/components/o-spacing) instead, or apply margin as needed, depending on the context of the table e.g.
 
 ```
 .o-table {
 	margin-bottom: oSpacingByName('s4');
 }
 ```
+- v8 updates the required version on the [o-icons](https://registry.origami.ft.com/components/o-icons) and [ftdomdelegate](https://github.com/Financial-Times/ftdomdelegate) dependencies. Make sure your project still builds with the new versions! 
 
 ### Migrating from v6 to v7
 - To prevent errors in IE11, add support for `IntersectionObserverEntry` and `IntersectionObserver` with the [polyfill service](https://polyfill.io/).

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -2,7 +2,7 @@
 
 ### Migration from v7 to v8
 
-- `.o-table-margin-bottom` has been removed. Use `.o-spacing-s4` from [o-spacing](https://registry.origami.ft.com/components/o-spacing@2.0.0) instead, or apply margin apply margin as needed, depending on the context of the table e.g.
+- `.o-table-margin-bottom` has been removed. Use `.o-spacing-s4` from [o-spacing](https://registry.origami.ft.com/components/o-spacing@2.0.0) instead, or apply margin as needed, depending on the context of the table e.g.
 
 ```
 .o-table {

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -8,7 +8,13 @@
 	margin-bottom: oSpacingByName('s4');
 }
 ```
-- v8 updates the required version on the [o-icons](https://registry.origami.ft.com/components/o-icons) and [ftdomdelegate](https://github.com/Financial-Times/ftdomdelegate) dependencies. Make sure your project still builds with the new versions! 
+- v8 updates the required version on the [o-icons](https://registry.origami.ft.com/components/o-icons) and [ftdomdelegate](https://github.com/Financial-Times/ftdomdelegate) dependencies. Make sure your project still builds with the new versions!
+
+#### Updated dependencies
+
+The dependencies for this component have all been updated to the latest major versions.
+If you have any conflicts while installing this version, you'll need to first update
+its dependencies. See [the Bower config for these](./bower.json).
 
 ### Migrating from v6 to v7
 - To prevent errors in IE11, add support for `IntersectionObserverEntry` and `IntersectionObserver` with the [polyfill service](https://polyfill.io/).

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,5 +1,15 @@
 ## Migration
 
+### Migration from v7 to v8
+
+- `.o-table-margin-bottom` has been removed. Use `.o-spacing-s4` from [o-spacing](https://registry.origami.ft.com/components/o-spacing@2.0.0) instead, or apply margin apply margin as needed, depending on the context of the table e.g.
+
+```
+.o-table {
+	margin-bottom: oSpacingByName('s4');
+}
+```
+
 ### Migrating from v6 to v7
 - To prevent errors in IE11, add support for `IntersectionObserverEntry` and `IntersectionObserver` with the [polyfill service](https://polyfill.io/).
 - Data attribute `data-o-table-order` has been removed. To specify a custom sort order on `td` cells use `data-o-table-sort-value` instead.

--- a/README.md
+++ b/README.md
@@ -511,8 +511,9 @@ Known issues:
 
 State | Major Version | Last Minor Release | Migration guide |
 :---: | :---: | :---: | :---:
-✨ active | 7 | N/A | [migrate to v7](MIGRATION.md#migrating-from-v6-to-v7) |
-⚠ maintained | 6 | 6.9 | [migrate to v6](MIGRATION.md#migrating-from-v5-to-v6) |
+✨ active | 8 | N/A | [migrate to v8](MIGRATION.md#migrating-from-v7-to-v8) |
+⚠ maintained | 7 | 7.4 | [migrate to v7](MIGRATION.md#migrating-from-v6-to-v7) |
+╳ deprecated | 6 | 6.9 | [migrate to v6](MIGRATION.md#migrating-from-v5-to-v6) |
 ╳ deprecated | 5 | 5.2 | [migrate to v5](MIGRATION.md#migrating-from-v4-to-v5) |
 ╳ deprecated | 4 | 4.1 | [migrate to v4](MIGRATION.md#migrating-from-v3-to-v4) |
 ╳ deprecated | 3 | 3.0 | N/A |

--- a/bower.json
+++ b/bower.json
@@ -1,14 +1,14 @@
 {
   "name": "o-table",
   "dependencies": {
-    "o-colors": "5.0.0-beta.3",
-    "o-grid": "5.0.0-beta.2",
-    "o-icons": "6.0.0-beta.3",
-    "o-typography": "6.0.0-beta.4",
-    "o-brand": "^3.1.1",
-    "o-visual-effects": "3.0.0-beta.2",
-    "o-buttons": "6.0.0-beta.4",
-    "ftdomdelegate": "4.0.0-beta.1",
+    "o-colors": "^5.0.0",
+    "o-grid": "^5.0.0",
+    "o-icons": "^6.0.0",
+    "o-typography": "^6.0.0",
+    "o-brand": "^3.2.5",
+    "o-visual-effects": "^3.0.0",
+    "o-buttons": "^6.0.0",
+    "ftdomdelegate": "^4.0.0",
     "o-spacing": "^2.0.0"
   },
   "main": [

--- a/bower.json
+++ b/bower.json
@@ -1,14 +1,14 @@
 {
   "name": "o-table",
   "dependencies": {
-    "o-colors": "^4.0.0",
-    "o-grid": "^4.0.6",
-    "o-icons": "^5.11.2",
-    "o-typography": "^5.0.0",
+    "o-colors": "5.0.0-beta.3",
+    "o-grid": "5.0.0-beta.2",
+    "o-icons": "6.0.0-beta.3",
+    "o-typography": "6.0.0-beta.4",
     "o-brand": "^3.1.1",
-    "o-visual-effects": "^2.0.3",
-    "o-buttons": "^5.14.0",
-    "ftdomdelegate": "^3.0.0",
+    "o-visual-effects": "3.0.0-beta.2",
+    "o-buttons": "6.0.0-beta.4",
+    "ftdomdelegate": "4.0.0-beta.1",
     "o-spacing": "^2.0.0"
   },
   "main": [

--- a/bower.json
+++ b/bower.json
@@ -3,12 +3,12 @@
   "dependencies": {
     "o-colors": "^4.0.0",
     "o-grid": "^4.0.6",
-    "o-icons": ">=4.0.0 <6",
+    "o-icons": "^5.11.2",
     "o-typography": "^5.0.0",
     "o-brand": "^3.1.1",
     "o-visual-effects": "^2.0.3",
     "o-buttons": "^5.14.0",
-    "ftdomdelegate": ">=2.2.0 <4.0.0",
+    "ftdomdelegate": "^3.0.0",
     "o-spacing": "^2.0.0"
   },
   "main": [

--- a/demos/src/demo.scss
+++ b/demos/src/demo.scss
@@ -1,10 +1,8 @@
 $o-table-is-silent: false;
 @import "./../../main";
 
-// Default font and styles
 html {
-	font-family: BentonSans, sans-serif;
-	background: oColorsGetColorFor('page', 'background');
+	background: oColorsByUsecase('page', 'background');
 }
 
 .o-forms-field--demo {

--- a/origami.json
+++ b/origami.json
@@ -28,11 +28,11 @@
 		"js": "demos/src/demo.js",
 		"sass": "demos/src/demo.scss",
 		"dependencies": [
-			"o-fonts@^3.0.0",
-			"o-normalise@^1.0.0",
-			"o-typography@^5.7.8",
-			"o-forms@^7.0.2",
-			"o-buttons@^5.16.2"
+			"o-fonts@^4.0.0",
+			"o-normalise@^2.0.0",
+			"o-typography@^6.0.0",
+			"o-forms@^8.0.0",
+			"o-buttons@^6.0.0"
 		]
 	},
 	"demos": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,4 +1,0 @@
-{
-  "name": "o-table",
-  "lockfileVersion": 1
-}

--- a/package.json
+++ b/package.json
@@ -1,9 +1,7 @@
 {
-  "name": "o-table",
-  "description": "FT-branded tables",
-  "private": true,
-  "scripts": {
-    "heroku-postbuild": "npx origami-build-tools install && npm i serve && npx origami-build-tools demo",
-    "start": "serve -l $PORT"
-  }
+	"private": true,
+	"name": "o-table",
+	"devDependencies": {
+		"origami-ci-tools": "^1.0.0"
+	}
 }

--- a/src/scss/_base.scss
+++ b/src/scss/_base.scss
@@ -13,6 +13,7 @@
 
 		th,
 		td {
+			@include oTypographySans(1);
 			padding: 10px;
 			text-align: left;
 			vertical-align: top;
@@ -22,7 +23,7 @@
 		}
 
 		th {
-			@include oTypographySansBold(1);
+			@include oTypographySans($weight: 'semibold', $include-font-family: false);
 			background-color: _oTableGet('header-background');
 			&:not([scope=row]) {
 				vertical-align: bottom;
@@ -30,10 +31,9 @@
 		}
 
 		td {
-			@include oTypographySans(1);
 			scroll-snap-align: none center;
 			&:empty:before {
-				@include oIconsGetIcon('minus', $container-width: 15,  $container-height: 15, $iconset-version: 1);
+				@include oIconsContent('minus', $size: 15);
 				content: '';
 				vertical-align: middle;
 			}
@@ -53,7 +53,7 @@
 		}
 
 		.o-table__cell--content-secondary {
-			@include oTypographySize(0);
+			@include oTypographySans(0, $include-font-family: false);
 			font-weight: normal;
 		}
 

--- a/src/scss/_base.scss
+++ b/src/scss/_base.scss
@@ -71,14 +71,6 @@
 		margin-left: 10px;
 	}
 
-	// A spacing class.
-	// e.g. .o-table.o-table-margin-bottom or .o-table-container.o-table-margin-bottom
-	// @deprecated - this is no longer needed now we have `o-spacing`.
-	// @see https://registry.origami.ft.com/components/o-spacing
-	.o-table-margin-bottom {
-		margin-bottom: oSpacingByName('s4');
-	}
-
 	// Visually hide any filtered rows.
 	// `display: none` is not used to avoid recalculating column row.
 	// `visibility: collaposed` is not used due to inconsistent browser support.

--- a/src/scss/_brand.scss
+++ b/src/scss/_brand.scss
@@ -13,11 +13,11 @@
 @if oBrandGetCurrentBrand() == 'master' {
 	@include oBrandDefine('o-table', 'master', (
 		'variables': (
-			table-background: oColorsGetPaletteColor('paper'),
-			table-alternate-background: oColorsGetPaletteColor('wheat'),
-			table-border-color: oColorsGetPaletteColor('black-20'),
-			table-data-color: oColorsGetColorFor(body, text),
-			table-footnote-color: oColorsGetPaletteColor('black-60'),
+			table-background: oColorsByName('paper'),
+			table-alternate-background: oColorsByName('wheat'),
+			table-border-color: oColorsByName('black-20'),
+			table-data-color: oColorsByUsecase('body', 'text'),
+			table-footnote-color: oColorsByName('black-60'),
 			'flat': (
 				table-item-alternate-background: oColorsMix('wheat', 'paper', 40)
 			)
@@ -32,13 +32,13 @@
 @if oBrandGetCurrentBrand() == 'internal' {
 	@include oBrandDefine('o-table', 'internal', (
 		'variables': (
-			table-background: oColorsGetPaletteColor('white'),
-			table-alternate-background: oColorsGetPaletteColor('slate-white-5'),
-			table-border-color: oColorsGetPaletteColor('black-20'),
-			table-data-color: oColorsGetColorFor(body, text),
-			table-footnote-color: oColorsGetPaletteColor('black-60'),
+			table-background: oColorsByName('white'),
+			table-alternate-background: oColorsByName('slate-white-5'),
+			table-border-color: oColorsByName('black-20'),
+			table-data-color: oColorsByUsecase('body', 'text'),
+			table-footnote-color: oColorsByName('black-60'),
 			'flat': (
-				table-item-alternate-background: oColorsGetPaletteColor('slate-white-5')
+				table-item-alternate-background: oColorsByName('slate-white-5')
 			)
 		),
 		'supports-variants': (

--- a/src/scss/_compact.scss
+++ b/src/scss/_compact.scss
@@ -2,17 +2,14 @@
 /// @access private
 @mixin _oTableCompact {
 	.o-table--compact {
-		th {
-			@include oTypographySansBold(0);
-		}
-
-		td {
-			@include oTypographySans(0);
-		}
-
 		th,
 		td {
+			@include oTypographySans(0);
 			padding: 4px 10px;
+		}
+
+		th {
+			@include oTypographySans($weight: 'semibold', $include-font-family: false);
 		}
 	}
 }

--- a/src/scss/_responsive-overflow.scss
+++ b/src/scss/_responsive-overflow.scss
@@ -25,7 +25,10 @@
 			pointer-events: all;
 			transition: 1s opacity ease-in-out;
 			button {
-				@include oButtons($size: 'big', $theme: 'primary');
+				@include oButtonsContent((
+					'type': 'primary',
+					'size': 'big'
+				));
 			}
 		}
 
@@ -45,9 +48,17 @@
 			@supports (pointer-events: none)  {
 				position: absolute;
 				top: calc(50% - 20px);
-				transition: opacity 0.3s $o-visual-effects-transition-fade;
+				transition: opacity 0.3s $o-visual-effects-timing-fade;
 			}
 			z-index: 1;
+		}
+
+		.o-table-control--back button,
+		.o-table-control--forward button {
+				@include oButtonsContent((
+					'size': 'big',
+					'icon-only': true
+				), $include-base-styles: false);
 		}
 
 		.o-table-control--back {
@@ -55,11 +66,13 @@
 			float: left; //sticky
 			margin: 0 10px;
 			button {
-				@include oButtonsIconButton(
-					$icon-name: 'arrow-left',
-					$size: 'big',
-					$theme: 'primary',
-					$is-icon-only: true
+				@include oButtonsContent(
+					$opts: (
+						'type': 'primary',
+						'icon': 'arrow-left'
+					),
+					$include-base-styles: false,
+					$include-base-icon-styles: false
 				);
 			}
 		}
@@ -69,11 +82,13 @@
 			float: right; //sticky
 			margin: 0 10px;
 			button {
-				@include oButtonsIconButton(
-					$icon-name: 'arrow-right',
-					$size: 'big',
-					$theme: 'primary',
-					$is-icon-only: true
+				@include oButtonsContent(
+					$opts: (
+						'type': 'primary',
+						'icon': 'arrow-right'
+					),
+					$include-base-styles: false,
+					$include-base-icon-styles: false
 				);
 			}
 		}
@@ -96,7 +111,7 @@
 			bottom: 0;
 			height: 40px;
 			pointer-events: none;
-			border-color: oButtonsGetColor('default', 'background', $theme: 'primary');
+			border-color: oButtonsGetColor('default', 'background', $type: 'primary');
 			border-style: solid;
 			width: 1px;
 		}

--- a/src/scss/_sort.scss
+++ b/src/scss/_sort.scss
@@ -29,7 +29,7 @@
 		padding: 0;
 		padding-right: $_o-table-sort-icon-size;
 		&:after {
-			@include oIconsGetIcon('arrows-up-down', $container-width: $_o-table-sort-icon-size,  $container-height: $_o-table-sort-icon-size, $iconset-version: 1);
+			@include oIconsContent('arrows-up-down', $size: $_o-table-sort-icon-size);
 			content: '';
 			vertical-align: middle;
 			margin: -($_o-table-sort-icon-size/2) 0;
@@ -40,7 +40,7 @@
 	// Show descending icon in sort button with DSC sort applied.
 	[aria-sort='descending'] .o-table__sort {
 		&:after {
-			@include oIconsGetIcon('arrow-down', $container-width: $_o-table-sort-icon-size,  $container-height: $_o-table-sort-icon-size, $iconset-version: 1);
+			@include oIconsContent('arrow-down', $size: $_o-table-sort-icon-size);
 			vertical-align: middle;
 		}
 	}
@@ -50,7 +50,7 @@
 	th:not([aria-sort]) .o-table__sort:hover, // sass-lint:disable-line no-qualifying-elements
 	[aria-sort='ascending'] .o-table__sort {
 		&:after {
-			@include oIconsGetIcon('arrow-up', $container-width: 1.25rem,  $container-height: 1.25rem, $iconset-version: 1);
+			@include oIconsContent('arrow-up', $size: 1.25rem);
 			vertical-align: middle;
 		}
 	}


### PR DESCRIPTION
(closes #166)

I've removed the deprecated margin class, updated the dependencies to use :carrot: ranges and that seems to be it.

There are no public mixins other than the primary, the JS is already esm. Do we want to break o-table some more?