### PR TITLE
add extension to relative imports to make the code work directly in a browser

### DIFF
--- a/demos/src/demo.js
+++ b/demos/src/demo.js
@@ -1,1 +1,1 @@
-import './../../main';
+import './../../main.js';

--- a/main.js
+++ b/main.js
@@ -1,4 +1,4 @@
-import oTable from './src/js/oTable';
+import oTable from './src/js/oTable.js';
 
 const constructAll = function() {
 	oTable.init();

--- a/src/js/Sort/TableSorter.js
+++ b/src/js/Sort/TableSorter.js
@@ -1,4 +1,4 @@
-import CellFormatter from "./CellFormatter.js.js";
+import CellFormatter from "./CellFormatter.js";
 
 /**
  * Construct Intl.Collator if supported.

--- a/src/js/Sort/TableSorter.js
+++ b/src/js/Sort/TableSorter.js
@@ -1,4 +1,4 @@
-import CellFormatter from "./CellFormatter";
+import CellFormatter from "./CellFormatter.js.js";
 
 /**
  * Construct Intl.Collator if supported.

--- a/src/js/Tables/BasicTable.js
+++ b/src/js/Tables/BasicTable.js
@@ -1,4 +1,4 @@
-import BaseTable from './BaseTable.js.js';
+import BaseTable from './BaseTable.js';
 
 class BasicTable extends BaseTable {
 

--- a/src/js/Tables/BasicTable.js
+++ b/src/js/Tables/BasicTable.js
@@ -1,4 +1,4 @@
-import BaseTable from './BaseTable';
+import BaseTable from './BaseTable.js.js';
 
 class BasicTable extends BaseTable {
 

--- a/src/js/Tables/FlatTable.js
+++ b/src/js/Tables/FlatTable.js
@@ -1,4 +1,4 @@
-import BaseTable from './BaseTable';
+import BaseTable from './BaseTable.js.js';
 
 class FlatTable extends BaseTable {
 

--- a/src/js/Tables/FlatTable.js
+++ b/src/js/Tables/FlatTable.js
@@ -1,4 +1,4 @@
-import BaseTable from './BaseTable.js.js';
+import BaseTable from './BaseTable.js';
 
 class FlatTable extends BaseTable {
 

--- a/src/js/Tables/OverflowTable.js
+++ b/src/js/Tables/OverflowTable.js
@@ -1,4 +1,4 @@
-import BaseTable from './BaseTable.js.js';
+import BaseTable from './BaseTable.js';
 
 class OverflowTable extends BaseTable {
 

--- a/src/js/Tables/OverflowTable.js
+++ b/src/js/Tables/OverflowTable.js
@@ -1,4 +1,4 @@
-import BaseTable from './BaseTable';
+import BaseTable from './BaseTable.js.js';
 
 class OverflowTable extends BaseTable {
 

--- a/src/js/Tables/ScrollTable.js
+++ b/src/js/Tables/ScrollTable.js
@@ -1,4 +1,4 @@
-import BaseTable from './BaseTable';
+import BaseTable from './BaseTable.js.js';
 
 class ScrollTable extends BaseTable {
 	/**

--- a/src/js/Tables/ScrollTable.js
+++ b/src/js/Tables/ScrollTable.js
@@ -1,4 +1,4 @@
-import BaseTable from './BaseTable.js.js';
+import BaseTable from './BaseTable.js';
 
 class ScrollTable extends BaseTable {
 	/**

--- a/src/js/oTable.js
+++ b/src/js/oTable.js
@@ -1,9 +1,9 @@
-import FlatTable from './Tables/FlatTable';
-import ScrollTable from './Tables/ScrollTable';
-import OverflowTable from './Tables/OverflowTable';
-import BasicTable from './Tables/BasicTable';
+import FlatTable from './Tables/FlatTable.js.js';
+import ScrollTable from './Tables/ScrollTable.js.js';
+import OverflowTable from './Tables/OverflowTable.js.js';
+import BasicTable from './Tables/BasicTable.js.js';
 
-import TableSorter from './Sort/TableSorter';
+import TableSorter from './Sort/TableSorter.js.js';
 const sorter = new TableSorter();
 
 

--- a/src/js/oTable.js
+++ b/src/js/oTable.js
@@ -1,9 +1,9 @@
-import FlatTable from './Tables/FlatTable.js.js';
-import ScrollTable from './Tables/ScrollTable.js.js';
-import OverflowTable from './Tables/OverflowTable.js.js';
-import BasicTable from './Tables/BasicTable.js.js';
+import FlatTable from './Tables/FlatTable.js';
+import ScrollTable from './Tables/ScrollTable.js';
+import OverflowTable from './Tables/OverflowTable.js';
+import BasicTable from './Tables/BasicTable.js';
 
-import TableSorter from './Sort/TableSorter.js.js';
+import TableSorter from './Sort/TableSorter.js';
 const sorter = new TableSorter();
 
 

--- a/test/BaseTable.test.js
+++ b/test/BaseTable.test.js
@@ -1,10 +1,10 @@
 /* eslint-env mocha */
 /* global proclaim, sinon */
 
-import * as sandbox from './helpers/sandbox';
-import * as fixtures from './helpers/fixtures';
-import BaseTable from './../src/js/Tables/BaseTable';
-import TableSorter from './../src/js/Sort/TableSorter';
+import * as sandbox from './helpers/sandbox.js';
+import * as fixtures from './helpers/fixtures.js';
+import BaseTable from './../src/js/Tables/BaseTable.js';
+import TableSorter from './../src/js/Sort/TableSorter.js';
 const sorter = new TableSorter();
 
 describe("BaseTable", () => {

--- a/test/BasicTable.test.js
+++ b/test/BasicTable.test.js
@@ -1,11 +1,11 @@
 /* eslint-env mocha */
 /* global proclaim, sinon */
 
-import * as sandbox from './helpers/sandbox';
-import * as fixtures from './helpers/fixtures';
-import BasicTable from './../src/js/Tables/BasicTable';
-import BaseTable from './../src/js/Tables/BaseTable';
-import TableSorter from './../src/js/Sort/TableSorter';
+import * as sandbox from './helpers/sandbox.js';
+import * as fixtures from './helpers/fixtures.js';
+import BasicTable from './../src/js/Tables/BasicTable.js';
+import BaseTable from './../src/js/Tables/BaseTable.js';
+import TableSorter from './../src/js/Sort/TableSorter.js';
 const sorter = new TableSorter();
 
 describe("BasicTable", () => {

--- a/test/FlatTable.test.js
+++ b/test/FlatTable.test.js
@@ -1,11 +1,11 @@
 /* eslint-env mocha */
 /* global proclaim */
 
-import * as sandbox from './helpers/sandbox';
-import * as fixtures from './helpers/fixtures';
-import FlatTable from './../src/js/Tables/FlatTable';
-import BaseTable from './../src/js/Tables/BaseTable';
-import TableSorter from './../src/js/Sort/TableSorter';
+import * as sandbox from './helpers/sandbox.js';
+import * as fixtures from './helpers/fixtures.js';
+import FlatTable from './../src/js/Tables/FlatTable.js';
+import BaseTable from './../src/js/Tables/BaseTable.js';
+import TableSorter from './../src/js/Sort/TableSorter.js';
 const sorter = new TableSorter();
 
 describe("FlatTable", () => {

--- a/test/OverflowTable.test.js
+++ b/test/OverflowTable.test.js
@@ -1,11 +1,11 @@
 /* eslint-env mocha */
 /* global proclaim */
 
-import * as sandbox from './helpers/sandbox';
-import * as fixtures from './helpers/fixtures';
-import OverflowTable from './../src/js/Tables/OverflowTable';
-import BaseTable from './../src/js/Tables/BaseTable';
-import TableSorter from './../src/js/Sort/TableSorter';
+import * as sandbox from './helpers/sandbox.js';
+import * as fixtures from './helpers/fixtures.js';
+import OverflowTable from './../src/js/Tables/OverflowTable.js';
+import BaseTable from './../src/js/Tables/BaseTable.js';
+import TableSorter from './../src/js/Sort/TableSorter.js';
 const sorter = new TableSorter();
 
 function expandable(oTableEl, { minimumRowCount, expanded }) {

--- a/test/ScrollTable.test.js
+++ b/test/ScrollTable.test.js
@@ -1,11 +1,11 @@
 /* eslint-env mocha */
 /* global proclaim */
 
-import * as sandbox from './helpers/sandbox';
-import * as fixtures from './helpers/fixtures';
-import ScrollTable from './../src/js/Tables/ScrollTable';
-import BaseTable from './../src/js/Tables/BaseTable';
-import TableSorter from './../src/js/Sort/TableSorter';
+import * as sandbox from './helpers/sandbox.js';
+import * as fixtures from './helpers/fixtures.js';
+import ScrollTable from './../src/js/Tables/ScrollTable.js';
+import BaseTable from './../src/js/Tables/BaseTable.js';
+import TableSorter from './../src/js/Sort/TableSorter.js';
 const sorter = new TableSorter();
 
 describe("ScrollTable", () => {

--- a/test/Sort/TableSorter.test.js
+++ b/test/Sort/TableSorter.test.js
@@ -1,11 +1,11 @@
 /* eslint-env mocha */
 /* global proclaim sinon */
 
-import * as sandbox from './../helpers/sandbox';
-import * as fixtures from './../helpers/fixtures';
-import BaseTable from './../../src/js/Tables/BaseTable';
-import FlatTable from './../../src/js/Tables/FlatTable';
-import TableSorter from './../../src/js/Sort/TableSorter';
+import * as sandbox from './../helpers/sandbox.js';
+import * as fixtures from './../helpers/fixtures.js';
+import BaseTable from './../../src/js/Tables/BaseTable.js';
+import FlatTable from './../../src/js/Tables/FlatTable.js';
+import TableSorter from './../../src/js/Sort/TableSorter.js';
 const sorter = new TableSorter();
 
 describe("BaseTable", () => {

--- a/test/oTable.test.js
+++ b/test/oTable.test.js
@@ -1,14 +1,14 @@
 /* eslint-env mocha */
 /* global proclaim */
 
-import * as sandbox from './helpers/sandbox';
-import * as fixtures from './helpers/fixtures';
-import OTable from './../main';
-import BaseTable from './../src/js/Tables/BaseTable';
-import OverflowTable from './../src/js/Tables/OverflowTable';
-import FlatTable from './../src/js/Tables/FlatTable';
-import ScrollTable from './../src/js/Tables/ScrollTable';
-import BasicTable from './../src/js/Tables/BasicTable';
+import * as sandbox from './helpers/sandbox.js';
+import * as fixtures from './helpers/fixtures.js';
+import OTable from './../main.js';
+import BaseTable from './../src/js/Tables/BaseTable.js';
+import OverflowTable from './../src/js/Tables/OverflowTable.js';
+import FlatTable from './../src/js/Tables/FlatTable.js';
+import ScrollTable from './../src/js/Tables/ScrollTable.js';
+import BasicTable from './../src/js/Tables/BasicTable.js';
 
 describe('OTable constructs', () => {
 	let oTableEl;


### PR DESCRIPTION
relative imports require the full path including the extension because browsers use the import name to make a network request and they do not implicitly add a .js file extension if one is missing