### PR TITLE
Exclude header cells with data-o-table-duplicate-header added to them…

### DIFF
--- a/demos/src/base.mustache
+++ b/demos/src/base.mustache
@@ -33,6 +33,12 @@
 				data-o-component="o-table"
 				{{#tableType}}data-o-table-responsive="{{tableType}}"{{/tableType}}>
 				<thead>
+					{{#multipleHeaderRows}}
+					<tr>
+						<th scope="col" role="columnheader" scope="col" role="columnheader" colspan="4">Description</th>
+						<th scope="col" role="columnheader" scope="col" role="columnheader" colspan="4">Price</th>
+					</tr>
+					{{/multipleHeaderRows}}
 					<tr>
 						<th scope="col" role="columnheader">Fruit</th>
 						<th scope="col" role="columnheader">Genus</th>

--- a/origami.json
+++ b/origami.json
@@ -97,6 +97,18 @@
 			"description": "Open demo and shrink browser to preview. Each entry in the flat table is shown individually with headers on small viewports. This demo includes the optional row stripes from the previous demo."
 		},
 		{
+			"title": "Multiple Columns",
+			"name": "multiple-columns-responsive-overflow",
+			"template": "demos/src/base.mustache",
+			"data": {
+				"tableType": "overflow",
+				"multipleHeaderRows": true
+			},
+			"hidden": true,
+			"documentClasses": "o-table-demo-constrain",
+			"description": "Multiple heading rows in a responsive-overflow table are partially supported. Styles are not supported yet. https://github.com/Financial-Times/o-table/issues/255"
+		},
+		{
 			"title": "Expanding Table",
 			"name": "expanding",
 			"template": "demos/src/expanding.mustache",

--- a/src/js/Tables/BaseTable.js
+++ b/src/js/Tables/BaseTable.js
@@ -57,7 +57,9 @@ class BaseTable {
 		this.thead = this.rootEl.querySelector('thead');
 		this.tbody = this.rootEl.querySelector('tbody');
 		this.tableCaption = this.rootEl.querySelector('caption');
-		this.tableHeaders = this.thead ? Array.from(this.thead.querySelectorAll('th:not([data-o-table-duplicate-header])')) : [];
+		this.tableHeaders = this.thead ? Array.from(
+			this.thead.querySelectorAll('tr:last-of-type > th')
+		) : [];
 		this.tableRows = this.tbody ? Array.from(this.tbody.getElementsByTagName('tr')) : [];
 		this._filteredTableRows = [];
 		this.wrapper = this.rootEl.closest('.o-table-scroll-wrapper');

--- a/src/js/Tables/BaseTable.js
+++ b/src/js/Tables/BaseTable.js
@@ -57,7 +57,7 @@ class BaseTable {
 		this.thead = this.rootEl.querySelector('thead');
 		this.tbody = this.rootEl.querySelector('tbody');
 		this.tableCaption = this.rootEl.querySelector('caption');
-		this.tableHeaders = this.thead ? Array.from(this.thead.querySelectorAll('th')) : [];
+		this.tableHeaders = this.thead ? Array.from(this.thead.querySelectorAll('th:not([data-o-table-duplicate-header])')) : [];
 		this.tableRows = this.tbody ? Array.from(this.tbody.getElementsByTagName('tr')) : [];
 		this._filteredTableRows = [];
 		this.wrapper = this.rootEl.closest('.o-table-scroll-wrapper');


### PR DESCRIPTION
… from this.headerCells so that tables with multiple header rows can still be sorted

Live example: https://ig.ft.com/tokyo-olympics-alternative-medal-table/ (I have hacked this link to be fixed for now by taking a local copy of o-table and making the change included in this PR, so it won't be broken here, but you can see the example markup of a table. The broken behaviour was that for example sorting by gold medals actually sorted the Medals predicted to date column, and sorting the Difference column for example didn't do anything because it was calculating the columnIndex to be higher than the total number of columns)

Currently having two `<tr>` elements inside `<thead>` means that the column sorting is broken. This is because the columnIndex used for sorting is calculated to be the index of the `<th>` cell in an array of all `<th>` cells. This PR excludes an optional data attribute `data-o-table-duplicate-header` from the `<th>` cell selection. That would mean I can add the attribute to my top row of header cells and the second row will be used for calculating column index.

Current markup of table:

```
<thead>
  <tr>
    <th></th>
    <th></th>
  </tr>
  <tr>
    <th></th>
    <th></th>
  </tr>
</thead>
<tbody>...
```

New markup of table:

```
<thead>
  <tr>
    <th data-o-table-duplicate-header></th>
    <th data-o-table-duplicate-header></th>
  </tr>
  <tr>
    <th></th>
    <th></th>
  </tr>
</thead>
<tbody>...
```