### PR TITLE
Enable heroku review apps to work once again

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,5 +10,9 @@
 		"remark-preset-lint-origami-component": "^1.1.3",
 		"stylelint": "^13.7.0",
 		"stylelint-config-origami-component": "^1.0.4"
+	},
+	"scripts": {
+		"build": "npm_config_yes=true npx \"origami-build-tools@^10\" install && npm_config_yes=true npx \"origami-build-tools@^10\" demo",
+		"start": "npx serve ./demos/local"
 	}
 }


### PR DESCRIPTION
This project used to support heroku review apps but lost that support when the npm-run scripts were deleted.

This commit adds the required npm-run scripts which enable heroku review apps to work once more.