### PR TITLE
Add option `data-o-table-preferred-sort-order`

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,12 +228,12 @@ Alternatively include base styles with only selected optional features. E.g. to 
 To manually instantiate `o-table`:
 
 ``` js
-const OTable = require('o-table');
+import OTable from 'o-table';
 OTable.init();
 ```
 or
 ``` js
-const OTable = require('o-table');
+import OTable from 'o-table';
 oTable = new OTable(document.body);
 ```
 
@@ -242,7 +242,7 @@ This will return an instance of `BasicTable` (default), `OverflowTable`, `FlatTa
 Instantiation will add column sorting to all tables. It will also add scroll controls and, if configured, an [expander](#expander) to any `OverflowTable`. These can be configured with [data attributes](#disable-sort) or imperatively with an options object:
 
 ``` js
-const OTable = require('o-table');
+import OTable from 'o-table';
 OTable.init(document.body, {
 	sortable: true,
 	expanded: true,
@@ -402,7 +402,7 @@ The formatter accepts the table cell (HTMLElement) and returns a sort value (Num
 In this case we add support for our custom type `emoji-time` by assigning the emoji a numerical sort value. This will effect all tables instantiated by `OTable`.
 
 ``` js
-const OTable = require('o-table');
+import OTable from 'o-table';
 // Set a filter for custom data type "emoji-time".
 // The return value may be a string or number.
 OTable.setSortFormatterForType('emoji-time', (cell) => {

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The table's footer `tfoot` element may use the helper class `o-table-footnote` t
 
 ### Sort Order
 
-When a sortable table column is clicked an ascending sort is applied by default. If clicked again the sort order is toggled to a descending sort. Inverse this, so a descending sort is applied on the first click, set the preferred sort order attribute `data-o-table-preferred-sort-order="descending"`.
+When a sortable table column is clicked an ascending sort is applied by default. If clicked again the sort order is toggled to a descending sort. Set the preferred sort order attribute `data-o-table-preferred-sort-order="descending"` to inverse this, so a descending sort is applied on the first click.
 
 ```html
 <table class="o-table" data-o-component="o-table" data-o-table-preferred-sort-order="descending">

--- a/README.md
+++ b/README.md
@@ -88,6 +88,15 @@ The table's footer `tfoot` element may use the helper class `o-table-footnote` t
 </table>
 ```
 
+### Sort Order
+
+When a sortable table column is clicked an ascending sort is applied by default. If clicked again the sort order is toggled to a descending sort. Inverse this, so a descending sort is applied on the first click, set the preferred sort order attribute `data-o-table-preferred-sort-order="descending"`.
+
+```html
+<table class="o-table" data-o-component="o-table" data-o-table-preferred-sort-order="descending">
+</table>
+```
+
 ### Disable sort
 
 Table columns are sortable by default but may be disabled by adding `data-o-table-sortable="false"` to the table.
@@ -237,6 +246,7 @@ const OTable = require('o-table');
 OTable.init(document.body, {
 	sortable: true,
 	expanded: true,
+	preferredSortOrder: 'ascending',
 	minimumRowCount: 10,
 });
 ```

--- a/src/js/Tables/BaseTable.js
+++ b/src/js/Tables/BaseTable.js
@@ -51,7 +51,8 @@ class BaseTable {
 		this._sorter = sorter;
 		this.rootEl = rootEl;
 		this._opts = Object.assign({
-			sortable: this.rootEl.getAttribute('data-o-table-sortable') !== 'false'
+			sortable: this.rootEl.getAttribute('data-o-table-sortable') !== 'false',
+			preferredSortOrder: this.rootEl.getAttribute('data-o-table-preferred-sort-order')
 		}, opts);
 		this.thead = this.rootEl.querySelector('thead');
 		this.tbody = this.rootEl.querySelector('tbody');
@@ -556,7 +557,14 @@ class BaseTable {
 		const columnIndex = this.tableHeaders.indexOf(th);
 		if (th && !isNaN(columnIndex)) {
 			const currentSort = th.getAttribute('aria-sort');
-			const sortOrder = [null, 'none', 'descending'].indexOf(currentSort) !== -1 ? 'ascending' : 'descending';
+			// Order the column ascending by default, or descending if the
+			// column is already sorted ascending.
+			let sortOrder = currentSort !== 'ascending' ? 'ascending' : 'descending';
+			// Unless there is no existing sort and a descending is preferred.
+			const noExistingSort = [null, 'none'].indexOf(currentSort) !== -1;
+			if (noExistingSort && this._opts.preferredSortOrder === 'descending') {
+				sortOrder = 'descending';
+			}
 			this.sortRowsByColumn(columnIndex, sortOrder);
 		}
 	}

--- a/src/js/oTable.js
+++ b/src/js/oTable.js
@@ -78,7 +78,7 @@ class OTable {
 	 * Set a custom sort formatter for a given data type.
 	 *
 	 * @example <caption>Mapping table cells which contain emojis to a numerical sort value.</caption>
-	 *	const OTable = require('o-table');
+	 *	import OTable from 'o-table';
 	 *	// Set a filter for custom data type "emoji-time".
 	 *	// The return value may be a string or number.
 	 *	OTable.setSortFormatterForType('emoji-time', (cell) => {

--- a/test/BaseTable.test.js
+++ b/test/BaseTable.test.js
@@ -298,6 +298,34 @@ describe("BaseTable", () => {
 				}, 100);
 			}, 100);
 		});
+
+		it('buttons toggle column sort by preferred sort order with header button click (descending first)', done => {
+			// Set preferred sort order on first column.
+			oTableEl.setAttribute('data-o-table-preferred-sort-order', 'descending');
+			const sorterSpy = sinon.spy(sorter, "sortRowsByColumn");
+			table.addSortButtons();
+			setTimeout(() => {
+				try {
+					click('thead th button');
+					proclaim.isTrue(sorterSpy.calledWith(table, 0, 'descending'), 'Expected the table to be sorted "descending" on first click of the header button, given a descending preferred sort order.');
+				} catch (error) {
+					sorterSpy.restore();
+					done(error);
+				}
+				setTimeout(() => {
+					try {
+						click('thead th button');
+						proclaim.isTrue(sorterSpy.calledWith(table, 0, 'ascending'), 'Expected the table to be sorted "ascending" on second click of the header button, given a descending preferred sort order.');
+					} catch (error) {
+						sorterSpy.restore();
+						done(error);
+					} finally {
+						sorterSpy.restore();
+						done();
+					}
+				}, 100);
+			}, 100);
+		});
 	});
 
 	describe('sortRowsByColumn', () => {

--- a/test/BaseTable.test.js
+++ b/test/BaseTable.test.js
@@ -301,9 +301,15 @@ describe("BaseTable", () => {
 
 		it('buttons toggle column sort by preferred sort order with header button click (descending first)', done => {
 			// Set preferred sort order on first column.
+			sandbox.init();
+			sandbox.setContents(fixtures.shortTableWithContainer);
+			oTableEl = document.querySelector('[data-o-component=o-table]');
 			oTableEl.setAttribute('data-o-table-preferred-sort-order', 'descending');
-			const sorterSpy = sinon.spy(sorter, "sortRowsByColumn");
+			table = new BaseTable(oTableEl, sorter);
+			// Add sort buttons
 			table.addSortButtons();
+			// Test sort order on click
+			const sorterSpy = sinon.spy(sorter, "sortRowsByColumn");
 			setTimeout(() => {
 				try {
 					click('thead th button');


### PR DESCRIPTION
When a sortable table heading is clicked for the first time
an ascending sort is applied by default, assuming no existing
sort i.e. a server side sort. However for some usecases a
descending sort is more helpful. A new
`data-o-table-preferred-sort-order` option allows the default
sort to be configured.

https://github.com/Financial-Times/o-table/issues/208