### PR TITLE
Allow multiple header rows

### DIFF
--- a/demos/src/base.mustache
+++ b/demos/src/base.mustache
@@ -33,6 +33,12 @@
 				data-o-component="o-table"
 				{{#tableType}}data-o-table-responsive="{{tableType}}"{{/tableType}}>
 				<thead>
+					{{#multipleHeaderRows}}
+					<tr>
+						<th scope="col" role="columnheader" scope="col" role="columnheader" colspan="4">Description</th>
+						<th scope="col" role="columnheader" scope="col" role="columnheader" colspan="4">Price</th>
+					</tr>
+					{{/multipleHeaderRows}}
 					<tr>
 						<th scope="col" role="columnheader">Fruit</th>
 						<th scope="col" role="columnheader">Genus</th>

--- a/origami.json
+++ b/origami.json
@@ -97,6 +97,18 @@
 			"description": "Open demo and shrink browser to preview. Each entry in the flat table is shown individually with headers on small viewports. This demo includes the optional row stripes from the previous demo."
 		},
 		{
+			"title": "Multiple Columns",
+			"name": "multiple-columns-responsive-overflow",
+			"template": "demos/src/base.mustache",
+			"data": {
+				"tableType": "overflow",
+				"multipleHeaderRows": true
+			},
+			"hidden": true,
+			"documentClasses": "o-table-demo-constrain",
+			"description": "Multiple heading rows in a responsive-overflow table are partially supported. Styles are not supported yet. https://github.com/Financial-Times/o-table/issues/255"
+		},
+		{
 			"title": "Expanding Table",
 			"name": "expanding",
 			"template": "demos/src/expanding.mustache",

--- a/src/js/Tables/BaseTable.js
+++ b/src/js/Tables/BaseTable.js
@@ -57,7 +57,9 @@ class BaseTable {
 		this.thead = this.rootEl.querySelector('thead');
 		this.tbody = this.rootEl.querySelector('tbody');
 		this.tableCaption = this.rootEl.querySelector('caption');
-		this.tableHeaders = this.thead ? Array.from(this.thead.querySelectorAll('th:not([data-o-table-duplicate-header])')) : [];
+		this.tableHeaders = this.thead ? Array.from(
+			this.thead.querySelectorAll('tr:last-of-type > th')
+		) : [];
 		this.tableRows = this.tbody ? Array.from(this.tbody.getElementsByTagName('tr')) : [];
 		this._filteredTableRows = [];
 		this.wrapper = this.rootEl.closest('.o-table-scroll-wrapper');


### PR DESCRIPTION
Supports the "overflow" responsive table but has not been tested
with other styles of table.

See related issue: https://github.com/Financial-Times/o-table/issues/255