### PR TITLE
Stop using magic webpack imports

### DIFF
--- a/demos/src/demo.js
+++ b/demos/src/demo.js
@@ -1,5 +1,1 @@
-/*global require*/
-
-(function() {
-	require('./../../main');
-}());
+import './../../main';

--- a/main.js
+++ b/main.js
@@ -1,4 +1,3 @@
-/*global require, module*/
 import oTable from './src/js/oTable';
 
 const constructAll = function() {

--- a/test/BaseTable.test.js
+++ b/test/BaseTable.test.js
@@ -1,7 +1,6 @@
-/* eslint-env mocha, sinon */
+/* eslint-env mocha */
+/* global proclaim, sinon */
 
-import proclaim from 'proclaim';
-import sinon from 'sinon/pkg/sinon';
 import * as sandbox from './helpers/sandbox';
 import * as fixtures from './helpers/fixtures';
 import BaseTable from './../src/js/Tables/BaseTable';
@@ -187,6 +186,7 @@ describe("BaseTable", () => {
 			sandbox.setContents(fixtures.shortTableWithContainer);
 			oTableEl = document.querySelector('[data-o-component=o-table]');
 			table = new BaseTable(oTableEl, sorter);
+			self.console.warn = sinon.spy();
 		});
 
 		it('adds buttons in the table column headers', done => {
@@ -464,7 +464,8 @@ describe("BaseTable", () => {
 			setTimeout(() => {
 				// The filter includes the original Apple row and the clone
 				// added after the table was initialised.
-				done(assertFilter(data, [cloneData, cloneData]));
+				assertFilter(data, [cloneData, cloneData]);
+				done();
 			}, 100); // wait for window.requestAnimationFrame
 		});
 

--- a/test/BasicTable.test.js
+++ b/test/BasicTable.test.js
@@ -1,7 +1,6 @@
 /* eslint-env mocha */
+/* global proclaim, sinon */
 
-import proclaim from 'proclaim';
-import sinon from 'sinon/pkg/sinon';
 import * as sandbox from './helpers/sandbox';
 import * as fixtures from './helpers/fixtures';
 import BasicTable from './../src/js/Tables/BasicTable';

--- a/test/FlatTable.test.js
+++ b/test/FlatTable.test.js
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
+/* global proclaim */
 
-import proclaim from 'proclaim';
 import * as sandbox from './helpers/sandbox';
 import * as fixtures from './helpers/fixtures';
 import FlatTable from './../src/js/Tables/FlatTable';

--- a/test/OverflowTable.test.js
+++ b/test/OverflowTable.test.js
@@ -1,6 +1,5 @@
-/* eslint-env mocha, sinon, proclaim */
-
-import proclaim from 'proclaim';
+/* eslint-env mocha */
+/* global proclaim */
 
 import * as sandbox from './helpers/sandbox';
 import * as fixtures from './helpers/fixtures';

--- a/test/ScrollTable.test.js
+++ b/test/ScrollTable.test.js
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
+/* global proclaim */
 
-import proclaim from 'proclaim';
 import * as sandbox from './helpers/sandbox';
 import * as fixtures from './helpers/fixtures';
 import ScrollTable from './../src/js/Tables/ScrollTable';

--- a/test/Sort/TableSorter.test.js
+++ b/test/Sort/TableSorter.test.js
@@ -1,7 +1,6 @@
-/* eslint-env mocha, sinon */
+/* eslint-env mocha */
+/* global proclaim sinon */
 
-import proclaim from 'proclaim';
-import sinon from 'sinon/pkg/sinon';
 import * as sandbox from './../helpers/sandbox';
 import * as fixtures from './../helpers/fixtures';
 import BaseTable from './../../src/js/Tables/BaseTable';
@@ -96,9 +95,9 @@ describe("BaseTable", () => {
 			const columnIndex = 0;
 			const sortOrder = 'ascending';
 			const expected = ['Æ', 'apple', 'café', 'caffeine'];
-			// Remove global.Intl
+			// Remove self.Intl
 			const intlBackup = Intl;
-			delete global.Intl;
+			delete self.Intl;
 			sorter.sortRowsByColumn(table, columnIndex, sortOrder);
 			let error;
 			assertSortOrder({ sortOrder, columnIndex, expected })
@@ -106,7 +105,7 @@ describe("BaseTable", () => {
 					error = err;
 				})
 				.finally(() => {
-					global.Intl = intlBackup; // Retore global.Intl
+					self.Intl = intlBackup; // Retore self.Intl
 					done(error);
 				});
 		});

--- a/test/oTable.test.js
+++ b/test/oTable.test.js
@@ -1,6 +1,5 @@
-/* eslint-env mocha, proclaim */
-
-import proclaim from 'proclaim';
+/* eslint-env mocha */
+/* global proclaim */
 
 import * as sandbox from './helpers/sandbox';
 import * as fixtures from './helpers/fixtures';


### PR DESCRIPTION
Stop using the magic imports for proclaim and sinon and pull them from the global because that's where Karma has added them. This is required for obt v10 to be released.