### PR TITLE
Add flat and scroll variants to the pa11y demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ OTable.init(document.body, {
 
 ### Filtering
 
-All `o-table` instances support filtering. Filters may be applied declaritively in HTML or the `filter` method may be called against a table instance.
+All `o-table` instances support filtering. Filters may be applied declaratively in HTML or the `filter` method may be called against a table instance.
 
 #### Filter (declarative)
 

--- a/demos/src/pa11y.mustache
+++ b/demos/src/pa11y.mustache
@@ -1,7 +1,7 @@
 <div class="o-table-container">
 	<div class="o-table-overlay-wrapper">
 		<div class="o-table-scroll-wrapper">
-			<table aria-describedby="demo-footnote" class="o-table o-table--horizontal-lines o-table--responsive-overflow" data-o-component="o-table" data-o-table-responsive="overflow" data-o-table-minimum-row-count="2" data-o-table-expanded="false">
+			<table aria-describedby="demo-footnote-overflow" class="o-table o-table--horizontal-lines o-table--responsive-overflow" data-o-component="o-table" data-o-table-responsive="overflow" data-o-table-minimum-row-count="2" data-o-table-expanded="false">
 				<thead>
 					<tr>
 						<th scope="col" role="columnheader">Fruit</th>
@@ -51,7 +51,7 @@
 			</table>
 		</div>
 	</div>
-	<div id="demo-footnote" class="o-table-footnote">
+	<div id="demo-footnote-overflow" class="o-table-footnote">
 		Source: The Origami team's love of fruit.
 	</div>
 </div>
@@ -59,7 +59,7 @@
 <div class="o-table-container">
 	<div class="o-table-overlay-wrapper">
 		<div class="o-table-scroll-wrapper">
-			<table aria-describedby="demo-footnote" class="o-table o-table--horizontal-lines o-table--responsive-flat" data-o-component="o-table" data-o-table-responsive="flat">
+			<table aria-describedby="demo-footnote-flat" class="o-table o-table--horizontal-lines o-table--responsive-flat" data-o-component="o-table" data-o-table-responsive="flat">
 				<thead>
 					<tr>
 						<th scope="col" role="columnheader">Fruit</th>
@@ -109,7 +109,7 @@
 			</table>
 		</div>
 	</div>
-	<div id="demo-footnote" class="o-table-footnote">
+	<div id="demo-footnote-flat" class="o-table-footnote">
 		Source: The Origami team's love of fruit.
 	</div>
 </div>
@@ -117,7 +117,7 @@
 <div class="o-table-container">
 	<div class="o-table-overlay-wrapper">
 		<div class="o-table-scroll-wrapper">
-			<table aria-describedby="demo-footnote" class="o-table o-table--horizontal-lines o-table--responsive-scroll" data-o-component="o-table" data-o-table-responsive="scroll">
+			<table aria-describedby="demo-footnote-scroll" class="o-table o-table--horizontal-lines o-table--responsive-scroll" data-o-component="o-table" data-o-table-responsive="scroll">
 				<thead>
 					<tr>
 						<th scope="col" role="columnheader">Fruit</th>
@@ -167,7 +167,7 @@
 			</table>
 		</div>
 	</div>
-	<div id="demo-footnote" class="o-table-footnote">
+	<div id="demo-footnote-scroll" class="o-table-footnote">
 		Source: The Origami team's love of fruit.
 	</div>
 </div>

--- a/demos/src/pa11y.mustache
+++ b/demos/src/pa11y.mustache
@@ -56,6 +56,121 @@
 	</div>
 </div>
 
+<div class="o-table-container">
+	<div class="o-table-overlay-wrapper">
+		<div class="o-table-scroll-wrapper">
+			<table aria-describedby="demo-footnote" class="o-table o-table--horizontal-lines o-table--responsive-flat" data-o-component="o-table" data-o-table-responsive="flat">
+				<thead>
+					<tr>
+						<th scope="col" role="columnheader">Fruit</th>
+						<th scope="col" role="columnheader">Genus</th>
+						<th scope="col" role="columnheader">Characteristic</th>
+						<th scope="col" role="columnheader" data-o-table-data-type="numeric" class="o-table__cell--numeric">Cost&nbsp;(GBP)</th>
+						<th scope="col" role="columnheader" data-o-table-data-type="numeric" class="o-table__cell--numeric">Cost&nbsp;(EUR)</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<td>Dragonfruit</td>
+						<td>Stenocereus</td>
+						<td>Juicy</td>
+						<td class="o-table__cell--numeric">3</td>
+						<td class="o-table__cell--numeric">2.72</td>
+					</tr>
+					<tr>
+						<td>Durian</td>
+						<td>Durio</td>
+						<td>Smelly</td>
+						<td class="o-table__cell--numeric">1.75</td>
+						<td class="o-table__cell--numeric">1.33</td>
+					</tr>
+					<tr>
+						<td>Naseberry</td>
+						<td>Manilkara</td>
+						<td>Chewy</td>
+						<td class="o-table__cell--numeric">2</td>
+						<td class="o-table__cell--numeric">1.85</td>
+					</tr>
+					<tr>
+						<td>Strawberry</td>
+						<td>Fragaria</td>
+						<td>Sweet</td>
+						<td class="o-table__cell--numeric">1.5</td>
+						<td class="o-table__cell--numeric">1.69</td>
+					</tr>
+					<tr>
+						<td>Apple</td>
+						<td>Malus</td>
+						<td>Crunchy</td>
+						<td class="o-table__cell--numeric">0.5</td>
+						<td class="o-table__cell--numeric">0.56</td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+	</div>
+	<div id="demo-footnote" class="o-table-footnote">
+		Source: The Origami team's love of fruit.
+	</div>
+</div>
+
+<div class="o-table-container">
+	<div class="o-table-overlay-wrapper">
+		<div class="o-table-scroll-wrapper">
+			<table aria-describedby="demo-footnote" class="o-table o-table--horizontal-lines o-table--responsive-scroll" data-o-component="o-table" data-o-table-responsive="scroll">
+				<thead>
+					<tr>
+						<th scope="col" role="columnheader">Fruit</th>
+						<th scope="col" role="columnheader">Genus</th>
+						<th scope="col" role="columnheader">Characteristic</th>
+						<th scope="col" role="columnheader" data-o-table-data-type="numeric" class="o-table__cell--numeric">Cost&nbsp;(GBP)</th>
+						<th scope="col" role="columnheader" data-o-table-data-type="numeric" class="o-table__cell--numeric">Cost&nbsp;(EUR)</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<td>Dragonfruit</td>
+						<td>Stenocereus</td>
+						<td>Juicy</td>
+						<td class="o-table__cell--numeric">3</td>
+						<td class="o-table__cell--numeric">2.72</td>
+					</tr>
+					<tr>
+						<td>Durian</td>
+						<td>Durio</td>
+						<td>Smelly</td>
+						<td class="o-table__cell--numeric">1.75</td>
+						<td class="o-table__cell--numeric">1.33</td>
+					</tr>
+					<tr>
+						<td>Naseberry</td>
+						<td>Manilkara</td>
+						<td>Chewy</td>
+						<td class="o-table__cell--numeric">2</td>
+						<td class="o-table__cell--numeric">1.85</td>
+					</tr>
+					<tr>
+						<td>Strawberry</td>
+						<td>Fragaria</td>
+						<td>Sweet</td>
+						<td class="o-table__cell--numeric">1.5</td>
+						<td class="o-table__cell--numeric">1.69</td>
+					</tr>
+					<tr>
+						<td>Apple</td>
+						<td>Malus</td>
+						<td>Crunchy</td>
+						<td class="o-table__cell--numeric">0.5</td>
+						<td class="o-table__cell--numeric">0.56</td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+	</div>
+	<div id="demo-footnote" class="o-table-footnote">
+		Source: The Origami team's love of fruit.
+	</div>
+</div>
 
 <table class="o-table o-table--compact o-table--row-stripes" data-o-component="o-table">
 	<tfoot>

--- a/src/js/Tables/FlatTable.js
+++ b/src/js/Tables/FlatTable.js
@@ -62,7 +62,7 @@ class FlatTable extends BaseTable {
 	_createFlatTableStructure(rows = this.tableRows) {
 		rows
 			.filter(row => !row.hasAttribute('data-o-table-flat-headings')) // only process rows once
-			.forEach((row, index) => {
+			.forEach(row => {
 				const data = Array.from(row.getElementsByTagName('td'));
 				row.setAttribute('data-o-table-flat-headings', true);
 				window.requestAnimationFrame(() => {

--- a/src/js/Tables/FlatTable.js
+++ b/src/js/Tables/FlatTable.js
@@ -1,16 +1,5 @@
 import BaseTable from './BaseTable';
 
-// function to return a unique id to link header to data cells
-let headerCount = 0;
-const generateCellId = (cell) => {
-	// Return an id if one already exists.
-	if (cell instanceof Node && cell.getAttribute('id')) {
-		return cell.getAttribute('id');
-	}
-	// Otherwise create an o-table id.
-	return `o-table-flat-header-${headerCount++}`;
-};
-
 class FlatTable extends BaseTable {
 
 	/**
@@ -80,47 +69,18 @@ class FlatTable extends BaseTable {
 					// Create a new table body for every row.
 					const newGroupBody = document.createElement('tbody');
 					newGroupBody.classList.add('o-table__responsive-body');
-					// Create a row in the new bodies for every data cell.
-					const newGroupRow = document.createElement('tr');
-					newGroupRow.classList.add('o-table__duplicate-row');
-					// Create a column header "item x" for each new body.
-					// First create a blank cell which will be the header for
-					// for our new column header. This will prevent some assistive
-					// technologies from reading a header our heading cell.
-					// https://www.w3.org/WAI/tutorials/tables/multi-level/
-					const newItemHeaderBlankItem = document.createElement('td');
-					const newItemHeaderBlankItemId = generateCellId(newItemHeaderBlankItem);
-					newItemHeaderBlankItem.setAttribute('id', newItemHeaderBlankItemId);
-					newItemHeaderBlankItem.innerHTML = '&nbsp;';
-					// Second create the actual header cell and set its headings
-					// to the blank heading cell.
-					const newItemHeader = document.createElement('th');
-					newItemHeader.innerText = `Item ${index + 1}`;
-					const groupHeaderId = generateCellId(newItemHeader);
-					newItemHeader.setAttribute('id', groupHeaderId);
-					newItemHeader.setAttribute('headers', `${newItemHeaderBlankItemId}`);
-					newItemHeader.setAttribute('scope', 'colgroup');
-					newItemHeader.classList.add('o-table__group-heading');
-					// Append the heading items to the new row,
-					// and append the new row to the new body.
-					newGroupRow.appendChild(newItemHeader);
-					newGroupRow.appendChild(newItemHeaderBlankItem);
-					newGroupBody.appendChild(newGroupRow);
 					// Append all the other rows as heading / value pairs.
 					this._tableHeadersWithoutSort.forEach((header, index) => {
 						// Create the row.
 						const newRow = document.createElement('tr');
 						newRow.classList.add('o-table__duplicate-row');
-						// Duplicate the original heading cell and set headings.
+						// Duplicate the original heading cell.
 						const clonedHeader = header.cloneNode(true);
-						const clonedHeaderId = generateCellId(clonedHeader);
-						clonedHeader.setAttribute('id', clonedHeaderId);
-						clonedHeader.setAttribute('headers', `${groupHeaderId}`);
+						clonedHeader.classList.add('o-table__duplicate-heading');
 						clonedHeader.setAttribute('scope', 'row');
-						clonedHeader.removeAttribute('role');
-						// Duplicate the original data cell and set headings.
+						clonedHeader.setAttribute('role', 'rowheader');
+						// Duplicate the original data cell.
 						const clonedTd = data[index].cloneNode(true);
-						clonedTd.setAttribute('headers', `${groupHeaderId} ${clonedHeaderId}`);
 						// Append the header and data cell to the row.
 						newRow.appendChild(clonedHeader);
 						newRow.appendChild(clonedTd);

--- a/src/scss/_responsive-flat.scss
+++ b/src/scss/_responsive-flat.scss
@@ -4,46 +4,58 @@
 	.o-table.o-table--responsive-flat {
 		width: 100%;
 
-		.o-table__duplicate-heading {
+		// hide elements added for the mobile version of the flat table
+		.o-table__duplicate-row,
+		.o-table__responsive-body {
 			display: none;
 		}
 
 		@include oGridRespondTo($until: S) {
-			display: block;
+			// hide elements for the desktop version of the table
+			thead,
+			thead tr,
+			thead th {
+				display: none;
+			}
 
-			td,
+			tbody:not(.o-table__responsive-body),
+			tr:not(.o-table__duplicate-row) {
+				display: none;
+			}
+
+			// show elements created for the mobile version of the flat table
+			.o-table__responsive-body {
+				display: table-row-group;
+			}
+
+			.o-table__duplicate-row {
+				display: table-row;
+			}
+
 			th,
-			tr {
-				box-sizing: border-box;
-			}
-
-			tr {
-				display: flex;
-				flex-flow: row wrap;
-				width: 100%;
-			}
-
 			td {
+				box-sizing: border-box;
 				padding: 10px;
 				width: 50%;
 			}
 
-			thead th {
-				display: none;
-				padding: 10px;
+			// Add border between items
+			tbody:not(:last-child) {
+				border-bottom: 1px solid _oTableGet('table-data-color');
 			}
 
-			thead tr {
-				display: none;
+			// Remove stripes when flat.
+			&.o-table--row-stripes tr,
+			&.o-table--row-stripes tr th {
+				background-color: transparent;
 			}
 
-			tbody tr:not(:first-child) {
-				border-top: 1px solid _oTableGet('table-data-color');
-			}
-
-			&.o-table--row-stripes tbody tr:nth-child(even) th, // Remove stripes when flat.
-			tbody tr:nth-child(even) {
-				background-color: _oTableGet('table-item-alternate-background', 'flat');
+			// Alternate background colour of each item
+			tbody {
+				background-color: _oTableGet('table-background');
+				&:nth-child(even) {
+					background-color: _oTableGet('table-item-alternate-background', 'flat');
+				}
 			}
 
 			&.o-table--horizontal-lines th:not(:last-of-type),
@@ -53,13 +65,6 @@
 				@if _oTableGet('table-border-color') {
 					border-bottom: 1px solid _oTableGet('table-border-color');
 				}
-			}
-
-			.o-table__duplicate-heading {
-				display: block;
-				float: left;
-				padding: 10px;
-				width: 50%;
 			}
 
 			.o-table__cell--numeric {

--- a/test/BaseTable.test.js
+++ b/test/BaseTable.test.js
@@ -40,7 +40,7 @@ describe("BaseTable", () => {
 	});
 
 	describe('constructor', () => {
-		it('applies declaritive table filters', (done) => {
+		it('applies declarative table filters', (done) => {
 			// Setup markup: Table + filter input.
 			const data = ['Dragonfruit', 'Durian', 'Naseberry', 'Strawberry', 'Apple'];
 			const tableId = 'constructor-test-table';
@@ -58,7 +58,7 @@ describe("BaseTable", () => {
 			`);
 			// Init table.
 			table = new BaseTable(oTableEl, sorter);
-			// Confirm default filter (set declaritively).
+			// Confirm default filter (set declaratively).
 			setTimeout(() => {
 				try {
 					assertFilter(data, ['Naseberry']);
@@ -66,7 +66,7 @@ describe("BaseTable", () => {
 				} catch(error) {
 					done(error);
 				}
-			}, 100); // wait for window.requestAnimationFrame
+			}, 1000); // wait for window.requestAnimationFrame
 		});
 	});
 

--- a/test/FlatTable.test.js
+++ b/test/FlatTable.test.js
@@ -30,15 +30,34 @@ describe("FlatTable", () => {
 		proclaim.isInstanceOf(table, BaseTable);
 	});
 
-	it('clones all headings into each row, so each cell has a row heading for the flat view (mobile version)', (done) => {
+	it('creates a row for each data cell with heading for the flat view (mobile version)', (done) => {
+		const generatedRowsClass = '.o-table__duplicate-row';
+		const generatedHeadingClass = '.o-table__duplicate-heading';
+		const expectedRowCount = 25;
 		const table = new FlatTable(oTableEl, sorter);
 		setTimeout(() => {
 			try {
-				proclaim.equal(table.tableRows.length, 5, `Expected to find 5 table rows.`);
-				table.tableRows.forEach(row => {
-					const duplicateHeadingClass = '.o-table__duplicate-heading';
-					const duplicateHeadings = row.querySelectorAll(`${duplicateHeadingClass}[scope="row"][role="rowheader"]`);
-					proclaim.equal(duplicateHeadings.length, 5, `Expected table rows to contain a clone of all headings,  with class "${duplicateHeadingClass}", scope="row", and role="rowheader".`);
+				const generatedRows = table.rootEl.querySelectorAll(generatedRowsClass);
+				proclaim.equal(
+					generatedRows.length,
+					expectedRowCount,
+					`Expected to find ${expectedRowCount} generated table rows ` +
+					`with class "${generatedHeadingClass}, "found ${generatedRows.length}.`
+				);
+				generatedRows.forEach(row => {
+					const generatedHeadings = row.querySelectorAll(`${generatedHeadingClass}[scope="row"][role="rowheader"]`);
+					const dataCells = row.querySelectorAll(`td`);
+					proclaim.equal(
+						generatedHeadings.length,
+						1,
+						`Expected generated rows to contain one heading with class` +
+						`"${generatedHeadingClass}", scope="row", and role="rowheader".` +
+						`Found ${generatedHeadings.length}.`);
+					proclaim.equal(
+						dataCells.length,
+						1,
+						`Expected generated rows to contain one data cell.` +
+						`Found ${dataCells.length}.`);
 				});
 			} catch (error) {
 				done(error);
@@ -47,8 +66,20 @@ describe("FlatTable", () => {
 		}, 100); // wait for window.requestAnimationFrame
 	});
 
+	it('only includes original rows in the `tableRows` property, not those generated for the flat view (mobile version)', (done) => {
+		const table = new FlatTable(oTableEl, sorter);
+		setTimeout(() => {
+			try {
+				proclaim.equal(table.tableRows.length, 5, `Expected to find 5 table rows.`);
+			} catch (error) {
+				done(error);
+			}
+			done();
+		}, 100); // wait for window.requestAnimationFrame
+	});
+
 	describe("updateRows", () => {
-		it('for any new rows, clones all headings into each row, so each cell has a row heading for the flat view (mobile version)', (done) => {
+		it('for any new rows, creates a row for each data cell for the flat view (mobile version)', (done) => {
 			const trClone = oTableEl.querySelector('tbody > tr').cloneNode({ deep: true });
 			const table = new FlatTable(oTableEl, sorter);
 			const originalTableRowLength = table.tableRows.length;
@@ -62,12 +93,17 @@ describe("FlatTable", () => {
 					try {
 						// confirm o-table found the new row
 						proclaim.equal(table.tableRows.length - originalTableRowLength, 1, `Expected to find 1 new table row.`);
-						// confirm that all rows, including the new row, have a duplicated heading for the "flat" view
-						table.tableRows.forEach(row => {
-							const duplicateHeadingClass = '.o-table__duplicate-heading';
-							const duplicateHeadings = row.querySelectorAll(`${duplicateHeadingClass}[scope="row"][role="rowheader"]`);
-							proclaim.equal(duplicateHeadings.length, 5, `Expected table rows to contain a clone of all headings,  with class "${duplicateHeadingClass}", scope="row", and role="rowheader".`);
-						});
+						// confirm that all rows, including the new row, have been split into multiple rows for the "flat" view
+						const generatedRowsClass = '.o-table__duplicate-row';
+						const generatedHeadingClass = '.o-table__duplicate-heading';
+						const expectedRowCount = 30;
+						const generatedRows = table.rootEl.querySelectorAll(generatedRowsClass);
+						proclaim.equal(
+							generatedRows.length,
+							expectedRowCount,
+							`Expected to find ${expectedRowCount} generated table rows ` +
+							`with class "${generatedHeadingClass}, "found ${generatedRows.length}.`
+						);
 					} catch (error) {
 						done(error);
 					}


### PR DESCRIPTION
Updates the responsive flat table to have valid html. It is no longer announced 
as an empty table to screen reader users. To achieve the visual look each row
becomes a new `tbody`, with a row for each data cell and its corresponding header.

Addresses: https://github.com/Financial-Times/o-table/issues/180

This:
```html
<table>
    <thead>
        <th>h</th>
    </thead>

    <tbody>
        <tr>
            <td>a</td>
        </tr>
        <tr>
            <td>b</td>
        </tr>
    </tbody>
</table>
```

Becomes this for the flat view:
```html
<table>
    <tbody>
        <tr>
            <th>h</th>
            <td>a</td>
        </tr>
    </tbody>
    <tbody>
        <tr>
            <th>h</th>
            <td>b</td>
        </tr>
    </tbody>
</table>
```

![Screenshot 2020-02-20 at 17 45 07](https://user-images.githubusercontent.com/10405691/74963384-8a4d9300-5409-11ea-866a-89b03e37b423.png)
