### PR TITLE
Improve table sort order buttons.

### DIFF
--- a/src/scss/_sort.scss
+++ b/src/scss/_sort.scss
@@ -35,7 +35,12 @@
 		}
 	}
 
-	// Show descending icon in sort button with DSC sort applied.
+	// Show descending icon in sort button with DSC sort applied,
+	// or on hover if no sort has been applied and a descending sort
+	// is the preferred sort.
+	// stylelint-disable-next-line selector-no-qualifying-type
+	[data-o-table-preferred-sort-order='descending'] th[aria-sort='none'] .o-table__sort:hover, // stylelint-disable-line selector-no-qualifying-type
+	[data-o-table-preferred-sort-order='descending'] th:not([aria-sort]) .o-table__sort:hover, // stylelint-disable-line selector-no-qualifying-type
 	[aria-sort='descending'] .o-table__sort {
 		&:after {
 			@include oIconsContent('arrow-down', $size: $_o-table-sort-icon-size);

--- a/test/BaseTable.test.js
+++ b/test/BaseTable.test.js
@@ -276,17 +276,21 @@ describe("BaseTable", () => {
 		it('buttons toggle column sort with header button click (ascending first)', done => {
 			const sorterSpy = sinon.spy(sorter, "sortRowsByColumn");
 			table.addSortButtons();
+			const buttonQuery = 'thead th button';
 			setTimeout(() => {
+				const button = oTableEl.querySelector(buttonQuery);
+				proclaim.include(button.getAttribute('title'), 'ascending', 'Expected the sort button to describe the next sort "ascending".');
 				try {
-					click('thead th button');
+					click(buttonQuery);
 					proclaim.isTrue(sorterSpy.calledWith(table, 0, 'ascending'), 'Expected the table to be sorted "ascending" on first click of the header button.');
 				} catch (error) {
 					sorterSpy.restore();
 					done(error);
 				}
 				setTimeout(() => {
+					proclaim.include(button.getAttribute('title'), 'descending', 'Expected the sort button to describe the next sort "descending".');
 					try {
-						click('thead th button');
+						click(buttonQuery);
 						proclaim.isTrue(sorterSpy.calledWith(table, 0, 'descending'), 'Expected the table to be sorted "descending" on second click of the header button.');
 					} catch (error) {
 						sorterSpy.restore();


### PR DESCRIPTION
- Express the sort order in the title of the sort button for
screen reader users. E.g. instead of `sort table by "name"`
use a title of `sort table by "name" ascending`.
- If the preferred sort order has been set, show the correct
sort icon on hover.

<img width="469" alt="Screenshot 2020-07-02 at 11 29 42" src="https://user-images.githubusercontent.com/10405691/86348286-60c63300-bc57-11ea-9e74-283cda27ba66.png">

Relates to:
https://github.com/Financial-Times/o-table/issues/208
https://github.com/Financial-Times/o-table/pull/210