### PR TITLE
use text instead of title

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,7 @@
 {
   "name": "o-table",
   "dependencies": {
+    "o-normalise": "^2.0.7",
     "o-colors": "^5.0.0",
     "o-grid": "^5.0.0",
     "o-icons": "^6.0.0",

--- a/main.scss
+++ b/main.scss
@@ -1,10 +1,11 @@
-// Dependancies
+// Dependencies
 @import "o-spacing/main";
 @import "o-brand/main";
 @import "o-buttons/main";
 @import "o-colors/main";
 @import "o-grid/main";
 @import "o-icons/main";
+@import "o-normalise/main";
 @import "o-typography/main";
 @import "o-visual-effects/main";
 // Branding

--- a/src/js/Tables/BaseTable.js
+++ b/src/js/Tables/BaseTable.js
@@ -467,10 +467,10 @@ class BaseTable {
 			const sortButton = document.createElement('button');
 			sortButton.innerHTML = headingHTML;
 			sortButton.classList.add('o-table__sort');
-			// In VoiceOver, button `aria-label` is repeated when moving from one column of tds to the next.
-			// Using `title` avoids this, but risks not being announced by other screen readers.
 			const nextSort = this._getNextSortOrder(th);
-			sortButton.setAttribute('title', `sort table by "${th.textContent}" ${nextSort}`);
+			const sortText = document.createElement('span');
+			span.classList.add('o-table__sort-text');
+			sortText.textContent = `sort table by "${th.textContent}" ${nextSort}`;
 			return sortButton;
 		});
 

--- a/src/scss/_sort.scss
+++ b/src/scss/_sort.scss
@@ -35,6 +35,10 @@
 		}
 	}
 
+	.o-table__sort-text {
+		@include oNormaliseVisuallyHidden();
+	}
+
 	// Show descending icon in sort button with DSC sort applied,
 	// or on hover if no sort has been applied and a descending sort
 	// is the preferred sort.


### PR DESCRIPTION
this implementation is in line with this table: https://heydon.github.io/react-sortable-table-demo/

we'd expect it to read that the button can be used to sort when changing between cells