### PR TITLE
Use the new $default-branch macro instead of hardcoding the branch name

### DIFF
--- a/.github/workflows/percy.yml
+++ b/.github/workflows/percy.yml
@@ -14,7 +14,7 @@ on:
      - "demos/**"
      - "src/**"
   push:
-    branches: master
+    branches: $default-branch
     paths: 
      - "bower.json"
      - "origami.json"


### PR DESCRIPTION
This will help with any future work on renaming the default branch name.